### PR TITLE
feat: Replace export command with activate

### DIFF
--- a/bin/device-inventory-docs.sh
+++ b/bin/device-inventory-docs.sh
@@ -9,6 +9,6 @@ device-inventory help adopt
 device-inventory help deactivate
 device-inventory help import
 device-inventory help list
-device-inventory help export
+device-inventory help activate
 device-inventory help remove
 device-inventory help completions

--- a/bin/device-inventory-smoke-test.sh
+++ b/bin/device-inventory-smoke-test.sh
@@ -9,7 +9,7 @@ set -x
 device-inventory import --source=json < crates/device-inventory/test-data/get-loans-response.json
 device-inventory add local 192.168.0.90 root pass
 device-inventory list
-device-inventory export --alias local
+device-inventory activate --alias local --destination environment
 device-inventory for-each sh -- -c 'echo $AXIS_DEVICE_IP'
 device-inventory remove --alias 'vlt-*'
 device-inventory list

--- a/crates/device-inventory/src/commands.rs
+++ b/crates/device-inventory/src/commands.rs
@@ -1,7 +1,7 @@
+pub mod activate;
 pub mod add;
 pub mod adopt;
 pub mod deactivate;
-pub mod export;
 pub mod for_each;
 pub mod import;
 pub mod list;

--- a/crates/device-inventory/src/commands/activate.rs
+++ b/crates/device-inventory/src/commands/activate.rs
@@ -11,16 +11,16 @@ pub(crate) enum Destination {
 }
 
 #[derive(Clone, Debug, clap::Parser)]
-pub struct ExportCommand {
-    /// The alias of the device to export
+pub struct ActivateCommand {
+    /// The alias of the device to activate.
     #[arg(long)]
     pub(crate) alias: Option<String>,
-    // How to export the device
-    #[arg(long, default_value = "environment")]
+    // Where to store the information about which device is active.
+    #[arg(long, default_value = "filesystem")]
     pub(crate) destination: Destination,
 }
 
-impl ExportCommand {
+impl ActivateCommand {
     pub async fn exec(self, db: Database) -> anyhow::Result<()> {
         let mut devices = db.read_devices()?;
 

--- a/crates/device-inventory/src/commands/adopt.rs
+++ b/crates/device-inventory/src/commands/adopt.rs
@@ -4,7 +4,7 @@ use device_inventory::db::Database;
 use log::warn;
 
 use crate::commands::{
-    export::{Destination, ExportCommand},
+    activate::{ActivateCommand, Destination},
     import::{ImportCommand, Source},
 };
 
@@ -21,13 +21,13 @@ fn infer_alias(before: HashSet<String>, after: impl Iterator<Item = String>) -> 
 
 #[derive(Clone, Debug, clap::Parser)]
 pub struct AdoptCommand {
-    /// The alias of the device(s) to import and export
+    /// The alias of the device(s) to import and activate.
     #[arg(long)]
     alias: Option<String>,
-    /// How to import devices
+    /// How to import devices.
     #[arg(long, default_value = "pool")]
     source: Source,
-    /// How to export the device
+    /// How to activate the device.
     #[arg(long, default_value = "filesystem")]
     destination: Destination,
 }
@@ -42,7 +42,7 @@ impl AdoptCommand {
         let before = db.read_devices()?.into_keys();
         ImportCommand { source }.exec(&db, offline).await?;
         let after = db.read_devices()?.into_keys();
-        ExportCommand {
+        ActivateCommand {
             alias: alias.or_else(|| infer_alias(before.into_iter().collect(), after.into_iter())),
             destination,
         }

--- a/crates/device-inventory/src/main.rs
+++ b/crates/device-inventory/src/main.rs
@@ -5,7 +5,7 @@ mod commands;
 use std::path::PathBuf;
 
 use clap::{Parser, Subcommand};
-use commands::{export::ExportCommand, import::ImportCommand};
+use commands::{activate::ActivateCommand, import::ImportCommand};
 use device_inventory::db::Database;
 use rs4a_bin_utils::completions_command::CompletionsCommand;
 
@@ -41,7 +41,7 @@ impl Cli {
             Commands::Import(cmd) => cmd.exec(&db, offline).await?,
             Commands::ForEach(cmd) => cmd.exec(db).await?,
             Commands::List(cmd) => cmd.exec(db).await?,
-            Commands::Export(cmd) => cmd.exec(db).await?,
+            Commands::Activate(cmd) => cmd.exec(db).await?,
             Commands::Remove(cmd) => cmd.exec(db).await?,
             Commands::Completions(cmd) => cmd.exec::<Self>()?,
         }
@@ -55,7 +55,7 @@ enum Commands {
     Login(LoginCommand),
     /// Add a device
     Add(AddCommand),
-    /// Import all matching devices and export at most one matching device.
+    /// Import all matching devices and activate at most one matching device.
     Adopt(AdoptCommand),
     /// Deactivate any active device.
     ///
@@ -67,10 +67,8 @@ enum Commands {
     ForEach(ForEachCommand),
     /// List available devices
     List(ListCommand),
-    /// Print export statements for a device
-    ///
-    /// Example: `device-inventory export | source /dev/stdin`
-    Export(ExportCommand),
+    /// Activate an existing device.
+    Activate(ActivateCommand),
     /// Remove a device
     Remove(RemoveCommand),
     /// Print a completion file for the given shell.

--- a/crates/device-inventory/tests/import_and_export_loans.rs
+++ b/crates/device-inventory/tests/import_and_export_loans.rs
@@ -44,7 +44,8 @@ fn can_export_loans_from_get_response() {
     assert_eq!(output.stdout, b"");
 
     let output = device_inventory_command(now)
-        .arg("export")
+        .arg("activate")
+        .args(["--destination", "environment"])
         .stderr(Stdio::inherit())
         .output()
         .unwrap();

--- a/snapshots/device-inventory-docs
+++ b/snapshots/device-inventory-docs
@@ -5,12 +5,12 @@ Usage: device-inventory [OPTIONS] <COMMAND>
 Commands:
   login        Login to a pool of shared devices
   add          Add a device
-  adopt        Import all matching devices and export at most one matching device
+  adopt        Import all matching devices and activate at most one matching device
   deactivate   Deactivate any active device
   import       Import devices
   for-each     Run a command with environment variables set for each device
   list         List available devices
-  export       Print export statements for a device
+  activate     Activate an existing device
   remove       Remove a device
   completions  Print a completion file for the given shell
   help         Print this message or the help of the given subcommand(s)
@@ -43,13 +43,13 @@ Options:
       --ssh-port <SSH_PORT>      SSH port to use, if different from default
   -h, --help                     Print help
 + device-inventory help adopt
-Import all matching devices and export at most one matching device
+Import all matching devices and activate at most one matching device
 
 Usage: device-inventory adopt [OPTIONS]
 
 Options:
       --alias <ALIAS>
-          The alias of the device(s) to import and export
+          The alias of the device(s) to import and activate
 
       --source <SOURCE>
           How to import devices
@@ -61,7 +61,7 @@ Options:
           - pool: Fetch reserved devices from a shared pool
 
       --destination <DESTINATION>
-          How to export the device
+          How to activate the device
           
           [default: filesystem]
 
@@ -109,19 +109,17 @@ Usage: device-inventory list [OPTIONS]
 Options:
       --alias <ALIAS>  The alias of the device to list
   -h, --help           Print help
-+ device-inventory help export
-Print export statements for a device
++ device-inventory help activate
+Activate an existing device
 
-Example: `device-inventory export | source /dev/stdin`
-
-Usage: device-inventory export [OPTIONS]
+Usage: device-inventory activate [OPTIONS]
 
 Options:
       --alias <ALIAS>
-          The alias of the device to export
+          The alias of the device to activate
 
       --destination <DESTINATION>
-          [default: environment]
+          [default: filesystem]
 
           Possible values:
           - filesystem:  Write information to the filesystem

--- a/snapshots/device-inventory-smoke-test
+++ b/snapshots/device-inventory-smoke-test
@@ -4,7 +4,7 @@
 ALIAS  MODEL              HOST
 local                     192.168.0.90
 vlt-8  AXIS Q1615 Mk III  195.60.68.14
-+ device-inventory export --alias local
++ device-inventory activate --alias local --destination environment
 export AXIS_DEVICE_IP=192.168.0.90
 export AXIS_DEVICE_USER=root
 export AXIS_DEVICE_PASS=pass


### PR DESCRIPTION
The new name better reflects the concept that one device from may be active at any time.

---

`crates/device-inventory/src/commands/activate.rs`:
- Change the default destination because I prefer working with the filesystem.