### PR TITLE
feat(v): Try get brand API when determining scheme

### DIFF
--- a/crates/vapix/src/apis.rs
+++ b/crates/vapix/src/apis.rs
@@ -15,6 +15,10 @@ pub mod jpg_3 {
     pub use crate::axis_cgi::jpg_3::get_image;
 }
 
+pub mod prod_brand_1 {
+    pub use crate::axis_cgi::prod_brand_info_1::get_brand;
+}
+
 pub mod remote_object_storage_1 {
     pub use crate::config::remote_object_storage_1::create_destinations;
 }

--- a/crates/vapix/src/axis_cgi.rs
+++ b/crates/vapix/src/axis_cgi.rs
@@ -2,4 +2,5 @@
 pub mod basic_device_info_1;
 
 pub mod jpg_3;
+pub mod prod_brand_info_1;
 pub mod system_ready_1;

--- a/crates/vapix/src/axis_cgi/prod_brand_info_1.rs
+++ b/crates/vapix/src/axis_cgi/prod_brand_info_1.rs
@@ -1,0 +1,47 @@
+// https://195.60.68.14:41095/axis-cgi/prod_brand_info/getbrand.cgi?timestamp=1760380912886
+
+use anyhow::Context;
+use serde::Deserialize;
+
+use crate::Client;
+
+// TODO: Consider tightening field types
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+pub struct Brand {
+    pub brand: String,
+    pub prod_type: String,
+    pub prod_short_name: String,
+    pub prod_nbr: String,
+    pub prod_full_name: String,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+struct GetBrandResponse {
+    brand: Brand,
+}
+
+pub struct GetBrandRequest;
+
+impl GetBrandRequest {
+    pub async fn send(self, client: &Client) -> anyhow::Result<Brand> {
+        let resp = client
+            .get("axis-cgi/prod_brand_info/getbrand.cgi")?
+            .send()
+            .await?
+            .error_for_status()?;
+
+        let status = resp.status();
+        let text = resp.text().await?;
+
+        serde_json::from_str::<GetBrandResponse>(&text)
+            .with_context(|| format!("Status: '{}'", status))
+            .map(|b| b.brand)
+    }
+}
+
+pub fn get_brand() -> GetBrandRequest {
+    GetBrandRequest
+}

--- a/crates/vapix/src/axis_cgi/prod_brand_info_1/get_brand_200.json
+++ b/crates/vapix/src/axis_cgi/prod_brand_info_1/get_brand_200.json
@@ -1,0 +1,9 @@
+{
+  "Brand": {
+    "Brand": "AXIS",
+    "ProdType": "PTZ Network Camera",
+    "ProdShortName": "AXIS V5915",
+    "ProdNbr": "V5915",
+    "ProdFullName": "AXIS V5915 PTZ Network Camera"
+  }
+}


### PR DESCRIPTION
The system ready API was introduced in AXIS OS 9.50, so for earlier versions `build_with_automatic_scheme` would fail. Such old devices aren't the focus of these tools since they are probably the target of only a small portion of development, but creating a client is the foundation for testing every other API and support can be added without hurting other use cases much (detecting the scheme probably takes a bit longer, but mostly for http and this should not be on a hot path anyway).

Note that it still fails if the root user has been set up and the authentication has not been changed to basic. Since this is the state that VLT devices are in when checked out, this problem will be encountered frequently. But at least there is a workaround in enabling basic authentication.