### PR TITLE
chore: Run main workflow on main branch

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1,6 +1,9 @@
 name: "Main"
 on:
   pull_request:
+  push:
+    branches:
+      - main
 jobs:
   checks:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This undoes part of #5, but I think it is worth it in order to get the green check mark next to the commit on the repo front page and in the commit history.