### PR TITLE
chore: Remove push trigger for main workflow

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1,7 +1,6 @@
 name: "Main"
 on:
   pull_request:
-  push:
 jobs:
   checks:
     runs-on: ubuntu-latest


### PR DESCRIPTION
I often find myself pushing as a way to share code between computers or with other people and running workflows in such cases is frivolous. For other projects I have found that creating a PR, even if it is only a draft, is a good way of indicating that something is mature enough to be tested on CI. For the cases when testing on CI earlier is important, modifying the workflow is easy.