### PR TITLE
feat(fm): Add upgrade command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1809,6 +1809,7 @@ dependencies = [
  "anyhow",
  "base32",
  "base64",
+ "clap",
  "env_logger",
  "expect-test",
  "libtest-mimic",

--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ Commands:
   restore      Restore the device to a clean state (factory default)
   init         Initialize a device in setup mode
   reinit       Restore and initialize the device to a known, useful state
+  upgrade      Upgrade the device firmware
   completions  Generate shell completions
   help         Print this message or the help of the given subcommand(s)
 

--- a/bin/device-manager-docs.sh
+++ b/bin/device-manager-docs.sh
@@ -14,3 +14,4 @@ device-manager help completions
 device-manager help init
 device-manager help reinit
 device-manager help restore
+device-manager help upgrade

--- a/crates/device-manager/Cargo.toml
+++ b/crates/device-manager/Cargo.toml
@@ -9,8 +9,8 @@ anyhow = { workspace = true }
 clap = { workspace = true, features = ["derive", "env"] }
 log = { workspace = true }
 semver = { workspace = true }
-tokio = { workspace = true, features = ["rt", "rt-multi-thread", "macros"] }
+tokio = { workspace = true, features = ["rt", "rt-multi-thread", "macros", "fs"] }
 url = { workspace = true }
 
 rs4a-bin-utils = { workspace = true }
-rs4a-vapix = { workspace = true }
+rs4a-vapix = { workspace = true, features = ["clap"] }

--- a/crates/device-manager/src/commands.rs
+++ b/crates/device-manager/src/commands.rs
@@ -1,3 +1,4 @@
 pub mod init;
 pub mod reinit;
 pub mod restore;
+pub mod upgrade;

--- a/crates/device-manager/src/commands/restore.rs
+++ b/crates/device-manager/src/commands/restore.rs
@@ -1,15 +1,14 @@
 use std::time::Duration;
 
-use log::{debug, info, trace, warn};
+use log::{debug, info};
 use rs4a_vapix::{
     firmware_management_1::{FactoryDefaultMode, FactoryDefaultRequest},
     json_rpc_http::JsonRpcHttp,
     system_ready_1,
-    system_ready_1::SystemreadyData,
 };
-use tokio::time::{sleep, timeout};
+use tokio::time::timeout;
 
-use crate::Netloc;
+use crate::{restart_detector::RestartDetector, Netloc};
 
 #[derive(Clone, Debug, clap::Args)]
 pub struct RestoreCommand {
@@ -20,117 +19,6 @@ pub struct RestoreCommand {
 impl RestoreCommand {
     pub async fn exec(self) -> anyhow::Result<()> {
         restore(&self.netloc).await
-    }
-}
-
-#[derive(Clone, Copy, Debug)]
-enum DetectorState {
-    WaitingToGoDown,
-    WaitingToComeBack,
-    WaitingToBeReady,
-    Ready,
-}
-
-struct RestartDetector<'a> {
-    client: &'a rs4a_vapix::Client,
-    boot_id: Option<String>,
-    uptime: Option<Duration>,
-}
-
-impl<'a> RestartDetector<'a> {
-    async fn try_new(client: &'a rs4a_vapix::Client) -> anyhow::Result<Self> {
-        let data = system_ready_1::system_ready().send(client).await?;
-        let boot_id = data.bootid.clone();
-        let uptime = data.try_uptime()?;
-        Ok(Self {
-            client,
-            boot_id,
-            uptime,
-        })
-    }
-
-    fn boot_id_has_changed(&self, data: &SystemreadyData) -> bool {
-        matches!(
-            (self.boot_id.as_deref(), data.bootid.as_deref()),
-            (Some(old), Some(new)) if old != new
-        )
-    }
-
-    fn uptime_has_decreased(&self, data: &SystemreadyData) -> bool {
-        matches!(
-            (self.uptime, data.try_uptime()),
-            (Some(old), Ok(Some(new))) if new < old
-        )
-    }
-
-    fn next_state(&self, prev: DetectorState, data: Option<SystemreadyData>) -> DetectorState {
-        use DetectorState::*;
-
-        match (prev, data) {
-            (WaitingToGoDown, None) => {
-                debug!("Device went down, waiting for it to come back up");
-                WaitingToComeBack
-            }
-            (WaitingToGoDown, Some(data)) => {
-                if self.boot_id_has_changed(&data) {
-                    debug!("Boot ID changed, device has restarted");
-                    match data.systemready {
-                        false => WaitingToBeReady,
-                        true => Ready,
-                    }
-                } else if self.uptime_has_decreased(&data) {
-                    debug!("Uptime decreased, device has restarted");
-                    match data.systemready {
-                        false => WaitingToBeReady,
-                        true => Ready,
-                    }
-                } else {
-                    trace!("Still up, waiting for it to go down");
-                    WaitingToGoDown
-                }
-            }
-            (WaitingToComeBack, None) => {
-                trace!("Device still down, waiting for it to come back up");
-                WaitingToComeBack
-            }
-            (WaitingToComeBack, Some(data)) => {
-                debug!("Device came back up, waiting for it to become ready");
-                match data.systemready {
-                    false => WaitingToBeReady,
-                    true => Ready,
-                }
-            }
-            (WaitingToBeReady, Some(data)) => {
-                trace!("Already waiting to become ready");
-                match data.systemready {
-                    false => WaitingToBeReady,
-                    true => Ready,
-                }
-            }
-            (WaitingToBeReady, None) => {
-                warn!("Waiting to become ready, but device is down");
-                WaitingToBeReady
-            }
-            (Ready, _) => {
-                unreachable!("Device is already ready");
-            }
-        }
-    }
-
-    async fn wait(self) {
-        let mut state = DetectorState::WaitingToGoDown;
-
-        while !matches!(state, DetectorState::Ready) {
-            sleep(Duration::from_secs(1)).await;
-
-            let data = system_ready_1::system_ready()
-                .send(self.client)
-                .await
-                .inspect_err(|e| debug!("converting error to option: {e}"))
-                .ok();
-
-            state = self.next_state(state, data);
-        }
     }
 }
 

--- a/crates/device-manager/src/commands/upgrade.rs
+++ b/crates/device-manager/src/commands/upgrade.rs
@@ -1,0 +1,75 @@
+use std::{path::PathBuf, time::Duration};
+
+use anyhow::Context;
+use log::info;
+use rs4a_vapix::firmware_management_1::{
+    AutoCommit, AutoRollback, FactoryDefaultMode, UpgradeRequest,
+};
+use tokio::time::timeout;
+
+use crate::{restart_detector::RestartDetector, Netloc};
+
+fn parse_auto_rollback(s: &str) -> anyhow::Result<AutoRollback> {
+    match s {
+        "never" => Ok(AutoRollback::Never),
+        "default" => Ok(AutoRollback::Default),
+        other => {
+            let minutes: u32 = other.parse().with_context(|| {
+                format!("expected 'never', 'default', or a number of minutes, got '{other}'")
+            })?;
+            Ok(AutoRollback::Minutes(minutes))
+        }
+    }
+}
+
+#[derive(Clone, Debug, clap::Args)]
+pub struct UpgradeCommand {
+    #[command(flatten)]
+    netloc: Netloc,
+    /// Path to the firmware image
+    firmware: PathBuf,
+    /// Factory default mode to apply during upgrade
+    #[arg(long, short, default_value_t = FactoryDefaultMode::None)]
+    factory_default_mode: FactoryDefaultMode,
+    /// Auto-commit behavior after upgrade
+    #[arg(long, short='c', default_value_t = AutoCommit::Default)]
+    auto_commit: AutoCommit,
+    /// Auto-rollback behavior: "never", "default", or minutes
+    #[arg(long, short = 'r', default_value = "default")]
+    auto_rollback: String,
+}
+
+impl UpgradeCommand {
+    pub async fn exec(self) -> anyhow::Result<()> {
+        let auto_rollback = parse_auto_rollback(&self.auto_rollback)?;
+
+        info!("Reading firmware from {:?}", self.firmware);
+        let firmware = tokio::fs::read(&self.firmware)
+            .await
+            .with_context(|| format!("Could not read firmware file {:?}", self.firmware))?;
+
+        info!("Connecting to device");
+        let client = self.netloc.connect().await?;
+
+        let restart_detector = RestartDetector::try_new(&client).await?;
+
+        info!("Sending upgrade request");
+        let data = UpgradeRequest::new(firmware)
+            .factory_default_mode(self.factory_default_mode)
+            .auto_commit(self.auto_commit)
+            .auto_rollback(auto_rollback)
+            .send(&client, None)
+            .await?;
+
+        info!(
+            "Upgrade accepted, firmware version: {}",
+            data.firmware_version
+        );
+
+        info!("Waiting for restart");
+        let () = timeout(Duration::from_secs(300), restart_detector.wait()).await?;
+
+        info!("Upgrade complete");
+        Ok(())
+    }
+}

--- a/crates/device-manager/src/main.rs
+++ b/crates/device-manager/src/main.rs
@@ -1,13 +1,16 @@
 #![forbid(unsafe_code)]
 
 mod commands;
+mod restart_detector;
 mod ssh_keygen;
 
 use clap::{Parser, Subcommand};
 use rs4a_bin_utils::completions_command::CompletionsCommand;
 use url::Host;
 
-use crate::commands::{init::InitCommand, reinit::ReinitCommand, restore::RestoreCommand};
+use crate::commands::{
+    init::InitCommand, reinit::ReinitCommand, restore::RestoreCommand, upgrade::UpgradeCommand,
+};
 
 #[derive(Clone, Debug, clap::Args)]
 pub struct Netloc {
@@ -61,6 +64,7 @@ impl Cli {
             Commands::Restore(cmd) => cmd.exec().await?,
             Commands::Init(cmd) => cmd.exec().await?,
             Commands::Reinit(cmd) => cmd.exec().await?,
+            Commands::Upgrade(cmd) => cmd.exec().await?,
             Commands::Completions(cmd) => cmd.exec::<Self>()?,
         }
         Ok(())
@@ -75,6 +79,8 @@ enum Commands {
     Init(InitCommand),
     /// Restore and initialize the device to a known, useful state
     Reinit(ReinitCommand),
+    /// Upgrade the device firmware
+    Upgrade(UpgradeCommand),
     /// Generate shell completions
     ///
     /// Example: `device-manager completions zsh | source /dev/stdin`

--- a/crates/device-manager/src/restart_detector.rs
+++ b/crates/device-manager/src/restart_detector.rs
@@ -1,0 +1,122 @@
+use std::time::Duration;
+
+use log::{debug, trace, warn};
+use rs4a_vapix::{json_rpc_http::JsonRpcHttp, system_ready_1, system_ready_1::SystemreadyData};
+use tokio::time::sleep;
+
+#[derive(Clone, Copy, Debug)]
+enum DetectorState {
+    WaitingToGoDown,
+    WaitingToComeBack,
+    WaitingToBeReady,
+    Ready,
+}
+
+pub(crate) struct RestartDetector<'a> {
+    client: &'a rs4a_vapix::Client,
+    boot_id: Option<String>,
+    uptime: Option<Duration>,
+}
+
+impl<'a> RestartDetector<'a> {
+    pub(crate) async fn try_new(client: &'a rs4a_vapix::Client) -> anyhow::Result<Self> {
+        let data = system_ready_1::system_ready().send(client).await?;
+        let boot_id = data.bootid.clone();
+        let uptime = data.try_uptime()?;
+        Ok(Self {
+            client,
+            boot_id,
+            uptime,
+        })
+    }
+
+    fn boot_id_has_changed(&self, data: &SystemreadyData) -> bool {
+        matches!(
+            (self.boot_id.as_deref(), data.bootid.as_deref()),
+            (Some(old), Some(new)) if old != new
+        )
+    }
+
+    fn uptime_has_decreased(&self, data: &SystemreadyData) -> bool {
+        matches!(
+            (self.uptime, data.try_uptime()),
+            (Some(old), Ok(Some(new))) if new < old
+        )
+    }
+
+    fn next_state(&self, prev: DetectorState, data: Option<SystemreadyData>) -> DetectorState {
+        use DetectorState::*;
+
+        match (prev, data) {
+            (WaitingToGoDown, None) => {
+                debug!("Device went down, waiting for it to come back up");
+                WaitingToComeBack
+            }
+            (WaitingToGoDown, Some(data)) => {
+                if self.boot_id_has_changed(&data) {
+                    debug!("Boot ID changed, device has restarted");
+                    match data.systemready {
+                        false => WaitingToBeReady,
+                        true => Ready,
+                    }
+                } else if self.uptime_has_decreased(&data) {
+                    debug!("Uptime decreased, device has restarted");
+                    match data.systemready {
+                        false => WaitingToBeReady,
+                        true => Ready,
+                    }
+                } else {
+                    trace!("Still up, waiting for it to go down");
+                    WaitingToGoDown
+                }
+            }
+            (WaitingToComeBack, None) => {
+                trace!("Device still down, waiting for it to come back up");
+                WaitingToComeBack
+            }
+            (WaitingToComeBack, Some(data)) => {
+                debug!("Device came back up, waiting for it to become ready");
+                match data.systemready {
+                    false => WaitingToBeReady,
+                    true => Ready,
+                }
+            }
+            (WaitingToBeReady, Some(data)) => {
+                trace!("Already waiting to become ready");
+                match data.systemready {
+                    false => WaitingToBeReady,
+                    true => Ready,
+                }
+            }
+            (WaitingToBeReady, None) => {
+                warn!("Waiting to become ready, but device is down");
+                WaitingToBeReady
+            }
+            (Ready, _) => {
+                unreachable!("Device is already ready");
+            }
+        }
+    }
+
+    pub(crate) async fn wait(self) {
+        let mut state = DetectorState::WaitingToGoDown;
+
+        while !matches!(state, DetectorState::Ready) {
+            sleep(Duration::from_secs(1)).await;
+
+            let data = tokio::time::timeout(
+                Duration::from_secs(5),
+                system_ready_1::system_ready().send(self.client),
+            )
+            .await
+            .inspect_err(|_| debug!("system_ready request timed out"))
+            .ok()
+            .and_then(|r| {
+                r.inspect_err(|e| debug!("converting error to option: {e}"))
+                    .ok()
+            });
+
+            state = self.next_state(state, data);
+        }
+    }
+}

--- a/crates/vapix/Cargo.toml
+++ b/crates/vapix/Cargo.toml
@@ -8,6 +8,7 @@ description = "Utilities for working with VAPIX"
 [dependencies]
 anyhow = { workspace = true }
 base32 = { workspace = true }
+clap = { workspace = true, optional = true }
 log = { workspace = true }
 reqwest = { workspace = true, features = ["json", "http2"] }
 serde = { workspace = true, features = ["derive"] }

--- a/crates/vapix/src/apis.rs
+++ b/crates/vapix/src/apis.rs
@@ -50,7 +50,7 @@ pub mod system_ready_1 {
 }
 
 pub mod firmware_management_1 {
-    pub use crate::firmware_management_1::FactoryDefaultRequest;
+    pub use crate::firmware_management_1::{FactoryDefaultRequest, UpgradeRequest};
 }
 
 pub mod parameter_management {

--- a/crates/vapix/src/axis_cgi/firmware_management_1.rs
+++ b/crates/vapix/src/axis_cgi/firmware_management_1.rs
@@ -2,16 +2,42 @@
 //!
 //! [Firmware Management API]: https://developer.axis.com/vapix/network-video/firmware-management-api/
 
+use std::{
+    convert::Infallible,
+    fmt::{Display, Formatter},
+};
+
+use anyhow::Context;
+use log::trace;
+use reqwest::Method;
 use serde::{Deserialize, Serialize};
 
-use crate::json_rpc_http::{JsonRpcHttp, JsonRpcHttpLossless};
+use crate::{
+    cassette::{Cassette, Request},
+    http::Error,
+    json_rpc_http::{from_response, from_response_lossless, JsonRpcHttp, JsonRpcHttpLossless},
+    Client,
+};
 
+const PATH: &str = "axis-cgi/firmwaremanagement.cgi";
+
+#[cfg_attr(feature = "clap", derive(clap::ValueEnum))]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub enum FactoryDefaultMode {
     None,
     Soft,
     Hard,
+}
+
+impl Display for FactoryDefaultMode {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::None => write!(f, "none"),
+            Self::Soft => write!(f, "soft"),
+            Self::Hard => write!(f, "hard"),
+        }
+    }
 }
 
 #[derive(Debug, Deserialize, Serialize)]
@@ -45,9 +71,206 @@ impl FactoryDefaultRequest {
 
 impl JsonRpcHttp for FactoryDefaultRequest {
     type Data = FactoryDefaultData;
-    const PATH: &'static str = "axis-cgi/firmwaremanagement.cgi";
+    const PATH: &'static str = PATH;
 }
 
 impl JsonRpcHttpLossless for FactoryDefaultRequest {
     type Data = FactoryDefaultData;
+}
+
+#[cfg_attr(feature = "clap", derive(clap::ValueEnum))]
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub enum AutoCommit {
+    Never,
+    Boot,
+    Started,
+    Default,
+}
+
+impl Display for AutoCommit {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Never => write!(f, "never"),
+            Self::Boot => write!(f, "boot"),
+            Self::Started => write!(f, "started"),
+            Self::Default => write!(f, "default"),
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub enum AutoRollback {
+    Never,
+    Minutes(u32),
+    Default,
+}
+
+impl Serialize for AutoRollback {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        match self {
+            Self::Never => serializer.serialize_str("never"),
+            Self::Minutes(m) => serializer.serialize_str(&m.to_string()),
+            Self::Default => serializer.serialize_str("default"),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct UpgradeParams {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    factory_default_mode: Option<FactoryDefaultMode>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    auto_commit: Option<AutoCommit>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    auto_rollback: Option<AutoRollback>,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct UpgradeData {
+    pub firmware_version: String,
+}
+
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct UpgradeRequestJson {
+    api_version: &'static str,
+    method: &'static str,
+    params: UpgradeParams,
+}
+
+pub struct UpgradeRequest {
+    json: UpgradeRequestJson,
+    bin: Vec<u8>,
+}
+
+impl UpgradeRequest {
+    pub fn new(bin: Vec<u8>) -> Self {
+        Self {
+            json: UpgradeRequestJson {
+                api_version: "1.0",
+                method: "upgrade",
+                params: UpgradeParams {
+                    factory_default_mode: None,
+                    auto_commit: None,
+                    auto_rollback: None,
+                },
+            },
+            bin,
+        }
+    }
+
+    pub fn factory_default_mode(mut self, mode: FactoryDefaultMode) -> Self {
+        self.json.params.factory_default_mode = Some(mode);
+        self
+    }
+
+    pub fn auto_commit(mut self, commit: AutoCommit) -> Self {
+        self.json.params.auto_commit = Some(commit);
+        self
+    }
+
+    pub fn auto_rollback(mut self, rollback: AutoRollback) -> Self {
+        self.json.params.auto_rollback = Some(rollback);
+        self
+    }
+
+    fn build_multipart_body(json: &[u8], firmware: &[u8], boundary: &str) -> Vec<u8> {
+        let mut body = Vec::new();
+
+        body.extend_from_slice(format!("--{boundary}\r\n").as_bytes());
+
+        body.extend_from_slice(b"Content-Disposition: form-data; name=\"data\"\r\n");
+        body.extend_from_slice(b"Content-Type: application/json\r\n\r\n");
+        body.extend_from_slice(json);
+        body.extend_from_slice(b"\r\n");
+
+        body.extend_from_slice(format!("--{boundary}\r\n").as_bytes());
+
+        body.extend_from_slice(b"Content-Disposition: form-data; name=\"firmwareImage\"; filename=\"firmware.bin\"\r\n");
+        body.extend_from_slice(b"Content-Type: application/octet-stream\r\n\r\n");
+        body.extend_from_slice(firmware);
+        body.extend_from_slice(b"\r\n");
+
+        body.extend_from_slice(format!("--{boundary}--\r\n").as_bytes());
+
+        body
+    }
+
+    pub async fn send(
+        self,
+        client: &Client,
+        cassette: Option<&mut Cassette>,
+    ) -> Result<UpgradeData, Error<Infallible>> {
+        let boundary = "----FormBoundaryS6untlhO8j7poXo";
+
+        let json = serde_json::to_string(&self.json)
+            .context("serialize request failed")
+            .map_err(Error::Request)?;
+
+        let body = Self::build_multipart_body(json.as_bytes(), &self.bin, boundary);
+
+        let response = Request::multipart_form_data(Method::POST, PATH.to_string(), boundary)
+            .body_bytes(body)
+            .send(client, cassette)
+            .await?;
+
+        let status = response.status;
+
+        let text = response.body;
+
+        if cfg!(debug_assertions) {
+            if let Ok(text) = text.as_deref() {
+                trace!("Received {status}: {text}");
+            }
+        }
+
+        match cfg!(debug_assertions) {
+            true => from_response_lossless(status, text),
+            false => from_response(status, text),
+        }
+        .map_err(Error::Decode)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use expect_test::expect;
+
+    use super::*;
+
+    #[test]
+    fn upgrade_request_json_envelope() {
+        let request = UpgradeRequest::new(Vec::new())
+            .factory_default_mode(FactoryDefaultMode::None)
+            .auto_commit(AutoCommit::Default)
+            .auto_rollback(AutoRollback::Minutes(15));
+        let json = serde_json::to_string_pretty(&request.json).unwrap();
+        expect![[r#"
+            {
+              "apiVersion": "1.0",
+              "method": "upgrade",
+              "params": {
+                "factoryDefaultMode": "none",
+                "autoCommit": "default",
+                "autoRollback": "15"
+              }
+            }"#]]
+        .assert_eq(&json);
+    }
+
+    #[test]
+    fn upgrade_request_minimal() {
+        let request = UpgradeRequest::new(Vec::new());
+        let json = serde_json::to_string_pretty(&request.json).unwrap();
+        expect![[r#"
+            {
+              "apiVersion": "1.0",
+              "method": "upgrade",
+              "params": {}
+            }"#]]
+        .assert_eq(&json);
+    }
 }

--- a/crates/vapix/src/axis_cgi/firmware_management_1/upgrade_1_0.json
+++ b/crates/vapix/src/axis_cgi/firmware_management_1/upgrade_1_0.json
@@ -1,0 +1,7 @@
+{
+  "apiVersion": "1.8",
+  "method": "upgrade",
+  "data": {
+    "firmwareVersion": "12.9.57"
+  }
+}

--- a/crates/vapix/src/axis_cgi/firmware_management_1/upgrade_409_error_1_0.json
+++ b/crates/vapix/src/axis_cgi/firmware_management_1/upgrade_409_error_1_0.json
@@ -1,0 +1,8 @@
+{
+  "apiVersion": "1.8",
+  "method": "upgrade",
+  "error": {
+    "code": 409,
+    "message": "Downgrade is only allowed if factoryDefault=hard is set."
+  }
+}

--- a/crates/vapix/src/cassette.rs
+++ b/crates/vapix/src/cassette.rs
@@ -17,7 +17,7 @@ use crate::{http::Error, Client};
 pub struct Request {
     method: Method,
     path: String,
-    body: Option<String>,
+    body: Option<Vec<u8>>,
     content_type: Option<String>,
 }
 
@@ -31,6 +31,15 @@ impl Request {
         }
     }
 
+    pub fn multipart_form_data(method: Method, path: String, boundary: &str) -> Self {
+        Self {
+            method,
+            path,
+            body: None,
+            content_type: Some(format!("multipart/form-data; boundary={boundary}")),
+        }
+    }
+
     pub fn no_content(method: Method, path: String) -> Self {
         Self {
             method,
@@ -41,6 +50,11 @@ impl Request {
     }
 
     pub fn body(mut self, body: String) -> Self {
+        self.body = Some(body.into_bytes());
+        self
+    }
+
+    pub fn body_bytes(mut self, body: Vec<u8>) -> Self {
         self.body = Some(body);
         self
     }
@@ -58,7 +72,7 @@ impl Request {
             content.push_str(&format!("Content-Type: {content_type}\n"));
         }
         if let Some(body) = body {
-            content.push_str(&format!("\n{body}"));
+            content.push_str(&format!("\n{}", String::from_utf8_lossy(body)));
         }
         let () =
             fs::write(file, content).with_context(|| format!("Could not write file {file:?}"))?;
@@ -82,7 +96,9 @@ impl Request {
         method.hash(&mut hasher);
         path.hash(&mut hasher);
         if let Some(body) = body {
-            body.hash(&mut hasher);
+            // Hash as str to stay compatible with cassettes recorded when body was String.
+            hasher.write(body);
+            hasher.write_u8(0xff);
         }
         content_type.hash(&mut hasher);
         hasher.finish()

--- a/crates/vapix/src/json_rpc_http.rs
+++ b/crates/vapix/src/json_rpc_http.rs
@@ -14,7 +14,7 @@ use crate::{
     Client,
 };
 
-fn from_response<T>(status: StatusCode, text: reqwest::Result<String>) -> anyhow::Result<T>
+pub fn from_response<T>(status: StatusCode, text: reqwest::Result<String>) -> anyhow::Result<T>
 where
     T: for<'a> Deserialize<'a>,
 {
@@ -22,7 +22,10 @@ where
     parse_data(&text).with_context(|| format!("Could not parse data, status was {status}"))
 }
 
-fn from_response_lossless<T>(status: StatusCode, text: reqwest::Result<String>) -> anyhow::Result<T>
+pub fn from_response_lossless<T>(
+    status: StatusCode,
+    text: reqwest::Result<String>,
+) -> anyhow::Result<T>
 where
     T: for<'a> Deserialize<'a> + Serialize,
 {

--- a/crates/vapix/tests/cassette_tests.rs
+++ b/crates/vapix/tests/cassette_tests.rs
@@ -16,6 +16,7 @@ use rs4a_vapix::{
     apis::basic_device_info_1,
     basic_device_info_1::{ProductType, UnrestrictedProperties},
     cassette::{Cassette, Mode},
+    firmware_management_1::UpgradeRequest,
     http,
     json_rpc_http::{JsonRpcHttp, JsonRpcHttpLossless},
     parameter_management::{ImageResolution, ListRequest},
@@ -379,6 +380,7 @@ cassette_tests! {
     device_configuration_item_does_not_exist,
     device_configuration_validation_error,
     device_configuration_item_already_exists,
+    firmware_management_1_upgrade_mismatch,
     parameter_management_list_error,
     parameter_management_list_image_resolution,
     remote_object_storage_1_beta_crud,
@@ -720,6 +722,33 @@ async fn device_configuration_item_already_exists(
         .send(&client, cassette.as_mut())
         .await
         .unwrap();
+}
+
+// This normally happens if the firmware is for a different device model.
+// Apparently it also happens with an invalid firmware binary.
+async fn firmware_management_1_upgrade_mismatch(
+    client: Client,
+    cassette: Cassette,
+    _prelude: Option<Prelude>,
+) {
+    let mut cassette = Some(cassette);
+    let firmware = b"DUMMY_FIRMWARE_BYTES".to_vec();
+    let error = UpgradeRequest::new(firmware)
+        .send(&client, cassette.as_mut())
+        .await
+        .unwrap_err();
+
+    // TODO: Propagate as service error.
+    let http::Error::Decode(error) = error else {
+        panic!("Expected Decode error but got {error:?}");
+    };
+
+    let error = format!("{error:?}");
+
+    assert!(
+        error.contains("421"),
+        "Expected error code 421 but got: {error}"
+    );
 }
 
 async fn parameter_management_list_error(

--- a/crates/vapix/tests/serde.rs
+++ b/crates/vapix/tests/serde.rs
@@ -3,6 +3,7 @@ use rs4a_vapix::{
     action1::{AddActionConfigurationResponse, Condition},
     apis,
     basic_device_info_1::{AllPropertiesData, AllUnrestrictedPropertiesData, Architecture},
+    firmware_management_1::UpgradeData,
     json_rpc::{parse_data, parse_data_lossless},
     rest,
     rest_http::RestHttp,
@@ -33,6 +34,16 @@ fn can_deserialize_basic_device_info_1_examples() {
         "../src/axis_cgi/basic_device_info_1/get_all_unrestricted_properties_2004_error_1_0.json"
     );
     parse_data_lossless::<AllUnrestrictedPropertiesData>(text).unwrap_err();
+    // TODO: Expose error code
+}
+
+#[test]
+fn can_deserialize_firmware_management_1_examples() {
+    let text = include_str!("../src/axis_cgi/firmware_management_1/upgrade_1_0.json");
+    let UpgradeData { .. } = parse_data_lossless::<UpgradeData>(text).unwrap();
+
+    let text = include_str!("../src/axis_cgi/firmware_management_1/upgrade_409_error_1_0.json");
+    parse_data_lossless::<UpgradeData>(text).unwrap_err();
     // TODO: Expose error code
 }
 

--- a/snapshots/device-manager-docs
+++ b/snapshots/device-manager-docs
@@ -11,6 +11,7 @@ Commands:
   restore      Restore the device to a clean state (factory default)
   init         Initialize a device in setup mode
   reinit       Restore and initialize the device to a known, useful state
+  upgrade      Upgrade the device firmware
   completions  Generate shell completions
   help         Print this message or the help of the given subcommand(s)
 
@@ -66,3 +67,30 @@ Options:
   -u, --user <USER>              The username to use for authentication [env: AXIS_DEVICE_USER=] [default: root]
   -p, --pass <PASS>              The password to use for authentication [env: AXIS_DEVICE_PASS=] [default: pass]
   -h, --help                     Print help
++ device-manager help upgrade
+Upgrade the device firmware
+
+Usage: device-manager upgrade [OPTIONS] --host <HOST> <FIRMWARE>
+
+Arguments:
+  <FIRMWARE>  Path to the firmware image
+
+Options:
+      --host <HOST>
+          Hostname or IP address of the device [env: AXIS_DEVICE_IP=]
+      --http-port <HTTP_PORT>
+          Override the default port for HTTP [env: AXIS_DEVICE_HTTP_PORT=]
+      --https-port <HTTPS_PORT>
+          Override the default port for HTTPS [env: AXIS_DEVICE_HTTPS_PORT=]
+  -u, --user <USER>
+          The username to use for authentication [env: AXIS_DEVICE_USER=] [default: root]
+  -p, --pass <PASS>
+          The password to use for authentication [env: AXIS_DEVICE_PASS=] [default: pass]
+  -f, --factory-default-mode <FACTORY_DEFAULT_MODE>
+          Factory default mode to apply during upgrade [default: none] [possible values: none, soft, hard]
+  -c, --auto-commit <AUTO_COMMIT>
+          Auto-commit behavior after upgrade [default: default] [possible values: never, boot, started, default]
+  -r, --auto-rollback <AUTO_ROLLBACK>
+          Auto-rollback behavior: "never", "default", or minutes [default: default]
+  -h, --help
+          Print help


### PR DESCRIPTION
The immediate goal is making it easier to chance firmware version when recording cassettes. Eventually I hope to automate cassette recording, and for that being able to change firmware version is necessary.

`crates/vapix/tests/cassette_tests.rs`:
- Add cassette tests only for cases that don't require a real firmware because putting the full firmware in the cassette would be impractical and probably illegal. I tried briefly to implement substitution for requests, but AI tried to put the implementation in the vapix crate and I want to make it less aware of the cassette tests, not more. The thing I would try next, but don't have time for now, is to move all file handling out of vapix. Note that it will be important to substitute before computing any checksums, or we would need access to real firmware images in CI.