### PR TITLE
feat: Emit warnings by default and save full log to file

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1577,6 +1577,8 @@ dependencies = [
  "anyhow",
  "clap",
  "clap_complete",
+ "env_logger",
+ "log",
 ]
 
 [[package]]

--- a/bin/device-inventory-smoke-test.sh
+++ b/bin/device-inventory-smoke-test.sh
@@ -9,7 +9,7 @@ set -x
 device-inventory import --source=json < crates/device-inventory/test-data/get-loans-response.json
 device-inventory add local 192.168.0.90 root pass
 device-inventory list
-device-inventory export
+device-inventory export --alias local
 device-inventory for-each sh -- -c 'echo $AXIS_DEVICE_IP'
 device-inventory remove --alias 'vlt-*'
 device-inventory list

--- a/crates/bin-utils/Cargo.toml
+++ b/crates/bin-utils/Cargo.toml
@@ -8,3 +8,5 @@ license = "MIT"
 anyhow = { workspace = true }
 clap = { workspace = true, features = ["derive"] }
 clap_complete = { workspace = true }
+env_logger = { workspace = true }
+log = { workspace = true }

--- a/crates/bin-utils/src/lib.rs
+++ b/crates/bin-utils/src/lib.rs
@@ -1,2 +1,3 @@
 //! Code that should be the same across all binaries in this project.
 pub mod completions_command;
+pub mod logger;

--- a/crates/bin-utils/src/logger.rs
+++ b/crates/bin-utils/src/logger.rs
@@ -1,0 +1,93 @@
+use std::{
+    env,
+    fs::File,
+    path::{Path, PathBuf},
+};
+
+use log::{info, LevelFilter, Log, Metadata, Record};
+
+struct Tee {
+    loggers: Vec<env_logger::Logger>,
+}
+
+impl Log for Tee {
+    fn enabled(&self, metadata: &Metadata) -> bool {
+        self.loggers.iter().any(|logger| logger.enabled(metadata))
+    }
+
+    fn log(&self, record: &Record) {
+        for logger in &self.loggers {
+            if logger.enabled(record.metadata()) {
+                logger.log(record);
+            }
+        }
+    }
+
+    fn flush(&self) {
+        for logger in &self.loggers {
+            logger.flush();
+        }
+    }
+}
+
+pub struct Guard {
+    file: Option<PathBuf>,
+}
+
+impl Guard {
+    pub fn disarm(&mut self) {
+        if let Some(file) = self.file.take() {
+            info!("Full log stored in {file:?}");
+        }
+    }
+}
+
+impl Drop for Guard {
+    fn drop(&mut self) {
+        if let Some(file) = self.file.as_ref() {
+            eprintln!("Full log stored in {file:?}");
+        }
+    }
+}
+
+fn file_path() -> Option<PathBuf> {
+    let current_exe = env::current_exe().ok()?;
+    let name = current_exe.file_name()?.to_str()?;
+    let path = env::temp_dir().join(name).with_extension("log");
+    Some(path)
+}
+
+fn file_logger(path: &Path) -> Option<env_logger::Logger> {
+    let target = env_logger::Target::Pipe(Box::new(File::create(path).ok()?));
+    Some(
+        env_logger::Builder::new()
+            .filter_level(LevelFilter::Trace)
+            .target(target)
+            .build(),
+    )
+}
+
+fn stderr_logger() -> env_logger::Logger {
+    env_logger::Builder::new()
+        .filter_level(LevelFilter::Warn)
+        .parse_default_env()
+        .build()
+}
+
+pub fn init() -> Guard {
+    let file_path = file_path().unwrap();
+    let file_logger = file_logger(&file_path).unwrap();
+    let stderr_logger = stderr_logger();
+
+    let max_level = file_logger.filter().max(stderr_logger.filter());
+
+    log::set_boxed_logger(Box::new(Tee {
+        loggers: vec![file_logger, stderr_logger],
+    }))
+    .unwrap();
+    log::set_max_level(max_level);
+
+    Guard {
+        file: Some(file_path),
+    }
+}

--- a/crates/device-finder/src/main.rs
+++ b/crates/device-finder/src/main.rs
@@ -41,6 +41,8 @@ impl Default for Commands {
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
-    env_logger::init();
-    Cli::parse().exec().await
+    let mut guard = rs4a_bin_utils::logger::init();
+    Cli::parse().exec().await?;
+    guard.disarm();
+    Ok(())
 }

--- a/crates/device-inventory/src/main.rs
+++ b/crates/device-inventory/src/main.rs
@@ -81,6 +81,8 @@ enum Commands {
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
-    env_logger::init();
-    Cli::parse().exec().await
+    let mut guard = rs4a_bin_utils::logger::init();
+    Cli::parse().exec().await?;
+    guard.disarm();
+    Ok(())
 }

--- a/snapshots/device-inventory-smoke-test
+++ b/snapshots/device-inventory-smoke-test
@@ -4,7 +4,7 @@
 ALIAS  MODEL              HOST
 local                     192.168.0.90
 vlt-8  AXIS Q1615 Mk III  195.60.68.14
-+ device-inventory export
++ device-inventory export --alias local
 export AXIS_DEVICE_IP=192.168.0.90
 export AXIS_DEVICE_USER=root
 export AXIS_DEVICE_PASS=pass


### PR DESCRIPTION
Prompted by me using the export command and being confused about why I didn't have a usable device exported.

Since I'm taking a look at the logging I thought I might as well write it to file as well; I find that I often don't want to see the logs unless something actually went wrong, so we write them to file. Unlike previous implementations I have made of this, we always write the logs to file, not only when we are not writing them to stderr because it is often useful to emit warnings and errors to the terminal to make the user aware of problems.

---

`bin/device-inventory-smoke-test.sh`:
- Specify which device to export because otherwise a warning will be logged and the logs contain timestamps that are not reproducible.