### PR TITLE
feat(dm): Add device-manager binary crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -560,6 +560,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "device-manager"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "clap",
+ "log",
+ "rs4a-bin-utils",
+ "rs4a-vapix",
+ "semver",
+ "tokio",
+ "url",
+]
+
+[[package]]
 name = "dirs"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Makefile
+++ b/Makefile
@@ -56,6 +56,7 @@ check_generated_files: \
 	snapshots/device-finder-docs \
 	snapshots/device-inventory-docs \
 	snapshots/device-inventory-smoke-test \
+	snapshots/device-manager-docs \
 	snapshots/firmware-inventory-docs
 	git update-index -q --refresh
 	git --no-pager diff --exit-code HEAD -- $^

--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ _A collection of language agnostic tools that facilitate development for the AXI
 - [Preview](#preview)
   - [device-finder](#device-finder)
   - [device-inventory](#device-inventory)
+  - [device-manager](#device-manager)
+  - [firmware-inventory](#firmware-inventory)
 - [Installation](#installation)
 - [Related projects](#related-projects)
 
@@ -55,6 +57,23 @@ Options:
   -h, --help                   Print help
 ```
 
+### `device-manager`
+
+```console
+$ device-manager help
+Usage: device-manager <COMMAND>
+
+Commands:
+  restore      Restore the device to a clean state (factory default)
+  init         Initialize a device in setup mode
+  reinit       Restore and initialize the device to a known, useful state
+  completions  Generate shell completions
+  help         Print this message or the help of the given subcommand(s)
+
+Options:
+  -h, --help  Print help
+```
+
 ### `firmware-inventory`
 
 ```console
@@ -82,6 +101,8 @@ The tools in this project can be installed using Cargo:
 ```shell
 cargo install --locked --git https://github.com/apljungquist/rs4a.git device-finder
 cargo install --locked --git https://github.com/apljungquist/rs4a.git device-inventory
+cargo install --locked --git https://github.com/apljungquist/rs4a.git device-manager
+cargo install --locked --git https://github.com/apljungquist/rs4a.git firmware-inventory
 ```
 
 If you want to install them another way, open an issue and I may be able to help.

--- a/bin/device-manager-docs.sh
+++ b/bin/device-manager-docs.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env sh
+set -eux
+unset RUST_LOG
+unset AXIS_DEVICE_IP
+unset AXIS_DEVICE_PASS
+unset AXIS_DEVICE_USER
+unset AXIS_DEVICE_HTTP_PORT
+unset AXIS_DEVICE_HTTPS_PORT
+
+# Special commands in alphabetical order
+device-manager help
+device-manager help completions
+# Normal commands in alphabetical order
+device-manager help init
+device-manager help reinit
+device-manager help restore

--- a/crates/device-manager/Cargo.toml
+++ b/crates/device-manager/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "device-manager"
+version = "0.1.0"
+edition.workspace = true
+license = "MIT"
+
+[dependencies]
+anyhow = { workspace = true }
+clap = { workspace = true, features = ["derive", "env"] }
+log = { workspace = true }
+semver = { workspace = true }
+tokio = { workspace = true, features = ["rt", "rt-multi-thread", "macros"] }
+url = { workspace = true }
+
+rs4a-bin-utils = { workspace = true }
+rs4a-vapix = { workspace = true }

--- a/crates/device-manager/src/commands.rs
+++ b/crates/device-manager/src/commands.rs
@@ -1,0 +1,3 @@
+pub mod init;
+pub mod reinit;
+pub mod restore;

--- a/crates/device-manager/src/commands/init.rs
+++ b/crates/device-manager/src/commands/init.rs
@@ -1,0 +1,107 @@
+use anyhow::{bail, Context};
+use log::{debug, info, warn};
+use rs4a_vapix::{
+    applications_config, basic_device_info_1, json_rpc_http::JsonRpcHttp, parameter_management,
+    pwdgrp, pwdgrp::AddUserRequest, system_ready_1,
+};
+use semver::Version;
+
+use crate::Netloc;
+
+#[derive(Clone, Debug, clap::Args)]
+pub struct InitCommand {
+    #[command(flatten)]
+    netloc: Netloc,
+}
+
+impl InitCommand {
+    pub async fn exec(self) -> anyhow::Result<()> {
+        require_root_user(&self.netloc)?;
+        initialize(&self.netloc).await
+    }
+}
+
+pub fn require_root_user(netloc: &Netloc) -> anyhow::Result<()> {
+    if netloc.user != "root" {
+        bail!(
+            "The --user must be 'root' (got '{}'); the initial user is always 'root' \
+             because older firmware requires it",
+            netloc.user
+        );
+    }
+    Ok(())
+}
+
+fn parse_firmware_version(s: &str) -> anyhow::Result<Version> {
+    let mut parts = s.splitn(4, '.');
+    let major = parts.next().unwrap_or_default().parse()?;
+    let minor = parts.next().unwrap_or_default().parse()?;
+    let patch = parts.next().unwrap_or_default().parse()?;
+    Ok(Version::new(major, minor, patch))
+}
+
+async fn apply_setup_profile(client: &rs4a_vapix::Client) -> anyhow::Result<()> {
+    let data = basic_device_info_1::get_all_unrestricted_properties()
+        .send(client)
+        .await
+        .context("Failed to query firmware version")?;
+    let version = parse_firmware_version(&data.property_list.version)
+        .context("Failed to parse firmware version")?;
+    debug!("Detected firmware version: {version}");
+
+    let allows_unsigned_toggle =
+        version >= Version::new(11, 2, 0) && version < Version::new(13, 0, 0);
+
+    if allows_unsigned_toggle {
+        info!("Allowing unsigned ACAP applications...");
+        applications_config::ApplicationConfigRequest::allow_unsigned(true)
+            .send(client, None)
+            .await?;
+    } else {
+        debug!("Skipping AllowUnsigned (not applicable for firmware {version})");
+    }
+
+    Ok(())
+}
+
+pub async fn initialize(netloc: &Netloc) -> anyhow::Result<()> {
+    info!("Initializing device...");
+
+    // Device needs setup, no authentication possible or required
+    let client = netloc.connect_anonymous().await?;
+
+    let data = system_ready_1::system_ready().send(&client).await?;
+    if !data.needsetup {
+        bail!("Expected device to be in setup mode, but needsetup is false");
+    }
+
+    info!("Adding root user...");
+    AddUserRequest::new(
+        "root",
+        &netloc.pass,
+        pwdgrp::Group::Root,
+        pwdgrp::Role::AdminOperatorViewerPtz,
+    )
+    .send(&client)
+    .await?;
+
+    // Device no longer needs setup, authentication is required
+    let client = netloc.connect().await?;
+
+    info!("Enabling SSH...");
+    parameter_management::UpdateRequest::default()
+        .network_ssh_enabled(true)
+        .send(&client)
+        .await?;
+
+    info!("Removing device from known_hosts...");
+    match crate::ssh_keygen::remove_known_host(&netloc.host.to_string()) {
+        Ok(()) => {}
+        Err(e) => warn!("Failed to remove known_hosts entry: {e:?}"),
+    }
+
+    apply_setup_profile(&client).await?;
+
+    info!("Device initialized");
+    Ok(())
+}

--- a/crates/device-manager/src/commands/reinit.rs
+++ b/crates/device-manager/src/commands/reinit.rs
@@ -1,0 +1,16 @@
+use crate::Netloc;
+
+#[derive(Clone, Debug, clap::Args)]
+pub struct ReinitCommand {
+    #[command(flatten)]
+    netloc: Netloc,
+}
+
+impl ReinitCommand {
+    pub async fn exec(self) -> anyhow::Result<()> {
+        super::init::require_root_user(&self.netloc)?;
+        super::restore::restore(&self.netloc).await?;
+        super::init::initialize(&self.netloc).await?;
+        Ok(())
+    }
+}

--- a/crates/device-manager/src/commands/restore.rs
+++ b/crates/device-manager/src/commands/restore.rs
@@ -1,0 +1,160 @@
+use std::time::Duration;
+
+use log::{debug, info, trace, warn};
+use rs4a_vapix::{
+    firmware_management_1::{FactoryDefaultMode, FactoryDefaultRequest},
+    json_rpc_http::JsonRpcHttp,
+    system_ready_1,
+    system_ready_1::SystemreadyData,
+};
+use tokio::time::{sleep, timeout};
+
+use crate::Netloc;
+
+#[derive(Clone, Debug, clap::Args)]
+pub struct RestoreCommand {
+    #[command(flatten)]
+    netloc: Netloc,
+}
+
+impl RestoreCommand {
+    pub async fn exec(self) -> anyhow::Result<()> {
+        restore(&self.netloc).await
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+enum DetectorState {
+    WaitingToGoDown,
+    WaitingToComeBack,
+    WaitingToBeReady,
+    Ready,
+}
+
+struct RestartDetector<'a> {
+    client: &'a rs4a_vapix::Client,
+    boot_id: Option<String>,
+    uptime: Option<Duration>,
+}
+
+impl<'a> RestartDetector<'a> {
+    async fn try_new(client: &'a rs4a_vapix::Client) -> anyhow::Result<Self> {
+        let data = system_ready_1::system_ready().send(client).await?;
+        let boot_id = data.bootid.clone();
+        let uptime = data.try_uptime()?;
+        Ok(Self {
+            client,
+            boot_id,
+            uptime,
+        })
+    }
+
+    fn boot_id_has_changed(&self, data: &SystemreadyData) -> bool {
+        matches!(
+            (self.boot_id.as_deref(), data.bootid.as_deref()),
+            (Some(old), Some(new)) if old != new
+        )
+    }
+
+    fn uptime_has_decreased(&self, data: &SystemreadyData) -> bool {
+        matches!(
+            (self.uptime, data.try_uptime()),
+            (Some(old), Ok(Some(new))) if new < old
+        )
+    }
+
+    fn next_state(&self, prev: DetectorState, data: Option<SystemreadyData>) -> DetectorState {
+        use DetectorState::*;
+
+        match (prev, data) {
+            (WaitingToGoDown, None) => {
+                debug!("Device went down, waiting for it to come back up");
+                WaitingToComeBack
+            }
+            (WaitingToGoDown, Some(data)) => {
+                if self.boot_id_has_changed(&data) {
+                    debug!("Boot ID changed, device has restarted");
+                    match data.systemready {
+                        false => WaitingToBeReady,
+                        true => Ready,
+                    }
+                } else if self.uptime_has_decreased(&data) {
+                    debug!("Uptime decreased, device has restarted");
+                    match data.systemready {
+                        false => WaitingToBeReady,
+                        true => Ready,
+                    }
+                } else {
+                    trace!("Still up, waiting for it to go down");
+                    WaitingToGoDown
+                }
+            }
+            (WaitingToComeBack, None) => {
+                trace!("Device still down, waiting for it to come back up");
+                WaitingToComeBack
+            }
+            (WaitingToComeBack, Some(data)) => {
+                debug!("Device came back up, waiting for it to become ready");
+                match data.systemready {
+                    false => WaitingToBeReady,
+                    true => Ready,
+                }
+            }
+            (WaitingToBeReady, Some(data)) => {
+                trace!("Already waiting to become ready");
+                match data.systemready {
+                    false => WaitingToBeReady,
+                    true => Ready,
+                }
+            }
+            (WaitingToBeReady, None) => {
+                warn!("Waiting to become ready, but device is down");
+                WaitingToBeReady
+            }
+            (Ready, _) => {
+                unreachable!("Device is already ready");
+            }
+        }
+    }
+
+    async fn wait(self) {
+        let mut state = DetectorState::WaitingToGoDown;
+
+        while !matches!(state, DetectorState::Ready) {
+            sleep(Duration::from_secs(1)).await;
+
+            let data = system_ready_1::system_ready()
+                .send(self.client)
+                .await
+                .inspect_err(|e| debug!("converting error to option: {e}"))
+                .ok();
+
+            state = self.next_state(state, data);
+        }
+    }
+}
+
+pub async fn restore(netloc: &Netloc) -> anyhow::Result<()> {
+    info!("Restoring to factory defaults");
+    let client = netloc.connect().await?;
+
+    debug!("Querying device state");
+    let data = system_ready_1::system_ready().send(&client).await?;
+    if data.needsetup {
+        info!("Already in setup mode, nothing to do");
+        return Ok(());
+    }
+
+    let restart_detector = RestartDetector::try_new(&client).await?;
+
+    info!("Sending factory default request");
+    FactoryDefaultRequest::new(FactoryDefaultMode::Soft)
+        .send(&client)
+        .await?;
+
+    info!("Waiting for restart");
+    let () = timeout(Duration::from_secs(120), restart_detector.wait()).await?;
+
+    info!("Factory default complete");
+    Ok(())
+}

--- a/crates/device-manager/src/main.rs
+++ b/crates/device-manager/src/main.rs
@@ -1,0 +1,90 @@
+#![forbid(unsafe_code)]
+
+mod commands;
+mod ssh_keygen;
+
+use clap::{Parser, Subcommand};
+use rs4a_bin_utils::completions_command::CompletionsCommand;
+use url::Host;
+
+use crate::commands::{init::InitCommand, reinit::ReinitCommand, restore::RestoreCommand};
+
+#[derive(Clone, Debug, clap::Args)]
+pub struct Netloc {
+    /// Hostname or IP address of the device.
+    #[arg(long, value_parser = url::Host::parse, env = "AXIS_DEVICE_IP")]
+    pub host: Host,
+    /// Override the default port for HTTP.
+    #[arg(long, env = "AXIS_DEVICE_HTTP_PORT")]
+    pub http_port: Option<u16>,
+    /// Override the default port for HTTPS.
+    #[arg(long, env = "AXIS_DEVICE_HTTPS_PORT")]
+    pub https_port: Option<u16>,
+    /// The username to use for authentication.
+    #[arg(short, long, env = "AXIS_DEVICE_USER", default_value = "root")]
+    pub user: String,
+    /// The password to use for authentication.
+    #[arg(short, long, env = "AXIS_DEVICE_PASS", default_value = "pass")]
+    pub pass: String,
+}
+
+impl Netloc {
+    pub async fn connect(&self) -> anyhow::Result<rs4a_vapix::Client> {
+        rs4a_vapix::ClientBuilder::new(self.host.clone())
+            .plain_port(self.http_port)
+            .secure_port(self.https_port)
+            .basic_authentication(&self.user, &self.pass)
+            .with_inner(|b| b.danger_accept_invalid_certs(true))
+            .build_with_automatic_scheme()
+            .await
+    }
+
+    pub async fn connect_anonymous(&self) -> anyhow::Result<rs4a_vapix::Client> {
+        rs4a_vapix::ClientBuilder::new(self.host.clone())
+            .plain_port(self.http_port)
+            .secure_port(self.https_port)
+            .with_inner(|b| b.danger_accept_invalid_certs(true))
+            .build_with_automatic_scheme()
+            .await
+    }
+}
+
+#[derive(Parser)]
+struct Cli {
+    #[command(subcommand)]
+    command: Commands,
+}
+
+impl Cli {
+    pub async fn exec(self) -> anyhow::Result<()> {
+        match self.command {
+            Commands::Restore(cmd) => cmd.exec().await?,
+            Commands::Init(cmd) => cmd.exec().await?,
+            Commands::Reinit(cmd) => cmd.exec().await?,
+            Commands::Completions(cmd) => cmd.exec::<Self>()?,
+        }
+        Ok(())
+    }
+}
+
+#[derive(Subcommand)]
+enum Commands {
+    /// Restore the device to a clean state (factory default)
+    Restore(RestoreCommand),
+    /// Initialize a device in setup mode
+    Init(InitCommand),
+    /// Restore and initialize the device to a known, useful state
+    Reinit(ReinitCommand),
+    /// Generate shell completions
+    ///
+    /// Example: `device-manager completions zsh | source /dev/stdin`
+    Completions(CompletionsCommand),
+}
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let mut guard = rs4a_bin_utils::logger::init();
+    Cli::parse().exec().await?;
+    guard.disarm();
+    Ok(())
+}

--- a/crates/device-manager/src/ssh_keygen.rs
+++ b/crates/device-manager/src/ssh_keygen.rs
@@ -1,0 +1,26 @@
+//! Rust API for the `ssh-keygen` program.
+
+use anyhow::bail;
+use log::debug;
+
+/// Remove a host from the known_hosts file.
+pub fn remove_known_host(host: &str) -> anyhow::Result<()> {
+    let output = std::process::Command::new("ssh-keygen")
+        .arg("-R")
+        .arg(host)
+        .output()?;
+
+    debug!(
+        "Discarding stdout: {}",
+        String::from_utf8_lossy(&output.stdout)
+    );
+
+    if !output.status.success() {
+        bail!(
+            "ssh-keygen -R failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    Ok(())
+}

--- a/crates/vapix/src/apis.rs
+++ b/crates/vapix/src/apis.rs
@@ -1,3 +1,7 @@
+pub mod applications_config {
+    pub use crate::applications_config::ApplicationConfigRequest;
+}
+
 pub mod action_1 {
     pub use crate::action1::{
         add_action_configuration, add_action_rule, get_action_configurations, get_action_rules,
@@ -43,4 +47,16 @@ pub mod ssh_1 {
 
 pub mod system_ready_1 {
     pub use crate::system_ready_1::system_ready;
+}
+
+pub mod firmware_management_1 {
+    pub use crate::firmware_management_1::FactoryDefaultRequest;
+}
+
+pub mod parameter_management {
+    pub use crate::parameter_management::UpdateRequest;
+}
+
+pub mod pwdgrp {
+    pub use crate::pwdgrp::AddUserRequest;
 }

--- a/crates/vapix/src/axis_cgi.rs
+++ b/crates/vapix/src/axis_cgi.rs
@@ -1,5 +1,8 @@
 //! A collection of APIs that can be found under the `/axis-cgi/` path.
+pub mod applications_config;
 pub mod basic_device_info_1;
-
+pub mod firmware_management_1;
 pub mod jpg_3;
+pub mod parameter_management;
+pub mod pwdgrp;
 pub mod system_ready_1;

--- a/crates/vapix/src/axis_cgi/applications_config.rs
+++ b/crates/vapix/src/axis_cgi/applications_config.rs
@@ -1,0 +1,82 @@
+//! The [Configure Applications] API.
+//!
+//! [Configure Applications]: https://developer.axis.com/vapix/applications/application-api/#configure-applications
+
+use reqwest::{Method, StatusCode};
+
+use crate::{
+    cassette::{Cassette, Request},
+    http::Error,
+    Client,
+};
+
+const PATH: &str = "axis-cgi/applications/config.cgi";
+
+fn bool2string(b: bool) -> &'static str {
+    match b {
+        true => "true",
+        false => "false",
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct ApplicationConfigRequest {
+    name: &'static str,
+    value: Option<&'static str>,
+}
+
+impl ApplicationConfigRequest {
+    /// Available in AXIS OS 11.5 - 11.11
+    ///
+    /// Default:
+    /// - `true` until AXIS OS 11.7
+    /// - `false` since AXIS OS 11.8
+    pub fn allow_root(allow: bool) -> Self {
+        Self {
+            name: "AllowRoot",
+            value: Some(bool2string(allow)),
+        }
+    }
+
+    /// Available since AXIS OS 11.2
+    ///
+    /// Default:
+    /// - `true` until AXIS OS 11.11
+    /// - `false` since AXIS OS 12.0
+    pub fn allow_unsigned(allow: bool) -> Self {
+        Self {
+            name: "AllowUnsigned",
+            value: Some(bool2string(allow)),
+        }
+    }
+
+    fn into_request(self) -> Request {
+        let Self { name, value } = self;
+        let path = match value {
+            None => format!("{PATH}?action=set&name={name}"),
+            Some(value) => format!("{PATH}?action=set&name={name}&value={value}"),
+        };
+        Request::no_content(Method::GET, path)
+    }
+
+    // TODO: Implement lossless self-checks
+    // Get requests return XML that needs parsing
+    // TODO: Add support for get requests
+    pub async fn send(
+        self,
+        client: &Client,
+        cassette: Option<&mut Cassette>,
+    ) -> Result<(), Error<std::convert::Infallible>> {
+        let response = self.into_request().send(client, cassette).await?;
+        let body = response.body.map_err(|e| Error::Transport(e.into()))?;
+        if response.status == StatusCode::OK && body.trim().starts_with(r#"<reply result="ok">"#) {
+            Ok(())
+        } else {
+            Err(Error::Decode(anyhow::anyhow!(
+                "Unexpected response: {} {}",
+                response.status,
+                body.trim()
+            )))
+        }
+    }
+}

--- a/crates/vapix/src/axis_cgi/firmware_management_1.rs
+++ b/crates/vapix/src/axis_cgi/firmware_management_1.rs
@@ -1,0 +1,53 @@
+//! The [Firmware Management API].
+//!
+//! [Firmware Management API]: https://developer.axis.com/vapix/network-video/firmware-management-api/
+
+use serde::{Deserialize, Serialize};
+
+use crate::json_rpc_http::{JsonRpcHttp, JsonRpcHttpLossless};
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub enum FactoryDefaultMode {
+    None,
+    Soft,
+    Hard,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct FactoryDefaultParams {
+    factory_default_mode: FactoryDefaultMode,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct FactoryDefaultData {}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FactoryDefaultRequest {
+    api_version: &'static str,
+    method: &'static str,
+    params: FactoryDefaultParams,
+}
+
+impl FactoryDefaultRequest {
+    pub fn new(mode: FactoryDefaultMode) -> Self {
+        Self {
+            api_version: "1.0",
+            method: "factoryDefault",
+            params: FactoryDefaultParams {
+                factory_default_mode: mode,
+            },
+        }
+    }
+}
+
+impl JsonRpcHttp for FactoryDefaultRequest {
+    type Data = FactoryDefaultData;
+    const PATH: &'static str = "axis-cgi/firmwaremanagement.cgi";
+}
+
+impl JsonRpcHttpLossless for FactoryDefaultRequest {
+    type Data = FactoryDefaultData;
+}

--- a/crates/vapix/src/axis_cgi/parameter_management.rs
+++ b/crates/vapix/src/axis_cgi/parameter_management.rs
@@ -1,0 +1,55 @@
+//! The [Parameter Management] API.
+//!
+//! [Parameter Management]: https://developer.axis.com/vapix/network-video/parameter-management/
+
+use std::{collections::HashMap, fmt::Debug};
+
+use anyhow::{bail, Context};
+use reqwest::StatusCode;
+
+use crate::Client;
+
+const PATH: &str = "axis-cgi/param.cgi";
+
+fn bool2str(b: bool) -> &'static str {
+    match b {
+        true => "yes",
+        false => "no",
+    }
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct UpdateRequest {
+    parameters: HashMap<String, String>,
+}
+
+impl UpdateRequest {
+    pub fn network_ssh_enabled(mut self, value: bool) -> Self {
+        self.parameters.insert(
+            "root.Network.SSH.Enabled".to_string(),
+            bool2str(value).to_string(),
+        );
+        self
+    }
+
+    pub async fn send(self, client: &Client) -> anyhow::Result<()> {
+        let mut query: Vec<(&str, &str)> = vec![("action", "update")];
+        for (k, v) in &self.parameters {
+            query.push((k, v));
+        }
+        let response = client.get(PATH)?.query(&query).send().await?;
+        let status = response.status();
+        let text = response
+            .text()
+            .await
+            .with_context(|| format!("status code: {status}"))?;
+
+        if status == StatusCode::OK && text.trim() == "OK" {
+            Ok(())
+        } else if let Some(e) = text.trim().strip_prefix("# Error: ") {
+            bail!("{e}")
+        } else {
+            bail!("Unexpected response: {status} {text}")
+        }
+    }
+}

--- a/crates/vapix/src/axis_cgi/pwdgrp.rs
+++ b/crates/vapix/src/axis_cgi/pwdgrp.rs
@@ -1,0 +1,123 @@
+//! The [User Management] CGI.
+//!
+//! [User Management]: https://developer.axis.com/vapix/network-video/user-management/
+
+use std::fmt::{Display, Formatter};
+
+use reqwest::{Method, StatusCode};
+
+use crate::{cassette::Request, http::Error, Client};
+
+const PATH: &str = "axis-cgi/pwdgrp.cgi";
+
+fn extract_body(html: &str) -> Option<&str> {
+    let body_start = html.find("<body")?;
+    let content_start = html[body_start..].find('>')? + body_start + 1;
+    let content_end = html[content_start..].find("</body>")? + content_start;
+    Some(&html[content_start..content_end])
+}
+
+#[derive(Clone, Copy, Debug)]
+pub enum Role {
+    Viewer,
+    OperatorViewer,
+    AdminOperatorViewerPtz,
+}
+
+impl Display for Role {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Role::Viewer => write!(f, "viewer"),
+            Role::OperatorViewer => write!(f, "operator:viewer"),
+            Role::AdminOperatorViewerPtz => write!(f, "admin:operator:viewer:ptz"),
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+pub enum Group {
+    Root,
+    Users,
+}
+
+impl Display for Group {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Group::Root => write!(f, "root"),
+            Group::Users => write!(f, "users"),
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct AddUserRequest {
+    username: String,
+    password: String,
+    group: Group,
+    role: Role,
+}
+
+impl AddUserRequest {
+    pub fn new(username: &str, password: &str, group: Group, role: Role) -> Self {
+        Self {
+            username: username.to_string(),
+            password: password.to_string(),
+            group,
+            role,
+        }
+    }
+
+    fn into_request(self) -> Request {
+        let group = self.group.to_string();
+        let role = self.role.to_string();
+        Request::no_content(
+            Method::GET,
+            format!(
+                "{PATH}?action=add&user={}&pwd={}&grp={}&sgrp={}",
+                self.username, self.password, group, role
+            ),
+        )
+    }
+
+    pub async fn send(self, client: &Client) -> Result<(), Error<std::convert::Infallible>> {
+        let expected = format!("Created account {}.", self.username);
+        let response = self.into_request().send(client, None).await?;
+        let body = response.body.map_err(|e| Error::Transport(e.into()))?;
+        if response.status == StatusCode::OK {
+            let html_body = extract_body(&body).unwrap_or("");
+            if html_body.trim() == expected {
+                return Ok(());
+            }
+        }
+        Err(Error::Decode(anyhow::anyhow!(
+            "Unexpected response: {} {}",
+            response.status,
+            body.trim()
+        )))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::extract_body;
+
+    #[test]
+    fn extract_body_simple() {
+        assert_eq!(
+            extract_body("<html><body>Created account root.</body></html>")
+                .unwrap()
+                .trim(),
+            "Created account root."
+        );
+    }
+
+    #[test]
+    fn extract_body_with_attributes() {
+        assert_eq!(
+            extract_body("<html><body class=\"foo\">Created account root.</body></html>")
+                .unwrap()
+                .trim(),
+            "Created account root."
+        );
+    }
+}

--- a/crates/vapix/src/axis_cgi/system_ready_1.rs
+++ b/crates/vapix/src/axis_cgi/system_ready_1.rs
@@ -2,6 +2,8 @@
 //!
 //! [Systemready API]: https://developer.axis.com/vapix/network-video/systemready-api/
 
+use std::time::Duration;
+
 use serde::{Deserialize, Serialize};
 
 use crate::json_rpc_http::{JsonRpcHttp, JsonRpcHttpLossless};
@@ -28,7 +30,6 @@ where
     }
 }
 
-// TODO: Consider parsing `uptime` as an unsigned integer
 // TODO: Consider parsing `bootid` as a UUID
 #[non_exhaustive]
 #[derive(Debug, Deserialize, Serialize)]
@@ -51,6 +52,17 @@ pub struct SystemreadyData {
     /// New in 1.5
     #[serde(skip_serializing_if = "Option::is_none")]
     pub passphrasepolicy: Option<String>,
+}
+
+impl SystemreadyData {
+    // TODO: Consider parsing `uptime` eagerly
+    /// Parse the uptime field as a duration in seconds.
+    pub fn try_uptime(&self) -> Result<Option<Duration>, std::num::ParseIntError> {
+        self.uptime
+            .as_deref()
+            .map(|s| s.parse::<u64>().map(Duration::from_secs))
+            .transpose()
+    }
 }
 
 #[derive(Debug, Deserialize, Serialize)]

--- a/crates/vapix/src/lib.rs
+++ b/crates/vapix/src/lib.rs
@@ -13,7 +13,10 @@ mod services;
 pub mod soap;
 pub mod soap_http;
 
-pub use axis_cgi::{basic_device_info_1, system_ready_1};
+pub use axis_cgi::{
+    applications_config, basic_device_info_1, firmware_management_1, parameter_management, pwdgrp,
+    system_ready_1,
+};
 pub use client::{Client, ClientBuilder, Scheme};
 pub use config::{
     recording_group_1, remote_object_storage_1, remote_object_storage_1_beta,

--- a/snapshots/device-manager-docs
+++ b/snapshots/device-manager-docs
@@ -1,0 +1,68 @@
++ unset RUST_LOG
++ unset AXIS_DEVICE_IP
++ unset AXIS_DEVICE_PASS
++ unset AXIS_DEVICE_USER
++ unset AXIS_DEVICE_HTTP_PORT
++ unset AXIS_DEVICE_HTTPS_PORT
++ device-manager help
+Usage: device-manager <COMMAND>
+
+Commands:
+  restore      Restore the device to a clean state (factory default)
+  init         Initialize a device in setup mode
+  reinit       Restore and initialize the device to a known, useful state
+  completions  Generate shell completions
+  help         Print this message or the help of the given subcommand(s)
+
+Options:
+  -h, --help  Print help
++ device-manager help completions
+Generate shell completions
+
+Example: `device-manager completions zsh | source /dev/stdin`
+
+Usage: device-manager completions <SHELL>
+
+Arguments:
+  <SHELL>
+          [possible values: bash, elvish, fish, powershell, zsh]
+
+Options:
+  -h, --help
+          Print help (see a summary with '-h')
++ device-manager help init
+Initialize a device in setup mode
+
+Usage: device-manager init [OPTIONS] --host <HOST>
+
+Options:
+      --host <HOST>              Hostname or IP address of the device [env: AXIS_DEVICE_IP=]
+      --http-port <HTTP_PORT>    Override the default port for HTTP [env: AXIS_DEVICE_HTTP_PORT=]
+      --https-port <HTTPS_PORT>  Override the default port for HTTPS [env: AXIS_DEVICE_HTTPS_PORT=]
+  -u, --user <USER>              The username to use for authentication [env: AXIS_DEVICE_USER=] [default: root]
+  -p, --pass <PASS>              The password to use for authentication [env: AXIS_DEVICE_PASS=] [default: pass]
+  -h, --help                     Print help
++ device-manager help reinit
+Restore and initialize the device to a known, useful state
+
+Usage: device-manager reinit [OPTIONS] --host <HOST>
+
+Options:
+      --host <HOST>              Hostname or IP address of the device [env: AXIS_DEVICE_IP=]
+      --http-port <HTTP_PORT>    Override the default port for HTTP [env: AXIS_DEVICE_HTTP_PORT=]
+      --https-port <HTTPS_PORT>  Override the default port for HTTPS [env: AXIS_DEVICE_HTTPS_PORT=]
+  -u, --user <USER>              The username to use for authentication [env: AXIS_DEVICE_USER=] [default: root]
+  -p, --pass <PASS>              The password to use for authentication [env: AXIS_DEVICE_PASS=] [default: pass]
+  -h, --help                     Print help
++ device-manager help restore
+Restore the device to a clean state (factory default)
+
+Usage: device-manager restore [OPTIONS] --host <HOST>
+
+Options:
+      --host <HOST>              Hostname or IP address of the device [env: AXIS_DEVICE_IP=]
+      --http-port <HTTP_PORT>    Override the default port for HTTP [env: AXIS_DEVICE_HTTP_PORT=]
+      --https-port <HTTPS_PORT>  Override the default port for HTTPS [env: AXIS_DEVICE_HTTPS_PORT=]
+  -u, --user <USER>              The username to use for authentication [env: AXIS_DEVICE_USER=] [default: root]
+  -p, --pass <PASS>              The password to use for authentication [env: AXIS_DEVICE_PASS=] [default: pass]
+  -h, --help                     Print help


### PR DESCRIPTION
`crates/vapix/src/axis_cgi/system_ready_1.rs`:
- Add method parsing uptime to document how the value should be interpreted and to make parsing it more concise in application code. Stop short of parsing it eagerly because it would be more work and I'm not sure how I want to do this in general. In particular I'm not sure how aggressive such parsing should be in cases where it is feasible, or even likely, that other values will be encountered in the future.
- Stop short of adding a parser for the boot ID because that would require adding a new dependency.

`README.md`:
- Add some `firmware-inventory` related documentation that was missing because I cannot be bothered making a separate commit for those two lines.