### PR TITLE
feat(vapix): Add product type enum to basic device info

### DIFF
--- a/crates/vapix/src/axis_cgi/basic_device_info_1.rs
+++ b/crates/vapix/src/axis_cgi/basic_device_info_1.rs
@@ -7,7 +7,7 @@ use std::{
     str::FromStr,
 };
 
-use anyhow::bail;
+use anyhow::{anyhow, bail, Context};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 use crate::json_rpc_http::{JsonRpcHttp, JsonRpcHttpLossless};
@@ -35,6 +35,46 @@ where
         Ok(None)
     } else {
         T::from_str(&s).map(Some).map_err(serde::de::Error::custom)
+    }
+}
+
+#[non_exhaustive]
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub enum ProductType {
+    BoxCamera,
+    DomeCamera,
+    NetworkCamera,
+    NetworkStrobeSpeaker,
+    PeopleCounter3D,
+    Radar,
+}
+
+impl Display for ProductType {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::BoxCamera => write!(f, "Box Camera"),
+            Self::DomeCamera => write!(f, "Dome Camera"),
+            Self::NetworkCamera => write!(f, "Network Camera"),
+            Self::NetworkStrobeSpeaker => write!(f, "Network Strobe Speaker"),
+            Self::PeopleCounter3D => write!(f, "3D People Counter"),
+            Self::Radar => write!(f, "Radar"),
+        }
+    }
+}
+
+impl FromStr for ProductType {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "Box Camera" => Ok(Self::BoxCamera),
+            "Dome Camera" => Ok(Self::DomeCamera),
+            "Network Camera" => Ok(Self::NetworkCamera),
+            "Network Strobe Speaker" => Ok(Self::NetworkStrobeSpeaker),
+            "3D People Counter" => Ok(Self::PeopleCounter3D),
+            "Radar" => Ok(Self::Radar),
+            _ => Err(anyhow!("unrecognized product type '{s}'")),
+        }
     }
 }
 
@@ -67,6 +107,12 @@ pub struct UnrestrictedProperties {
     pub version: String,
     #[serde(rename = "WebURL")]
     pub web_url: String,
+}
+
+impl UnrestrictedProperties {
+    pub fn parse_product_type(&self) -> anyhow::Result<ProductType> {
+        self.prod_type.parse().context("invalid product type")
+    }
 }
 
 #[derive(Debug, Deserialize, Serialize)]

--- a/crates/vapix/tests/cassette_tests.rs
+++ b/crates/vapix/tests/cassette_tests.rs
@@ -14,7 +14,7 @@ use regex::Regex;
 use rs4a_vapix::{
     apis,
     apis::basic_device_info_1,
-    basic_device_info_1::UnrestrictedProperties,
+    basic_device_info_1::{ProductType, UnrestrictedProperties},
     cassette::{Cassette, Mode},
     http,
     json_rpc_http::{JsonRpcHttp, JsonRpcHttpLossless},
@@ -644,10 +644,13 @@ async fn basic_device_info_get_all_unrestricted_properties(
     _: Option<Prelude>,
 ) {
     let mut cassette = Some(cassette);
-    basic_device_info_1::get_all_unrestricted_properties()
+    let property_list = basic_device_info_1::get_all_unrestricted_properties()
         .send_lossless(&client, cassette.as_mut())
         .await
-        .unwrap();
+        .unwrap()
+        .property_list;
+
+    property_list.parse_product_type().unwrap();
 }
 
 async fn device_configuration_item_does_not_exist(
@@ -774,8 +777,14 @@ async fn parameter_management_list_error(
     prelude: Option<Prelude>,
 ) {
     if let Some(prelude) = prelude {
-        if prelude.props.prod_type.as_str() == "Box Camera" {
-            return;
+        match prelude.props.parse_product_type().unwrap() {
+            ProductType::BoxCamera => return,
+            ProductType::DomeCamera => return,
+            ProductType::NetworkCamera => return,
+            ProductType::NetworkStrobeSpeaker => {}
+            ProductType::Radar => return,
+            ProductType::PeopleCounter3D => return,
+            _ => {}
         }
     }
 
@@ -795,7 +804,10 @@ async fn parameter_management_list_image_resolution(
     prelude: Option<Prelude>,
 ) {
     if let Some(prelude) = prelude {
-        if prelude.props.prod_type.as_str() == "Network Strobe Speaker" {
+        if matches!(
+            prelude.props.parse_product_type().unwrap(),
+            ProductType::NetworkStrobeSpeaker
+        ) {
             return;
         }
     }


### PR DESCRIPTION
This serves two purposes:
- Document known potential values
- Make it easier to handle known values

The variants added are the ones that are already documented in cassettes and a few more that come to mind; there are probably many others still and these will be added as the cassette coverage grows.

---

`crates/vapix/src/axis_cgi/basic_device_info_1.rs`:
- Mark as non-exhaustive for consistency with existing enums in the module.

`crates/vapix/tests/cassette_tests.rs`:
- Change when `parameter_management_list_error` runs because we expect all cameras to have this property, we just don't have cassettes for any other cameras. This is an example of why documenting the possible variants is helpful.
