### PR TITLE
feat: Add `export-loans` command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1444,6 +1444,8 @@ dependencies = [
  "mdns",
  "reqwest",
  "rs4a-vapix",
+ "serde",
+ "serde_json",
  "tokio",
  "url",
 ]

--- a/crates/rs4a/Cargo.toml
+++ b/crates/rs4a/Cargo.toml
@@ -13,5 +13,7 @@ log = { workspace = true }
 mdns = { workspace = true }
 reqwest = { workspace = true }
 rs4a-vapix = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true }
 tokio = { workspace = true, features = ["rt", "rt-multi-thread", "macros"] }
 url = { workspace = true }

--- a/crates/rs4a/src/commands.rs
+++ b/crates/rs4a/src/commands.rs
@@ -1,1 +1,2 @@
 pub mod discover_devices;
+pub mod export_loans;

--- a/crates/rs4a/src/commands/export_loans.rs
+++ b/crates/rs4a/src/commands/export_loans.rs
@@ -1,0 +1,29 @@
+use std::io::{self, Read};
+
+use anyhow::Context;
+
+use crate::vlt;
+
+#[derive(clap::Parser, Debug, Clone)]
+pub struct ExportLoansCommand;
+
+impl ExportLoansCommand {
+    pub async fn exec(self) -> anyhow::Result<()> {
+        let mut content = String::new();
+        io::stdin()
+            .read_to_string(&mut content)
+            .context("Failed to read from stdin")?;
+
+        let loan = vlt::parse(&content)?;
+        println!("export AXIS_DEVICE_IP={}", loan.effective_ip()?);
+        println!("export AXIS_DEVICE_USER={}", loan.username());
+        println!(
+            "export AXIS_DEVICE_PASS={}",
+            loan.password().dangerous_reveal()
+        );
+        println!("export AXIS_DEVICE_HTTP_PORT={}", loan.http_port());
+        println!("export AXIS_DEVICE_HTTPS_PORT={}", loan.https_port());
+        println!("export AXIS_DEVICE_SSH_PORT={}", loan.ssh_port());
+        Ok(())
+    }
+}

--- a/crates/rs4a/src/main.rs
+++ b/crates/rs4a/src/main.rs
@@ -2,9 +2,11 @@
 
 use clap::{Parser, Subcommand};
 
-use crate::commands::discover_devices::DiscoverDevicesCommand;
+use crate::commands::{discover_devices::DiscoverDevicesCommand, export_loans::ExportLoansCommand};
 
 mod commands;
+mod psst;
+mod vlt;
 
 #[derive(Parser)]
 struct Cli {
@@ -16,6 +18,7 @@ impl Cli {
     pub async fn exec(self) -> anyhow::Result<()> {
         match self.command {
             Commands::DiscoverDevices(cmd) => cmd.exec().await?,
+            Commands::ExportLoans(cmd) => cmd.exec().await?,
         }
         Ok(())
     }
@@ -25,6 +28,10 @@ impl Cli {
 enum Commands {
     /// Discover devices on the local network
     DiscoverDevices(DiscoverDevicesCommand),
+    /// Print export statements for the current loan
+    ///
+    /// Example: `pbpaste | rs4a export-loans | source /dev/stdin`.
+    ExportLoans(ExportLoansCommand),
 }
 
 #[tokio::main]

--- a/crates/rs4a/src/psst.rs
+++ b/crates/rs4a/src/psst.rs
@@ -1,0 +1,17 @@
+//! Utilities for avoiding accidental disclosure of secrets.
+use std::fmt;
+
+#[derive(Clone, serde::Deserialize)]
+pub struct Password(String);
+
+impl Password {
+    pub fn dangerous_reveal(&self) -> &str {
+        &self.0
+    }
+}
+
+impl fmt::Debug for Password {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "***")
+    }
+}

--- a/crates/rs4a/src/vlt.rs
+++ b/crates/rs4a/src/vlt.rs
@@ -1,0 +1,78 @@
+//! Utilities for working with the Virtual Loan Tool
+
+use std::net::Ipv4Addr;
+
+use anyhow::{anyhow, bail, Context};
+use log::debug;
+use serde::Deserialize;
+use serde_json::value::RawValue;
+use url::Host;
+
+use crate::psst::Password;
+
+#[derive(Debug, Deserialize)]
+pub struct Response<'a> {
+    success: bool,
+    #[serde(borrow)]
+    data: &'a RawValue,
+}
+pub fn parse(response: &str) -> anyhow::Result<Loan> {
+    let Response { success, data } = serde_json::from_str(response)?;
+    let data = serde_json::from_str::<Vec<Loan>>(data.get())
+        .with_context(|| format!("Success was {success}"))?;
+    let mut loans = data.into_iter();
+    let loan = loans.next().ok_or_else(|| anyhow!("No loans found"))?;
+    if loans.next().is_some() {
+        bail!("Multiple loans found");
+    }
+    debug!("Internal ip was {}", loan.loanable.internal_ip);
+    Ok(loan)
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct Loan {
+    username: String,
+    password: Password,
+    loanable: Loanable,
+}
+
+impl Loan {
+    fn external_ip(&self) -> anyhow::Result<Ipv4Addr> {
+        let addr = &self.loanable.external_ip;
+        let addr = Host::parse(addr).context("External IP is not a valid host")?;
+        let Host::Ipv4(addr) = addr else {
+            bail!("External IP is not an IPv4 address");
+        };
+        Ok(addr)
+    }
+    pub fn effective_ip(&self) -> anyhow::Result<Ipv4Addr> {
+        let external = self.external_ip()?;
+        let [_, _, _, last] = external.octets();
+        Ok(Ipv4Addr::from([195, 60, 68, last]))
+    }
+
+    pub fn username(&self) -> &str {
+        &self.username
+    }
+    pub fn password(&self) -> &Password {
+        &self.password
+    }
+
+    pub fn http_port(&self) -> u16 {
+        12051
+    }
+
+    pub fn https_port(&self) -> u16 {
+        42051
+    }
+
+    pub fn ssh_port(&self) -> u16 {
+        22051
+    }
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct Loanable {
+    pub internal_ip: String,
+    pub external_ip: String,
+}

--- a/crates/rs4a/tests/export_loans.rs
+++ b/crates/rs4a/tests/export_loans.rs
@@ -1,0 +1,45 @@
+use std::{
+    collections::HashMap,
+    fs,
+    io::{BufRead, Write},
+    process::Command,
+};
+
+const CARGO_BIN_EXE: &str = env!("CARGO_BIN_EXE_rs4a");
+
+#[test]
+fn can_export_loans_from_get_response() {
+    let json_str = fs::read_to_string("tests/export_loans/get-loans-response.json").unwrap();
+    let mut child = Command::new(CARGO_BIN_EXE)
+        .arg("export-loans")
+        .stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::piped())
+        .spawn()
+        .unwrap();
+    child
+        .stdin
+        .take()
+        .unwrap()
+        .write_all(json_str.as_bytes())
+        .unwrap();
+    let output = child.wait_with_output().unwrap();
+
+    assert!(output.status.success());
+
+    let mut exports = HashMap::new();
+    for line in output.stdout.lines() {
+        let line = line.unwrap();
+        let (k, v) = line
+            .strip_prefix("export ")
+            .unwrap()
+            .split_once('=')
+            .unwrap();
+        exports.insert(k.to_string(), v.to_string());
+    }
+    assert_eq!(exports["AXIS_DEVICE_IP"], "195.60.68.51");
+    assert_eq!(exports["AXIS_DEVICE_USERNAME"], "VLTuser");
+    assert_eq!(exports["AXIS_DEVICE_PASSWORD"], "nAy0cuvW");
+    assert_eq!(exports["AXIS_DEVICE_HTTP_PORT"], "12051");
+    assert_eq!(exports["AXIS_DEVICE_HTTPS_PORT"], "42051");
+    assert_eq!(exports["AXIS_DEVICE_SSH_PORT"], "22051");
+}

--- a/crates/rs4a/tests/export_loans.rs
+++ b/crates/rs4a/tests/export_loans.rs
@@ -37,8 +37,8 @@ fn can_export_loans_from_get_response() {
         exports.insert(k.to_string(), v.to_string());
     }
     assert_eq!(exports["AXIS_DEVICE_IP"], "195.60.68.51");
-    assert_eq!(exports["AXIS_DEVICE_USERNAME"], "VLTuser");
-    assert_eq!(exports["AXIS_DEVICE_PASSWORD"], "nAy0cuvW");
+    assert_eq!(exports["AXIS_DEVICE_USER"], "VLTuser");
+    assert_eq!(exports["AXIS_DEVICE_PASS"], "nYy3cuvX");
     assert_eq!(exports["AXIS_DEVICE_HTTP_PORT"], "12051");
     assert_eq!(exports["AXIS_DEVICE_HTTPS_PORT"], "42051");
     assert_eq!(exports["AXIS_DEVICE_SSH_PORT"], "22051");

--- a/crates/rs4a/tests/export_loans/get-loans-response.json
+++ b/crates/rs4a/tests/export_loans/get-loans-response.json
@@ -1,0 +1,24 @@
+{
+  "success": true,
+  "data": [
+    {
+      "id": 12345,
+      "status": 1,
+      "created_at": "2025-01-02T01:23:45.678Z",
+      "loan_start": "2025-01-02T00:00:00.000Z",
+      "loan_end": "2025-01-02T23:59:59.000Z",
+      "username": "VLTuser",
+      "password": "nYy3cuvX",
+      "selected_firmware": "12.4.59",
+      "started_at": "2025-01-02T01:23:45.000Z",
+      "loanable": {
+        "model": "AXIS Q1615 Mk III",
+        "internal_ip": "10.20.41.10:12051",
+        "external_ip": "192.168.2.51",
+        "id": 8
+      },
+      "meta": []
+    }
+  ],
+  "meta": []
+}

--- a/shell.nix
+++ b/shell.nix
@@ -15,4 +15,8 @@ pkgs.mkShellNoCC {
     rustc
     rustfmt
   ];
+
+  shellHook = ''
+    export PATH="$PATH:$HOME/.cargo/bin"
+  '';
 }


### PR DESCRIPTION
This is intended to make it easier to use the Virtual Loan Tool [^1] with programs that infer what device to interact with from environment variables, such `cargo-acap-sdk`.

`shell.nix` is updated because clippy fails on the new integration test:

> error: unexpected `cfg` condition name: `test`

This is a warning that is promoted to an error because we use `-D warnings`. It can be reproduced like: `nix-shell --pure --run 'cargo clippy --all-targets`; removing either `--pure` or `--all-targets- makes the error go away.

I still don't fully understand what is happening and I'm not entirely happy with the solution. As far as I can tell the issue is that if the cargo bin directory is not on the path, then it is prepended; any of these changes makes the error go away:
- Appending it to the path manually, as is done in this commit.
- Removing the `~/.cargo/bin` directory.
- Setting `CARGO_HOME` to another directory.