### PR TITLE
feat: Make `rest` module public

### DIFF
--- a/crates/vapix/src/lib.rs
+++ b/crates/vapix/src/lib.rs
@@ -4,7 +4,7 @@ mod client;
 mod config;
 pub mod json_rpc;
 pub mod json_rpc_http;
-mod rest;
+pub mod rest;
 mod services;
 pub mod soap;
 pub mod soap_http;


### PR DESCRIPTION
These utilities are meant to be used by the protocols-pillar of this crate and access to the error in particular is necessary to make effective use of the fluent API.

This commit stops short of reorganizing the modules according to the pillars because I don't have a clear view of what the pillars should be called or where to draw the line between pillars. As of writing the idea is roughly:
- An HTTP client specialized in connecting to a single device.
- Protocol utilities facilitating handling responses from various style APIs (JSON RPC, REST, SOAP)
- Ergonomic API tying it all together.