### PR TITLE
feat(di): Add ensure command

### DIFF
--- a/crates/device-inventory/src/commands.rs
+++ b/crates/device-inventory/src/commands.rs
@@ -1,9 +1,12 @@
+pub mod abandon;
 pub mod activate;
 pub mod add;
 pub mod adopt;
 pub mod deactivate;
+pub mod ensure;
 pub mod for_each;
 pub mod import;
 pub mod list;
 pub mod login;
 pub mod remove;
+pub mod search;

--- a/crates/device-inventory/src/commands/abandon.rs
+++ b/crates/device-inventory/src/commands/abandon.rs
@@ -1,0 +1,61 @@
+use anyhow::Context;
+use device_inventory::{
+    db::{Database, Device},
+    db_vlt,
+};
+use log::{info, warn};
+
+#[derive(Clone, Debug, clap::Parser)]
+pub struct AbandonCommand {
+    /// The alias of the device to abandon.
+    ///
+    /// If not set, any activated device will be abandoned instead.
+    #[arg(long)]
+    alias: Option<String>,
+}
+
+impl AbandonCommand {
+    pub async fn exec(self, db: &Database, offline: bool) -> anyhow::Result<()> {
+        let devices = db.read_devices()?;
+
+        let (removed, retained): (Vec<_>, Vec<_>) = match self.alias {
+            Some(alias) => {
+                let pattern = glob::Pattern::new(&alias)?;
+                devices
+                    .into_iter()
+                    .partition(|(alias, _)| pattern.matches(alias))
+            }
+            None => {
+                let fingerprint = Device::from(
+                    rs4a_dut::Device::from_anywhere()?
+                        .context("An alias must be provided if there is no active device")?,
+                )
+                .fingerprint();
+                devices
+                    .into_iter()
+                    .partition(|(_, device)| device.fingerprint() == fingerprint)
+            }
+        };
+
+        if removed.is_empty() {
+            warn!("No devices were removed");
+            return Ok(());
+        }
+
+        for (alias, device) in removed {
+            info!("Removing device {}", alias);
+            if let Some(loan_id) = device.loan_id {
+                info!("Canceling loan {loan_id}");
+                let client = db_vlt::client(db, offline)
+                    .await?
+                    .context("No VLT session")?;
+                rs4a_vlt::requests::cancel_loan(loan_id)
+                    .send(&client)
+                    .await?;
+            }
+        }
+
+        db.write_devices(&retained.into_iter().collect())?;
+        Ok(())
+    }
+}

--- a/crates/device-inventory/src/commands/activate.rs
+++ b/crates/device-inventory/src/commands/activate.rs
@@ -21,7 +21,7 @@ pub struct ActivateCommand {
 }
 
 impl ActivateCommand {
-    pub async fn exec(self, db: Database) -> anyhow::Result<()> {
+    pub async fn exec(self, db: &Database) -> anyhow::Result<()> {
         let mut devices = db.read_devices()?;
 
         if let Some(pattern) = &self.alias {

--- a/crates/device-inventory/src/commands/add.rs
+++ b/crates/device-inventory/src/commands/add.rs
@@ -52,6 +52,7 @@ impl AddCommand {
                 ssh_port,
                 // TODO: Fetch from device
                 model: None,
+                loan_id: None,
             },
         );
         db.write_devices(&devices)?;

--- a/crates/device-inventory/src/commands/adopt.rs
+++ b/crates/device-inventory/src/commands/adopt.rs
@@ -46,7 +46,7 @@ impl AdoptCommand {
             alias: alias.or_else(|| infer_alias(before.into_iter().collect(), after.into_iter())),
             destination,
         }
-        .exec(db)
+        .exec(&db)
         .await?;
         Ok(())
     }

--- a/crates/device-inventory/src/commands/ensure.rs
+++ b/crates/device-inventory/src/commands/ensure.rs
@@ -1,0 +1,178 @@
+use anyhow::{bail, Context};
+use device_inventory::{db, db::Database, db_vlt, db_vlt::try_device_from_loan};
+use log::{debug, warn};
+use rs4a_vlt::{
+    client::Client,
+    requests,
+    requests::{Reason, TimeOption},
+    responses::{DeviceStatus, Loan},
+};
+
+use crate::commands::{
+    activate::{ActivateCommand, Destination},
+    import::{ImportCommand, Source},
+    search,
+    search::{SearchCommand, SearchFilter},
+};
+
+#[derive(Clone, Debug, clap::Parser)]
+pub struct EnsureCommand {
+    #[command(flatten)]
+    search: SearchCommand,
+    /// How to activate the device.
+    #[arg(long, default_value = "filesystem")]
+    destination: Destination,
+}
+
+fn try_active(filter: &SearchFilter) -> anyhow::Result<Option<rs4a_dut::Device>> {
+    debug!("Searching active...");
+    let device = rs4a_dut::Device::from_anywhere()
+        .inspect(|d| debug!("Found {} active devices", d.iter().len()))?
+        .filter(|d| filter.matches(search::Device::from(d)));
+    Ok(device)
+}
+
+async fn try_devices(
+    filter: &SearchFilter,
+    client: &Client,
+) -> anyhow::Result<Option<rs4a_vlt::responses::Device>> {
+    let mut other = requests::devices()
+        .send(client)
+        .await
+        .inspect(|d| debug!("Found {} other devices", d.len()))?
+        .into_iter()
+        .filter(|d| filter.matches(search::Device::from(d)) && d.status == DeviceStatus::Connected)
+        .collect::<Vec<_>>();
+    other.sort_by_key(|d| d.id.as_u16());
+    let mut other = other.into_iter();
+    let Some(device) = other.next() else {
+        return Ok(None);
+    };
+    if other.next().is_some() {
+        warn!("Found more than one device, using the first one");
+    }
+    Ok(Some(device))
+}
+
+async fn try_inventory(
+    filter: &SearchFilter,
+    db: &Database,
+) -> anyhow::Result<Option<(String, db::Device)>> {
+    debug!("Searching inventory...");
+    let mut from_inventory = db
+        .read_devices()
+        .inspect(|d| debug!("Found {} devices in inventory", d.len()))?
+        .into_iter()
+        .filter(|kv| filter.matches(search::Device::from(kv)))
+        .collect::<Vec<_>>();
+    from_inventory.sort_by_key(|(alias, _)| alias.clone());
+    let mut from_inventory = from_inventory.into_iter();
+    let Some((alias, device)) = from_inventory.next() else {
+        return Ok(None);
+    };
+
+    if from_inventory.next().is_some() {
+        warn!("More than matching device found in the inventory, proceeding with the first");
+    }
+    Ok(Some((alias, device)))
+}
+
+async fn try_loans(filter: &SearchFilter, client: &Client) -> anyhow::Result<Option<Loan>> {
+    debug!("Searching loans...");
+    let mut loaned = requests::loans()
+        .send(client)
+        .await
+        .inspect(|d| debug!("Found {} loans", d.len()))?
+        .into_iter()
+        .filter(|l| filter.matches(search::Device::from(l)));
+    let Some(loan) = loaned.next() else {
+        return Ok(None);
+    };
+
+    if loaned.next().is_some() {
+        warn!("Found more than one device loaned, using the first one");
+    }
+    Ok(Some(loan))
+}
+
+impl EnsureCommand {
+    pub async fn exec(self, db: &Database, offline: bool) -> anyhow::Result<()> {
+        let Self {
+            search,
+            destination,
+        } = self;
+        let search = search.into_filter()?;
+
+        if try_active(&search)?.is_some() {
+            debug!("Found matching active device");
+            return Ok(());
+        }
+
+        if let Some((alias, _)) = try_inventory(&search, db).await? {
+            debug!("Found matching imported device");
+
+            ActivateCommand {
+                alias: Some(alias),
+                destination,
+            }
+            .exec(db)
+            .await?;
+
+            return Ok(());
+        }
+
+        let client = db_vlt::client(db, offline)
+            .await?
+            .context("no active VLT session")?;
+
+        if let Some(loan) = try_loans(&search, &client).await? {
+            debug!("Found matching loaned device");
+            let (alias, _) = try_device_from_loan(loan)?;
+
+            ImportCommand {
+                source: Source::Pool,
+            }
+            .exec(db, offline)
+            .await?;
+
+            ActivateCommand {
+                alias: Some(alias.clone()),
+                destination,
+            }
+            .exec(db)
+            .await?;
+
+            return Ok(());
+        }
+
+        if let Some(device) = try_devices(&search, &client).await? {
+            debug!("Found matching other device: {device:?}");
+            let loan = requests::create_loan(
+                device.id,
+                Reason::ACAPTest,
+                TimeOption::hours_from_now(8),
+                device.firmware_version,
+            )
+            .send(&client)
+            .await?;
+            let alias = format!("vlt-{}", loan.loanable.id);
+
+            ImportCommand {
+                source: Source::Pool,
+            }
+            .exec(db, offline)
+            .await?;
+
+            ActivateCommand {
+                alias: Some(alias.clone()),
+                destination,
+            }
+            .exec(db)
+            .await?;
+
+            return Ok(());
+        }
+
+        bail!("No matching device found")
+    }
+}

--- a/crates/device-inventory/src/commands/search.rs
+++ b/crates/device-inventory/src/commands/search.rs
@@ -1,0 +1,233 @@
+use std::borrow::Cow;
+
+use anyhow::Context;
+use device_inventory::{db, db::Database, db_vlt, db_vlt::try_device_from_loan};
+use rs4a_vlt::{
+    requests,
+    responses::{DeviceArchitecture, DeviceStatus, Loan},
+};
+
+// TODO: Consider making these mandatory.
+pub struct Device<'a> {
+    pub(crate) alias: Option<Cow<'a, str>>,
+    pub(crate) architecture: Option<DeviceArchitecture>,
+    pub(crate) model: Option<&'a str>,
+    pub(crate) status: Option<DeviceStatus>,
+}
+
+impl<'a> From<&'a (String, db::Device)> for Device<'a> {
+    fn from(value: &'a (String, db::Device)) -> Self {
+        Self {
+            alias: Some(Cow::Borrowed(value.0.as_str())),
+            architecture: None,
+            model: None,
+            status: None,
+        }
+    }
+}
+
+impl<'a> From<&'a rs4a_vlt::responses::Device> for Device<'a> {
+    fn from(value: &'a rs4a_vlt::responses::Device) -> Self {
+        let rs4a_vlt::responses::Device {
+            architecture,
+            id,
+            model,
+            status,
+            ..
+        } = value;
+        Self {
+            alias: Some(Cow::Owned(format!("vlt-{id}"))),
+            architecture: Some(*architecture),
+            model: Some(model.as_ref()),
+            status: Some(*status),
+        }
+    }
+}
+impl<'a> From<&'a Loan> for Device<'a> {
+    fn from(value: &'a Loan) -> Self {
+        let loanable_id = value.loanable.id;
+        Self {
+            alias: Some(Cow::Owned(format!("vlt-{loanable_id}"))),
+            architecture: None,
+            model: None,
+            status: None,
+        }
+    }
+}
+
+impl<'a> From<&'a rs4a_dut::Device> for Device<'a> {
+    fn from(_value: &'a rs4a_dut::Device) -> Self {
+        Self {
+            alias: None,
+            architecture: None,
+            model: None,
+            status: None,
+        }
+    }
+}
+
+#[derive(Clone, Debug, clap::Parser)]
+pub struct SearchCommand {
+    /// An alias for the device unique within the inventory.
+    #[arg(long)]
+    alias: Option<String>,
+    #[arg(long, short)]
+    architecture: Option<DeviceArchitecture>,
+    #[arg(long, short)]
+    model: Option<String>,
+    #[arg(long, short)]
+    status: Option<DeviceStatus>,
+}
+
+pub(crate) struct SearchFilter {
+    alias: Option<glob::Pattern>,
+    model: Option<glob::Pattern>,
+    architecture: Option<DeviceArchitecture>,
+    status: Option<DeviceStatus>,
+}
+
+impl SearchFilter {
+    pub(crate) fn matches(&self, d: Device) -> bool {
+        let Device {
+            alias,
+            architecture,
+            model,
+            status,
+        } = d;
+
+        if let Some(p) = self.alias.as_ref() {
+            if let Some(alias) = alias {
+                if !p.matches(&alias.to_lowercase()) {
+                    return false;
+                }
+            } else {
+                return false;
+            }
+        }
+
+        if let Some(p) = self.model.as_ref() {
+            if let Some(model) = model {
+                if !p.matches(&model.to_lowercase()) {
+                    return false;
+                }
+            } else {
+                return false;
+            }
+        }
+
+        if let Some(a) = self.architecture {
+            if let Some(architecture) = architecture {
+                if a != architecture {
+                    return false;
+                }
+            } else {
+                return false;
+            }
+        }
+
+        if let Some(s) = self.status {
+            if let Some(status) = status {
+                if s != status {
+                    return false;
+                }
+            } else {
+                return false;
+            }
+        }
+
+        true
+    }
+}
+
+impl SearchCommand {
+    pub(crate) fn into_filter(self) -> anyhow::Result<SearchFilter> {
+        let Self {
+            alias,
+            architecture,
+            model,
+            status,
+        } = self;
+        let alias = alias
+            .map(|s| glob::Pattern::new(s.to_lowercase().as_str()))
+            .transpose()?;
+        let model = model
+            .map(|s| glob::Pattern::new(s.to_lowercase().as_str()))
+            .transpose()?;
+        Ok(SearchFilter {
+            alias,
+            model,
+            architecture,
+            status,
+        })
+    }
+
+    pub async fn exec(self, db: &Database, offline: bool) -> anyhow::Result<()> {
+        let client = db_vlt::client(db, offline)
+            .await?
+            .context("VLT is not configured, skipping VLT devices")?;
+        let filter = self.into_filter()?;
+
+        // Loaned devices are not filtered because the loans does not include enough information,
+        // so that would have to be retrieved with additional calls. Furthermore, there's probably
+        // only a few loaned devices which are probably all relevant and the devices document
+        // confusingly omits loaned devices.
+        // TODO: Consider filtering loaned devices
+        let loaned = requests::loans().send(&client).await?;
+
+        let mut other = requests::devices()
+            .send(&client)
+            .await?
+            .into_iter()
+            .filter(|d| filter.matches(Device::from(d)))
+            .collect::<Vec<_>>();
+        other.sort_by_key(|d| d.id.as_u16());
+
+        let mut aliases = vec!["ALIAS".to_string()];
+        let mut models = vec!["MODEL".to_string()];
+        let mut architectures = vec!["ARCHITECTURE".to_string()];
+        let mut statuses = vec!["STATUS".to_string()];
+
+        for loan in loaned {
+            let (alias, device) = try_device_from_loan(loan)?;
+            let db::Device { model, .. } = device;
+            aliases.push(alias);
+            models.push(model.unwrap_or_default());
+            architectures.push("".to_string());
+            statuses.push("loaned".to_string());
+        }
+
+        for device in other {
+            let rs4a_vlt::responses::Device {
+                architecture,
+                id,
+                model,
+                status,
+                ..
+            } = device;
+            aliases.push(format!("vlt-{id}"));
+            models.push(model.to_string());
+            architectures.push(
+                serde_json::to_string(&architecture)
+                    .unwrap()
+                    .trim_matches('"')
+                    .to_string(),
+            );
+            statuses.push(status.as_str().to_string());
+        }
+
+        let aliases_width = 1 + aliases.iter().map(|s| s.len()).max().unwrap();
+        let models_width = 1 + models.iter().map(|s| s.len()).max().unwrap();
+        let architectures_width = 1 + architectures.iter().map(|s| s.len()).max().unwrap();
+        let statuses_width = 1 + statuses.iter().map(|s| s.len()).max().unwrap();
+
+        for (((alias, model), architecture), status) in aliases
+            .into_iter()
+            .zip(models.into_iter())
+            .zip(architectures.into_iter())
+            .zip(statuses.into_iter())
+        {
+            println!("{alias:aliases_width$} {model:models_width$} {architecture:architectures_width$} {status:statuses_width$}");
+        }
+        Ok(())
+    }
+}

--- a/crates/device-inventory/src/db.rs
+++ b/crates/device-inventory/src/db.rs
@@ -3,6 +3,7 @@ use std::{collections::HashMap, fs, path::PathBuf};
 
 use anyhow::{anyhow, Context};
 use log::debug;
+use rs4a_vlt::responses::LoanId;
 use url::Host;
 
 use crate::psst::Password;
@@ -19,6 +20,14 @@ pub struct Device {
     pub https_port: Option<u16>,
     pub ssh_port: Option<u16>,
     pub model: Option<String>,
+    pub loan_id: Option<LoanId>,
+}
+
+impl Device {
+    /// No two distinct devices have the same fingerprint at the same time.
+    pub fn fingerprint(&self) -> (Host, u16) {
+        (self.host.clone(), self.http_port.unwrap_or(80))
+    }
 }
 
 impl From<rs4a_dut::Device> for Device {
@@ -39,6 +48,7 @@ impl From<rs4a_dut::Device> for Device {
             https_port,
             ssh_port,
             model: None,
+            loan_id: None,
         }
     }
 }
@@ -53,6 +63,7 @@ impl From<Device> for rs4a_dut::Device {
             https_port,
             ssh_port,
             model: _,
+            loan_id: _,
         } = value;
         rs4a_dut::Device {
             host,

--- a/crates/device-inventory/src/db_vlt.rs
+++ b/crates/device-inventory/src/db_vlt.rs
@@ -75,18 +75,19 @@ pub fn try_device_from_loan(loan: Loan) -> anyhow::Result<(String, Device)> {
     let Loan {
         username,
         password,
+        id: loan_id,
         loanable:
             Loanable {
                 external_ip: _,
                 internal_ip: _,
-                id,
+                id: loanable_id,
                 model,
                 ..
             },
         ..
     } = loan;
     Ok((
-        format!("vlt-{id}"),
+        format!("vlt-{}", loanable_id),
         Device {
             model: Some(model),
             host: Host::Ipv4(Ipv4Addr::from([195, 60, 68, 14])),
@@ -95,6 +96,7 @@ pub fn try_device_from_loan(loan: Loan) -> anyhow::Result<(String, Device)> {
             http_port: Some(http_port),
             https_port: Some(https_port),
             ssh_port: Some(ssh_port),
+            loan_id: Some(loan_id),
         },
     ))
 }

--- a/snapshots/device-inventory-docs
+++ b/snapshots/device-inventory-docs
@@ -4,6 +4,8 @@ Usage: device-inventory [OPTIONS] <COMMAND>
 
 Commands:
   login        Login to a pool of shared devices
+  search       Search for devices in the VLT
+  ensure       Ensure that a matching device is active
   add          Add a device
   adopt        Import all matching devices and activate at most one matching device
   deactivate   Deactivate any active device
@@ -11,6 +13,7 @@ Commands:
   for-each     Run a command with environment variables set for each device
   list         List available devices
   activate     Activate an existing device
+  abandon      Remove devices and cancel any loans
   remove       Remove a device
   completions  Print a completion file for the given shell
   help         Print this message or the help of the given subcommand(s)


### PR DESCRIPTION
I often find that I want to start a new loan, import the loaned device, activate it, and initialize it. The new command is intended to speed that up, and eventually make it easier to do consistently.

---

`crates/device-inventory/src/commands/abandon.rs`:
- This is added primarily to test the `cancel_loan` function from `rs4a-vlt`, but I also foresee that it will be a useful complement to adopt, especially when working with multiple devices.
- Abandon the active device if no alias is provided to make working with a single device super easy since this is probably the most common use case.
- Devices are left in the inventory in case of failure to avoid leaving them in limbo where they are in a bad state but we don't know how to access them so we cannot fix them.

`crates/device-inventory/src/commands/ensure.rs`:
- 

`crates/device-inventory/src/commands/search.rs`:
- Added primarily to make it easier to test the filtering without side effects, but I have actually found it a reasonable alternative to the GUI for simple use cases since I don't have to leave the terminal.

