### PR TITLE
chore: Install `rustc` in dev env

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -14,6 +14,7 @@ pkgs.mkShellNoCC {
     llvmPackages.libclang
     mkhelp
     nixfmt-rfc-style
+    rustc
     rustfmt
   ];
 


### PR DESCRIPTION
When running locally on MacOS I again run into the problem of some crates being compiled with the wrong version of rust, at least when running clippy. I'm guessing clippy calls rustc directly and picks up the version that is available on the host machine since it is not shadowed by any rustc from the development environment.

Another way to solve this would be to use nix with `--pure` as is done in CI, but I suspect that would be tedious in development because all contributors must agree on exactly what tooling should be available.