### PR TITLE
fix: Use correct program name in completions help

### DIFF
--- a/crates/bin-utils/src/completions_command.rs
+++ b/crates/bin-utils/src/completions_command.rs
@@ -1,8 +1,5 @@
 use clap_complete::{generate, Shell};
 
-/// Print a completion file for the given shell.
-///
-/// Example: `cargo-acap-sdk completions zsh | source /dev/stdin`.
 #[derive(Debug, clap::Parser)]
 pub struct CompletionsCommand {
     shell: Shell,

--- a/crates/device-finder/src/main.rs
+++ b/crates/device-finder/src/main.rs
@@ -27,6 +27,9 @@ impl Cli {
 enum Commands {
     /// Discover devices on the local network
     DiscoverDevices(DiscoverDevicesCommand),
+    /// Print a completion file for the given shell.
+    ///
+    /// Example: `device-finder completions zsh | source /dev/stdin`.
     Completions(CompletionsCommand),
 }
 

--- a/crates/device-inventory/src/main.rs
+++ b/crates/device-inventory/src/main.rs
@@ -73,6 +73,9 @@ enum Commands {
     Export(ExportCommand),
     /// Remove a device
     Remove(RemoveCommand),
+    /// Print a completion file for the given shell.
+    ///
+    /// Example: `device-inventory completions zsh | source /dev/stdin`.
     Completions(CompletionsCommand),
 }
 

--- a/snapshots/device-finder-docs
+++ b/snapshots/device-finder-docs
@@ -12,7 +12,7 @@ Options:
 + device-finder help completions
 Print a completion file for the given shell.
 
-Example: `cargo-acap-sdk completions zsh | source /dev/stdin`.
+Example: `device-finder completions zsh | source /dev/stdin`.
 
 Usage: device-finder completions <SHELL>
 

--- a/snapshots/device-inventory-docs
+++ b/snapshots/device-inventory-docs
@@ -140,7 +140,7 @@ Options:
 + device-inventory help completions
 Print a completion file for the given shell.
 
-Example: `cargo-acap-sdk completions zsh | source /dev/stdin`.
+Example: `device-inventory completions zsh | source /dev/stdin`.
 
 Usage: device-inventory completions <SHELL>
 


### PR DESCRIPTION
`crates/bin-utils/src/completions_command.rs`:
- I investigated modifying the command created by `#[derive(Parser)]` to make it easier keeping all the help texts up to date, varying only the program name, but I couldn't quickly find a way to parse it back into the `Cli` struct. Because it makes sense that this would not be a supported use case, I didn't spend much time on this.