### PR TITLE
chore: Add snapshot test for device-inventory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -111,6 +111,8 @@ Cargo.lock: $(wildcard crates/*/Cargo.toml)
 	cargo metadata --format-version=1 > /dev/null
 
 snapshots/device-inventory-smoke-test:
+	cargo build --bin device-inventory
+	PATH=$$(pwd)/target/debug:$$PATH \
 	./bin/device-inventory-smoke-test.sh \
-	> $@
+	> $@ 2>&1
 .PHONY: snapshots/device-inventory-smoke-test

--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,7 @@ check_format_rs:
 .PHONY: check_format_rs
 
 ## _
-check_generated_files: Cargo.lock
+check_generated_files: Cargo.lock snapshots/device-inventory-smoke-test
 	git update-index -q --refresh
 	git --no-pager diff --exit-code HEAD -- $^
 .PHONY: check_generated_files
@@ -109,3 +109,8 @@ fix_lint:
 
 Cargo.lock: $(wildcard crates/*/Cargo.toml)
 	cargo metadata --format-version=1 > /dev/null
+
+snapshots/device-inventory-smoke-test:
+	./bin/device-inventory-smoke-test.sh \
+	> $@
+.PHONY: snapshots/device-inventory-smoke-test

--- a/bin/device-inventory-smoke-test.sh
+++ b/bin/device-inventory-smoke-test.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env sh
+set -eu
+
+base_cmd="device-inventory --offline"
+export RUST_LOG=debug
+
+for cmd in \
+  "$base_cmd help" \
+  "$base_cmd help login" \
+  "$base_cmd help add" \
+  "$base_cmd help import" \
+  "$base_cmd help list" \
+  "$base_cmd help export" \
+  "$base_cmd help remove"
+do
+  echo "$ $cmd"
+  $cmd
+  echo
+done
+
+echo "$ $base_cmd import --source=json < crates/device-inventory/test-data/get-loans-response.json"
+$base_cmd import --source=json < crates/device-inventory/test-data/get-loans-response.json
+echo
+
+for cmd in \
+  "$base_cmd list" \
+  "$base_cmd export" \
+  "$base_cmd remove --alias vlt-12345"
+do
+  echo "$ $cmd"
+  $cmd
+  echo
+done
+
+echo "$ $base_cmd list"
+$base_cmd list

--- a/bin/device-inventory-smoke-test.sh
+++ b/bin/device-inventory-smoke-test.sh
@@ -1,36 +1,22 @@
 #!/usr/bin/env sh
 set -eu
 
-base_cmd="device-inventory --offline"
-export RUST_LOG=debug
+echo '+ device-inventory help'
+device-inventory help
 
-for cmd in \
-  "$base_cmd help" \
-  "$base_cmd help login" \
-  "$base_cmd help add" \
-  "$base_cmd help import" \
-  "$base_cmd help list" \
-  "$base_cmd help export" \
-  "$base_cmd help remove"
-do
-  echo "$ $cmd"
-  $cmd
-  echo
-done
+unset RUST_LOG
+export DEVICE_INVENTORY_LOCATION=$(mktemp -d)
+export DEVICE_INVENTORY_OFFLINE=true
 
-echo "$ $base_cmd import --source=json < crates/device-inventory/test-data/get-loans-response.json"
-$base_cmd import --source=json < crates/device-inventory/test-data/get-loans-response.json
-echo
-
-for cmd in \
-  "$base_cmd list" \
-  "$base_cmd export" \
-  "$base_cmd remove --alias vlt-12345"
-do
-  echo "$ $cmd"
-  $cmd
-  echo
-done
-
-echo "$ $base_cmd list"
-$base_cmd list
+set -x
+device-inventory help login
+device-inventory help add
+device-inventory help import
+device-inventory help list
+device-inventory help export
+device-inventory help remove
+device-inventory import --source=json < crates/device-inventory/test-data/get-loans-response.json
+device-inventory list
+device-inventory export
+device-inventory remove --alias vlt-8
+device-inventory list

--- a/crates/device-inventory/Cargo.toml
+++ b/crates/device-inventory/Cargo.toml
@@ -5,7 +5,7 @@ edition.workspace = true
 
 [dependencies]
 anyhow = { workspace = true }
-clap = { workspace = true, features = ["derive"] }
+clap = { workspace = true, features = ["derive", "env"] }
 dirs = { workspace = true }
 env_logger = { workspace = true }
 log = { workspace = true }

--- a/crates/device-inventory/src/main.rs
+++ b/crates/device-inventory/src/main.rs
@@ -15,9 +15,9 @@ use crate::commands::{
 #[derive(Parser)]
 struct Cli {
     /// Location of the application data.
-    #[arg(long)]
+    #[clap(long, env = "DEVICE_INVENTORY_LOCATION")]
     inventory: Option<PathBuf>,
-    #[arg(long)]
+    #[clap(long, env = "DEVICE_INVENTORY_OFFLINE")]
     offline: bool,
     #[command(subcommand)]
     command: Commands,

--- a/snapshots/device-inventory-smoke-test
+++ b/snapshots/device-inventory-smoke-test
@@ -1,0 +1,111 @@
+$ device-inventory --offline help
+Usage: device-inventory [OPTIONS] <COMMAND>
+
+Commands:
+  login   Login to a pool of shared devices
+  add     Add a device
+  import  Import devices
+  list    List available devices
+  export  Print export statements for a device
+  remove  Remove a device
+  help    Print this message or the help of the given subcommand(s)
+
+Options:
+      --inventory <INVENTORY>  Location of the application data
+      --offline                
+  -h, --help                   Print help
+
+$ device-inventory --offline help login
+Login to a pool of shared devices
+
+Usage: device-inventory login
+
+Options:
+  -h, --help  Print help
+
+$ device-inventory --offline help add
+Add a device
+
+Usage: device-inventory add [OPTIONS] <ALIAS> <HOST> <USERNAME> <PASSWORD>
+
+Arguments:
+  <ALIAS>     An alias for the device unique within the inventory
+  <HOST>      The IP address or hostname of the device
+  <USERNAME>  The username of an administrator on the device, or root
+  <PASSWORD>  The password of an administrator on the device, or of root
+
+Options:
+      --http-port <HTTP_PORT>    HTTP port to use, if different from default
+      --https-port <HTTPS_PORT>  HTTPS port to use, if different from default
+      --ssh-port <SSH_PORT>      SSH port to use, if different from default
+  -h, --help                     Print help
+
+$ device-inventory --offline help import
+Import devices
+
+Usage: device-inventory import [OPTIONS]
+
+Options:
+      --source <SOURCE>
+          How to import devices
+          
+          [default: pool]
+
+          Possible values:
+          - json: Parse devices from the provided JSON
+          - pool: Fetch reserved devices from a shared pool
+
+  -h, --help
+          Print help (see a summary with '-h')
+
+$ device-inventory --offline help list
+List available devices
+
+Usage: device-inventory list
+
+Options:
+  -h, --help  Print help
+
+$ device-inventory --offline help export
+Print export statements for a device
+
+Example: `device-inventory export | source /dev/stdin`
+
+Usage: device-inventory export [OPTIONS]
+
+Options:
+      --alias <ALIAS>
+          The alias of the device to export
+
+  -h, --help
+          Print help (see a summary with '-h')
+
+$ device-inventory --offline help remove
+Remove a device
+
+Usage: device-inventory remove --alias <ALIAS>
+
+Options:
+      --alias <ALIAS>  The alias of the device to remove
+  -h, --help           Print help
+
+$ device-inventory --offline import --source=json < crates/device-inventory/test-data/get-loans-response.json
+
+$ device-inventory --offline list
+ALIAS  MODEL              HOST
+vlt-8  AXIS Q1615 Mk III  195.60.68.14
+
+$ device-inventory --offline export
+export AXIS_DEVICE_IP=195.60.68.14
+export AXIS_DEVICE_USER=VLTuser
+export AXIS_DEVICE_PASS=nYy3cuvX
+export AXIS_DEVICE_SSH_PORT=22051
+export AXIS_DEVICE_HTTP_PORT=12051
+export AXIS_DEVICE_HTTPS_PORT=42051
+export AXIS_DEVICE_HTTPS_SELF_SIGNED=1
+
+$ device-inventory --offline remove --alias vlt-12345
+
+$ device-inventory --offline list
+ALIAS  MODEL              HOST
+vlt-8  AXIS Q1615 Mk III  195.60.68.14

--- a/snapshots/device-inventory-smoke-test
+++ b/snapshots/device-inventory-smoke-test
@@ -1,4 +1,4 @@
-$ device-inventory --offline help
++ device-inventory help
 Usage: device-inventory [OPTIONS] <COMMAND>
 
 Commands:
@@ -11,19 +11,17 @@ Commands:
   help    Print this message or the help of the given subcommand(s)
 
 Options:
-      --inventory <INVENTORY>  Location of the application data
-      --offline                
+      --inventory <INVENTORY>  Location of the application data [env: DEVICE_INVENTORY_LOCATION=]
+      --offline                [env: DEVICE_INVENTORY_OFFLINE=]
   -h, --help                   Print help
-
-$ device-inventory --offline help login
++ device-inventory help login
 Login to a pool of shared devices
 
 Usage: device-inventory login
 
 Options:
   -h, --help  Print help
-
-$ device-inventory --offline help add
++ device-inventory help add
 Add a device
 
 Usage: device-inventory add [OPTIONS] <ALIAS> <HOST> <USERNAME> <PASSWORD>
@@ -39,8 +37,7 @@ Options:
       --https-port <HTTPS_PORT>  HTTPS port to use, if different from default
       --ssh-port <SSH_PORT>      SSH port to use, if different from default
   -h, --help                     Print help
-
-$ device-inventory --offline help import
++ device-inventory help import
 Import devices
 
 Usage: device-inventory import [OPTIONS]
@@ -57,16 +54,14 @@ Options:
 
   -h, --help
           Print help (see a summary with '-h')
-
-$ device-inventory --offline help list
++ device-inventory help list
 List available devices
 
 Usage: device-inventory list
 
 Options:
   -h, --help  Print help
-
-$ device-inventory --offline help export
++ device-inventory help export
 Print export statements for a device
 
 Example: `device-inventory export | source /dev/stdin`
@@ -79,8 +74,7 @@ Options:
 
   -h, --help
           Print help (see a summary with '-h')
-
-$ device-inventory --offline help remove
++ device-inventory help remove
 Remove a device
 
 Usage: device-inventory remove --alias <ALIAS>
@@ -88,14 +82,11 @@ Usage: device-inventory remove --alias <ALIAS>
 Options:
       --alias <ALIAS>  The alias of the device to remove
   -h, --help           Print help
-
-$ device-inventory --offline import --source=json < crates/device-inventory/test-data/get-loans-response.json
-
-$ device-inventory --offline list
++ device-inventory import --source=json
++ device-inventory list
 ALIAS  MODEL              HOST
 vlt-8  AXIS Q1615 Mk III  195.60.68.14
-
-$ device-inventory --offline export
++ device-inventory export
 export AXIS_DEVICE_IP=195.60.68.14
 export AXIS_DEVICE_USER=VLTuser
 export AXIS_DEVICE_PASS=nYy3cuvX
@@ -103,9 +94,6 @@ export AXIS_DEVICE_SSH_PORT=22051
 export AXIS_DEVICE_HTTP_PORT=12051
 export AXIS_DEVICE_HTTPS_PORT=42051
 export AXIS_DEVICE_HTTPS_SELF_SIGNED=1
-
-$ device-inventory --offline remove --alias vlt-12345
-
-$ device-inventory --offline list
-ALIAS  MODEL              HOST
-vlt-8  AXIS Q1615 Mk III  195.60.68.14
++ device-inventory remove --alias vlt-8
++ device-inventory list
+ALIAS  MODEL  HOST


### PR DESCRIPTION
I find that it slow to write tests in rust and that it is tiresome to understand how they map onto actions that I as a human would take. But I also think that maintaining elaborate bash scripts is error prone and tedious. Hopefully I can get the best of both worlds like this.

Communicate inventory path via environment variable to avoid having it show up in the output. This is important because it is different on every run. And since `device-inventory help` prints the environment variables, we treat is specially to avoid that happening.

Communicate offline flag via environment variable to be consistent.

Use `set -x` instead of looping because it is easier.