### PR TITLE
chore: Use `nix-shell` with `--pure` in CI

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -17,8 +17,8 @@ jobs:
       - name: Print nixpkgs version
         run: nix-instantiate --eval -E '(import <nixpkgs> {}).lib.version'
       - name: Install dependencies
-        run: nix-shell --run "exit"
+        run: nix-shell --pure --run "exit"
       - name: Verify that dependencies were installed
-        run: nix-shell --run "make"
+        run: nix-shell --pure --run "make"
       - name: Run checks
-        run: nix-shell --run "make check"
+        run: nix-shell --pure --run "make check"

--- a/shell.nix
+++ b/shell.nix
@@ -9,6 +9,7 @@ pkgs.mkShellNoCC {
     clang
     clippy
     fd
+    git
     mkhelp
     nixfmt-rfc-style
     rustfmt


### PR DESCRIPTION
When I added a more complicated rust program CI started failing because not all crates were compiled with the same version of rustc. This was probably because cargo was provided by nix at version 1.82.0 whereas rustc was provided by the host at version 1.86.0.

---

`.github/workflows/main.yaml`:
- Use `--pure` to improve reproducibility across time and space (machines).

`shell.nix`:
- Add `git` because it is required for the `make check_generated_files`.