### PR TITLE
feat(vapix): Add `parse_version` to unrestricted properties

### DIFF
--- a/crates/vapix/Cargo.toml
+++ b/crates/vapix/Cargo.toml
@@ -14,6 +14,7 @@ serde = { workspace = true, features = ["derive"] }
 base64 = { workspace = true }
 quick-xml = { workspace = true, features = ["serialize"] }
 rs4a-dut = { workspace = true }
+semver = { workspace = true }
 serde_json = { workspace = true, features = ["raw_value"] }
 thiserror = { workspace = true }
 tokio = { workspace = true }
@@ -24,7 +25,6 @@ env_logger = { workspace = true }
 expect-test = { workspace = true }
 libtest-mimic = { workspace = true }
 regex = { workspace = true }
-semver = { workspace = true }
 tokio = { workspace = true, features = ["macros"] }
 
 [features]

--- a/crates/vapix/src/axis_cgi/basic_device_info_1.rs
+++ b/crates/vapix/src/axis_cgi/basic_device_info_1.rs
@@ -8,6 +8,7 @@ use std::{
 };
 
 use anyhow::{anyhow, bail, Context};
+use semver::Version;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 use crate::json_rpc_http::{JsonRpcHttp, JsonRpcHttpLossless};
@@ -112,6 +113,12 @@ pub struct UnrestrictedProperties {
 impl UnrestrictedProperties {
     pub fn parse_product_type(&self) -> anyhow::Result<ProductType> {
         self.prod_type.parse().context("invalid product type")
+    }
+
+    // AXIS OS versions less than 10 do not always follow semver.
+    // TODO: Parse firmware versions <10
+    pub fn parse_version(&self) -> anyhow::Result<Version> {
+        Version::parse(self.version.as_str()).context("invalid version")
     }
 }
 

--- a/crates/vapix/tests/cassette_tests.rs
+++ b/crates/vapix/tests/cassette_tests.rs
@@ -30,7 +30,7 @@ use rs4a_vapix::{
     },
     Client, ClientBuilder, Scheme,
 };
-use semver::{Version, VersionReq};
+use semver::VersionReq;
 use serde::{Deserialize, Serialize};
 use url::{Host, Url};
 // When a test fails, it may leave resources intact that will cause future runs to fail.
@@ -76,7 +76,7 @@ impl Prelude {
 
 impl Prelude {
     fn version_matches(&self, req: &str) -> bool {
-        let v = Version::parse(self.props.version.as_str()).unwrap();
+        let v = self.props.parse_version().unwrap();
         let req = VersionReq::parse(req).unwrap();
         req.matches(&v)
     }
@@ -602,6 +602,7 @@ async fn basic_device_info_get_all_unrestricted_properties(
         .property_list;
 
     property_list.parse_product_type().unwrap();
+    property_list.parse_version().unwrap();
 }
 
 async fn device_configuration_item_does_not_exist(


### PR DESCRIPTION
Like other `parse_*` functions this primarily serves as documentation of the range of values that may be returned. It is also ever so slightly more concise than `.version.parse::<Version>()`.