### PR TITLE
chore: Install `mkhelp` in dev env

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -18,5 +18,7 @@ jobs:
         run: nix-instantiate --eval -E '(import <nixpkgs> {}).lib.version'
       - name: Install dependencies
         run: nix-shell --run "exit"
+      - name: Verify that dependencies were installed
+        run: nix-shell --run "make"
       - name: Run checks
         run: nix-shell --run "make check"

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,6 @@
 ## Verbs
 ## =====
 
-# TODO: Install mkhelp in the nix shell
 help:
 	@mkhelp $(firstword $(MAKEFILE_LIST))
 

--- a/pkgs/mkhelp/default.nix
+++ b/pkgs/mkhelp/default.nix
@@ -1,0 +1,27 @@
+{
+  lib,
+  fetchFromGitHub,
+  rustPlatform,
+}:
+
+rustPlatform.buildRustPackage rec {
+  pname = "mkhelp";
+  version = "0.2.3";
+
+  src = fetchFromGitHub {
+    owner = "apljungquist";
+    repo = "mkhelp-rs";
+    rev = "v${version}";
+    hash = "sha256-Rj+bhopZLQr/bIkwNlaRji/aOm3qWce/82qmLrQNwZU=";
+  };
+
+  useFetchCargoVendor = true;
+  cargoHash = "sha256-wcF5e8RfPNMgXyfhtJO+spXdnW+DvYMnwlk/0O+mmZY=";
+
+  meta = {
+    description = "Support for docstrings in makefiles";
+    homepage = "https://github.com/apljungquist/mkhelp-rs";
+    license = lib.licenses.mit;
+    maintainers = [ ];
+  };
+}

--- a/shell.nix
+++ b/shell.nix
@@ -1,5 +1,6 @@
 let
   pkgs = import (fetchTarball "https://github.com/NixOS/nixpkgs/archive/f9ebe33a928b.tar.gz") { };
+  mkhelp = pkgs.callPackage ./pkgs/mkhelp { };
 in
 
 pkgs.mkShellNoCC {
@@ -8,6 +9,7 @@ pkgs.mkShellNoCC {
     clang
     clippy
     fd
+    mkhelp
     nixfmt-rfc-style
     rustfmt
   ];


### PR DESCRIPTION
`.github/workflows/main.yaml`:
- Add a step to verify that `mkhelp` is available in the development environment to convince myself that it works and that the cache is used as expected. The cost of keeping this in to ensure that the development environment continues to function should be negligible since the program can be, and is, fetched from cache.
- `y832li5g1aalxmsk9sbp6lj6j5vbd5i5-mkhelp-0.2.3` was uploaded to the nix cache manually. I'd like to automate this eventually.

`pkgs/mkhelp/default.nix`:
- Inspired by nixpkgs's rust section documentation [^1].
- The meta section appears to be optional, but is kept because recipes I have looked at consistently include it.

[^1]: https://github.com/NixOS/nixpkgs/blob/master/doc/languages-frameworks/rust.section.md#buildrustpackage-compiling-rust-applications-with-cargo-compiling-rust-applications-with-cargo