### PR TITLE
feat(vapix)!: Remove cassette from `send` methods

### DIFF
--- a/crates/device-manager/src/commands/init.rs
+++ b/crates/device-manager/src/commands/init.rs
@@ -55,7 +55,7 @@ async fn apply_setup_profile(client: &rs4a_vapix::Client) -> anyhow::Result<()> 
     if allows_unsigned_toggle {
         info!("Allowing unsigned ACAP applications...");
         applications_config::ApplicationConfigRequest::allow_unsigned(true)
-            .send(client, None)
+            .send(client)
             .await?;
     } else {
         debug!("Skipping AllowUnsigned (not applicable for firmware {version})");

--- a/crates/device-manager/src/commands/upgrade.rs
+++ b/crates/device-manager/src/commands/upgrade.rs
@@ -58,7 +58,7 @@ impl UpgradeCommand {
             .factory_default_mode(self.factory_default_mode)
             .auto_commit(self.auto_commit)
             .auto_rollback(auto_rollback)
-            .send(&client, None)
+            .send(&client)
             .await?;
 
         info!(

--- a/crates/vapix/src/axis_cgi/applications_config.rs
+++ b/crates/vapix/src/axis_cgi/applications_config.rs
@@ -4,11 +4,7 @@
 
 use reqwest::{Method, StatusCode};
 
-use crate::{
-    cassette::{Cassette, Request},
-    http::Error,
-    Client,
-};
+use crate::http::{Error, HttpClient, Request};
 
 const PATH: &str = "axis-cgi/applications/config.cgi";
 
@@ -64,10 +60,12 @@ impl ApplicationConfigRequest {
     // TODO: Add support for get requests
     pub async fn send(
         self,
-        client: &Client,
-        cassette: Option<&mut Cassette>,
+        client: &impl HttpClient,
     ) -> Result<(), Error<std::convert::Infallible>> {
-        let response = self.into_request().send(client, cassette).await?;
+        let response = client
+            .execute(self.into_request())
+            .await
+            .map_err(Error::Transport)?;
         let body = response.body.map_err(|e| Error::Transport(e.into()))?;
         if response.status == StatusCode::OK && body.trim().starts_with(r#"<reply result="ok">"#) {
             Ok(())

--- a/crates/vapix/src/axis_cgi/firmware_management_1.rs
+++ b/crates/vapix/src/axis_cgi/firmware_management_1.rs
@@ -13,10 +13,8 @@ use reqwest::Method;
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    cassette::{Cassette, Request},
-    http::Error,
+    http::{Error, HttpClient, Request},
     json_rpc_http::{from_response, from_response_lossless, JsonRpcHttp, JsonRpcHttpLossless},
-    Client,
 };
 
 const PATH: &str = "axis-cgi/firmwaremanagement.cgi";
@@ -199,11 +197,7 @@ impl UpgradeRequest {
         body
     }
 
-    pub async fn send(
-        self,
-        client: &Client,
-        cassette: Option<&mut Cassette>,
-    ) -> Result<UpgradeData, Error<Infallible>> {
+    pub async fn send(self, client: &impl HttpClient) -> Result<UpgradeData, Error<Infallible>> {
         let boundary = "----FormBoundaryS6untlhO8j7poXo";
 
         let json = serde_json::to_string(&self.json)
@@ -212,10 +206,10 @@ impl UpgradeRequest {
 
         let body = Self::build_multipart_body(json.as_bytes(), &self.bin, boundary);
 
-        let response = Request::multipart_form_data(Method::POST, PATH.to_string(), boundary)
-            .body_bytes(body)
-            .send(client, cassette)
-            .await?;
+        let request =
+            Request::multipart_form_data(Method::POST, PATH.to_string(), boundary).body_bytes(body);
+
+        let response = client.execute(request).await.map_err(Error::Transport)?;
 
         let status = response.status;
 

--- a/crates/vapix/src/axis_cgi/parameter_management.rs
+++ b/crates/vapix/src/axis_cgi/parameter_management.rs
@@ -8,7 +8,7 @@ use anyhow::{bail, Context};
 use reqwest::{Method, StatusCode};
 
 use crate::{
-    cassette::{self, Cassette},
+    http::{HttpClient, Request},
     Client,
 };
 
@@ -102,14 +102,10 @@ impl ListRequest {
         }
     }
 
-    pub async fn send(
-        self,
-        client: &Client,
-        cassette: Option<&mut Cassette>,
-    ) -> anyhow::Result<ParamList> {
+    pub async fn send(self, client: &impl HttpClient) -> anyhow::Result<ParamList> {
         let path = format!("{PATH}?action=list&group={}", self.group);
-        let response = cassette::Request::no_content(Method::GET, path)
-            .send::<std::convert::Infallible>(client, cassette)
+        let response = client
+            .execute(Request::no_content(Method::GET, path))
             .await
             .context("sending param.cgi request")?;
 

--- a/crates/vapix/src/axis_cgi/pwdgrp.rs
+++ b/crates/vapix/src/axis_cgi/pwdgrp.rs
@@ -6,7 +6,7 @@ use std::fmt::{Display, Formatter};
 
 use reqwest::{Method, StatusCode};
 
-use crate::{cassette::Request, http::Error, Client};
+use crate::http::{Error, HttpClient, Request};
 
 const PATH: &str = "axis-cgi/pwdgrp.cgi";
 
@@ -79,9 +79,15 @@ impl AddUserRequest {
         )
     }
 
-    pub async fn send(self, client: &Client) -> Result<(), Error<std::convert::Infallible>> {
+    pub async fn send(
+        self,
+        client: &impl HttpClient,
+    ) -> Result<(), Error<std::convert::Infallible>> {
         let expected = format!("Created account {}.", self.username);
-        let response = self.into_request().send(client, None).await?;
+        let response = client
+            .execute(self.into_request())
+            .await
+            .map_err(Error::Transport)?;
         let body = response.body.map_err(|e| Error::Transport(e.into()))?;
         if response.status == StatusCode::OK {
             let html_body = extract_body(&body).unwrap_or("");

--- a/crates/vapix/src/cassette.rs
+++ b/crates/vapix/src/cassette.rs
@@ -5,208 +5,78 @@ use std::{
     hash::{DefaultHasher, Hash, Hasher},
     path::{Path, PathBuf},
     str::FromStr,
+    sync::Mutex,
 };
 
 use anyhow::Context;
 use log::debug;
-use reqwest::{Method, StatusCode};
+use reqwest::StatusCode;
 
-use crate::{http::Error, Client};
+use crate::{
+    http::{HttpClient, Request, Response},
+    Client,
+};
 
-#[derive(Debug)]
-pub struct Request {
-    method: Method,
-    path: String,
-    body: Option<Vec<u8>>,
-    content_type: Option<String>,
+// TODO: Move the cassette infrastructure out of the vapix library crate.
+
+fn write_request(request: &Request, file: &Path) -> anyhow::Result<()> {
+    let () = create_dir_all(file.parent().context("the file has no parent")?)?;
+    let mut content = format!("{} {}\n", request.method, request.path);
+    if let Some(content_type) = &request.content_type {
+        content.push_str(&format!("Content-Type: {content_type}\n"));
+    }
+    if let Some(body) = &request.body {
+        content.push_str(&format!("\n{}", String::from_utf8_lossy(body)));
+    }
+    let () = fs::write(file, content).with_context(|| format!("Could not write file {file:?}"))?;
+    Ok(())
 }
 
-impl Request {
-    pub fn json(method: Method, path: String) -> Self {
-        Self {
-            method,
-            path,
-            body: None,
-            content_type: Some("application/json".to_string()),
-        }
+fn request_checksum(request: &Request) -> u64 {
+    // The `DefaultHasher` is not guaranteed to be stable across rust versions.
+    // If it changes, all cassettes tracked in VCS will be invalidated.
+    // TODO: Use a stable hashing algorithm.
+
+    let mut hasher = DefaultHasher::new();
+    request.method.hash(&mut hasher);
+    request.path.hash(&mut hasher);
+    if let Some(body) = &request.body {
+        // Hash as str to stay compatible with cassettes recorded when body was String.
+        hasher.write(body);
+        hasher.write_u8(0xff);
     }
-
-    pub fn multipart_form_data(method: Method, path: String, boundary: &str) -> Self {
-        Self {
-            method,
-            path,
-            body: None,
-            content_type: Some(format!("multipart/form-data; boundary={boundary}")),
-        }
-    }
-
-    pub fn no_content(method: Method, path: String) -> Self {
-        Self {
-            method,
-            path,
-            body: None,
-            content_type: None,
-        }
-    }
-
-    pub fn body(mut self, body: String) -> Self {
-        self.body = Some(body.into_bytes());
-        self
-    }
-
-    pub fn body_bytes(mut self, body: Vec<u8>) -> Self {
-        self.body = Some(body);
-        self
-    }
-
-    fn write(&self, file: &Path) -> anyhow::Result<()> {
-        let Self {
-            method,
-            path,
-            body,
-            content_type,
-        } = self;
-        let () = create_dir_all(file.parent().context("the file has no parent")?)?;
-        let mut content = format!("{method} {path}\n");
-        if let Some(content_type) = content_type {
-            content.push_str(&format!("Content-Type: {content_type}\n"));
-        }
-        if let Some(body) = body {
-            content.push_str(&format!("\n{}", String::from_utf8_lossy(body)));
-        }
-        let () =
-            fs::write(file, content).with_context(|| format!("Could not write file {file:?}"))?;
-
-        Ok(())
-    }
-
-    fn checksum(&self) -> u64 {
-        let Self {
-            method,
-            path,
-            body,
-            content_type,
-        } = self;
-
-        // The `DefaultHasher` is not guaranteed to be stable across rust versions.
-        // If it changes, all cassettes tracked in VCS will be invalidated.
-        // TODO: Use a stable hashing algorithm.
-
-        let mut hasher = DefaultHasher::new();
-        method.hash(&mut hasher);
-        path.hash(&mut hasher);
-        if let Some(body) = body {
-            // Hash as str to stay compatible with cassettes recorded when body was String.
-            hasher.write(body);
-            hasher.write_u8(0xff);
-        }
-        content_type.hash(&mut hasher);
-        hasher.finish()
-    }
-
-    // TODO: Make passing the client optional when reading from a cassette
-    /// Sends the request and returns a future response.
-    ///
-    /// # Panics
-    ///
-    /// This method panics if reading from or writing to a provided cassette fails.
-    pub async fn send<T>(
-        self,
-        client: &Client,
-        cassette: Option<&mut Cassette>,
-    ) -> Result<Response, Error<T>> {
-        let response_file = match cassette {
-            Some(cassette) => {
-                // PANICS:
-                // Unwrapping is acceptable when a cassette is provided as stated in the docstring.
-                cassette.advance();
-                let checksum = self.checksum();
-                match cassette.mode {
-                    Mode::Read => {
-                        let file = cassette.response_file(checksum);
-                        debug!("Reading response from the cassette file {file:?}");
-                        return Ok(Response::read(&file).unwrap());
-                    }
-                    Mode::Write => {
-                        let file = cassette.request_file(checksum);
-                        debug!("Writing request to the cassette file {file:?}");
-                        self.write(&file).unwrap();
-                        Some(cassette.response_file(checksum))
-                    }
-                }
-            }
-            None => None,
-        };
-
-        let mut request_builder = client
-            .request(self.method, &self.path)
-            .map_err(Error::Request)?;
-        if let Some(content_type) = self.content_type.as_deref() {
-            request_builder = request_builder.header(reqwest::header::CONTENT_TYPE, content_type);
-        }
-        if let Some(body) = self.body {
-            debug_assert!(self.content_type.is_some());
-            request_builder = request_builder.body(body);
-        }
-        let response = request_builder
-            .send()
-            .await
-            .context("failed to send")
-            .map_err(Error::Transport)?;
-        let response = Response {
-            status: response.status(),
-            body: response.text().await,
-        };
-
-        if let Some(file) = response_file {
-            // PANICS:
-            // Unwrapping is acceptable when a cassette is provided as stated in the docstring and
-            // `response_file` is set only when a cassette is provided.
-            debug!("Writing response to the cassette file {file:?}");
-            response.write(&file).unwrap();
-        }
-
-        Ok(response)
-    }
+    request.content_type.hash(&mut hasher);
+    hasher.finish()
 }
 
-#[derive(Debug)]
-pub struct Response {
-    pub status: StatusCode,
-    pub body: Result<String, reqwest::Error>,
+fn read_response(file: &Path) -> anyhow::Result<Response> {
+    let content =
+        fs::read_to_string(file).with_context(|| format!("Could not read the file {file:?}"))?;
+    let (status, body) = content
+        .split_once("\n\n")
+        .context("Could not split response")?;
+    let code = status
+        .split_whitespace()
+        .next()
+        .context("Could not get status code")?;
+
+    Ok(Response {
+        status: StatusCode::from_str(code).context("Could not parse status code")?,
+        body: Ok(body.to_string()),
+    })
 }
 
-impl Response {
-    fn read(file: &Path) -> anyhow::Result<Self> {
-        let content = fs::read_to_string(file)
-            .with_context(|| format!("Could not read the file {file:?}"))?;
-        let (status, body) = content
-            .split_once("\n\n")
-            .context("Could not split response")?;
-        let code = status
-            .split_whitespace()
-            .next()
-            .context("Could not get status code")?;
+fn write_response(response: &Response, file: &Path) -> anyhow::Result<()> {
+    let Ok(body) = &response.body else {
+        unimplemented!();
+    };
+    let content = format!("{}\n\n{body}", response.status);
 
-        Ok(Self {
-            status: StatusCode::from_str(code).context("Could not parse status code")?,
-            body: Ok(body.to_string()),
-        })
-    }
+    let () = create_dir_all(file.parent().context("the file has no parent")?)?;
+    let () =
+        fs::write(file, content).with_context(|| format!("Could not write the file {file:?}"))?;
 
-    fn write(&self, file: &Path) -> anyhow::Result<()> {
-        let Self { status, body } = self;
-        let Ok(body) = body else {
-            unimplemented!();
-        };
-        let content = format!("{status}\n\n{body}");
-
-        let () = create_dir_all(file.parent().context("the file has no parent")?)?;
-        let () = fs::write(file, content)
-            .with_context(|| format!("Could not write the file {file:?}"))?;
-
-        Ok(())
-    }
+    Ok(())
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -238,9 +108,7 @@ impl Cassette {
             Err(e) => Err(e.into()),
         }
     }
-}
 
-impl Cassette {
     fn advance(&mut self) {
         self.request_number += 1;
     }
@@ -257,5 +125,56 @@ impl Cassette {
             "{:>03}-{checksum:016x}-response",
             self.request_number
         ))
+    }
+}
+
+pub struct CassetteClient {
+    inner: Option<Client>,
+    cassette: Mutex<Cassette>,
+}
+
+impl CassetteClient {
+    pub fn for_playback(cassette: Cassette) -> Self {
+        assert!(matches!(cassette.mode, Mode::Read));
+        Self {
+            inner: None,
+            cassette: Mutex::new(cassette),
+        }
+    }
+
+    pub fn for_recording(client: Client, cassette: Cassette) -> Self {
+        assert!(matches!(cassette.mode, Mode::Write));
+        Self {
+            inner: Some(client),
+            cassette: Mutex::new(cassette),
+        }
+    }
+}
+
+impl HttpClient for CassetteClient {
+    async fn execute(&self, request: Request) -> Result<Response, anyhow::Error> {
+        let (mode, req_file, resp_file) = {
+            let mut cassette = self.cassette.lock().unwrap();
+            cassette.advance();
+            let checksum = request_checksum(&request);
+            let req_file = cassette.request_file(checksum);
+            let resp_file = cassette.response_file(checksum);
+            (cassette.mode, req_file, resp_file)
+        };
+
+        match mode {
+            Mode::Read => {
+                debug!("Reading response from the cassette file {resp_file:?}");
+                Ok(read_response(&resp_file).unwrap())
+            }
+            Mode::Write => {
+                debug!("Writing request to the cassette file {req_file:?}");
+                write_request(&request, &req_file).unwrap();
+                let response = self.inner.as_ref().unwrap().execute(request).await?;
+                debug!("Writing response to the cassette file {resp_file:?}");
+                write_response(&response, &resp_file).unwrap();
+                Ok(response)
+            }
+        }
     }
 }

--- a/crates/vapix/src/client.rs
+++ b/crates/vapix/src/client.rs
@@ -1,4 +1,4 @@
-use anyhow::bail;
+use anyhow::{bail, Context};
 use base64::Engine;
 use log::debug;
 use reqwest::{
@@ -7,7 +7,11 @@ use reqwest::{
 };
 use url::{Host, Url};
 
-use crate::{apis, json_rpc_http::JsonRpcHttp};
+use crate::{
+    apis,
+    http::{HttpClient, Request, Response},
+    json_rpc_http::JsonRpcHttp,
+};
 
 fn authorization_headers(username: &str, password: &str) -> HeaderMap {
     let credentials = format!("{username}:{password}");
@@ -190,5 +194,23 @@ impl Client {
             Url::parse(&format!("{scheme}://{host}"))
         }
         .expect("Restricted types are known to combine into a valid URL")
+    }
+}
+
+impl HttpClient for Client {
+    async fn execute(&self, request: Request) -> Result<Response, anyhow::Error> {
+        let mut request_builder = self.request(request.method, &request.path)?;
+        if let Some(body) = request.body {
+            debug_assert!(request.content_type.is_some());
+            request_builder = request_builder.body(body);
+        }
+        if let Some(content_type) = request.content_type {
+            request_builder = request_builder.header(reqwest::header::CONTENT_TYPE, content_type);
+        }
+        let response = request_builder.send().await.context("failed to send")?;
+        Ok(Response {
+            status: response.status(),
+            body: response.text().await,
+        })
     }
 }

--- a/crates/vapix/src/config/remote_object_storage_1_beta.rs
+++ b/crates/vapix/src/config/remote_object_storage_1_beta.rs
@@ -6,7 +6,7 @@ use reqwest::Method;
 use serde_json::json;
 use url::Url;
 
-use crate::{cassette::Request, rest_http2::RestHttp2};
+use crate::{http::Request, rest_http2::RestHttp2};
 
 const BASE_PATH: &str = "config/rest/remote-object-storage/v1beta/destinations";
 

--- a/crates/vapix/src/config/siren_and_light_2_alpha.rs
+++ b/crates/vapix/src/config/siren_and_light_2_alpha.rs
@@ -3,7 +3,7 @@
 use reqwest::Method;
 use serde_json::json;
 
-use crate::{cassette::Request, rest_http2::RestHttp2};
+use crate::{http::Request, rest_http2::RestHttp2};
 
 const BASE_PATH: &str = "config/rest/siren-and-light/v2alpha";
 

--- a/crates/vapix/src/http.rs
+++ b/crates/vapix/src/http.rs
@@ -1,5 +1,9 @@
 //! Client independent utilities for VAPIX HTTP integration
 
+use std::future::Future;
+
+use reqwest::{Method, StatusCode};
+
 #[derive(Debug, thiserror::Error)]
 pub enum Error<E> {
     /// Incorrect API usage while building a request
@@ -24,4 +28,65 @@ impl<E> Error<E> {
             Err(e) => Err(Self::Decode(e)),
         }
     }
+}
+
+#[non_exhaustive]
+#[derive(Debug)]
+pub struct Request {
+    pub method: Method,
+    pub path: String,
+    pub body: Option<Vec<u8>>,
+    pub content_type: Option<String>,
+}
+
+impl Request {
+    pub fn json(method: Method, path: String) -> Self {
+        Self {
+            method,
+            path,
+            body: None,
+            content_type: Some("application/json".to_string()),
+        }
+    }
+
+    pub fn multipart_form_data(method: Method, path: String, boundary: &str) -> Self {
+        Self {
+            method,
+            path,
+            body: None,
+            content_type: Some(format!("multipart/form-data; boundary={boundary}")),
+        }
+    }
+
+    pub fn no_content(method: Method, path: String) -> Self {
+        Self {
+            method,
+            path,
+            body: None,
+            content_type: None,
+        }
+    }
+
+    pub fn body(mut self, body: String) -> Self {
+        self.body = Some(body.into_bytes());
+        self
+    }
+
+    pub fn body_bytes(mut self, body: Vec<u8>) -> Self {
+        self.body = Some(body);
+        self
+    }
+}
+
+#[derive(Debug)]
+pub struct Response {
+    pub status: StatusCode,
+    pub body: Result<String, reqwest::Error>,
+}
+
+pub trait HttpClient {
+    fn execute(
+        &self,
+        request: Request,
+    ) -> impl Future<Output = Result<Response, anyhow::Error>> + Send;
 }

--- a/crates/vapix/src/json_rpc_http.rs
+++ b/crates/vapix/src/json_rpc_http.rs
@@ -8,8 +8,7 @@ use reqwest::{Method, StatusCode};
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    cassette::{Cassette, Request},
-    http::Error,
+    http::{Error, HttpClient, Request},
     json_rpc::{parse_data, parse_data_lossless},
     Client,
 };
@@ -73,19 +72,12 @@ pub trait JsonRpcHttpLossless: JsonRpcHttp {
 
     fn send_lossless(
         self,
-        client: &Client,
-        cassette: Option<&mut Cassette>,
+        client: &(impl HttpClient + Sync),
     ) -> impl Future<Output = anyhow::Result<<Self as JsonRpcHttpLossless>::Data>> + Send {
         async move {
             let body = serde_json::to_string_pretty(&self)?;
-            let response = Request::json(Method::POST, Self::PATH.to_string())
-                .body(body)
-                .send::<Infallible>(client, cassette)
-                .await
-                .map_err(|e| match e {
-                    Error::Request(e) | Error::Transport(e) | Error::Decode(e) => e,
-                    Error::Service(e) => match e {},
-                })?;
+            let request = Request::json(Method::POST, Self::PATH.to_string()).body(body);
+            let response = client.execute(request).await?;
             from_response_lossless(response.status, response.body)
         }
     }

--- a/crates/vapix/src/rest_http2.rs
+++ b/crates/vapix/src/rest_http2.rs
@@ -5,11 +5,9 @@ use std::future::Future;
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    cassette::{Cassette, Request, Response},
-    http::Error,
+    http::{Error, HttpClient, Request, Response},
     rest,
     rest_http::from_response_lossless,
-    Client,
 };
 
 // As a user of the request builders, I find having to import the correct trait annoying.
@@ -22,11 +20,13 @@ pub trait RestHttp2: Send + Sized {
 
     fn send(
         self,
-        client: &Client,
-        cassette: Option<&mut Cassette>,
+        client: &(impl HttpClient + Sync),
     ) -> impl Future<Output = Result<Self::ResponseData, Error<rest::Error>>> + Send {
         async move {
-            let Response { status, body } = self.to_request().send(client, cassette).await?;
+            let Response { status, body } = client
+                .execute(self.to_request())
+                .await
+                .map_err(Error::Transport)?;
             from_response_lossless(status, body)
         }
     }

--- a/crates/vapix/tests/cassette_tests.rs
+++ b/crates/vapix/tests/cassette_tests.rs
@@ -15,7 +15,7 @@ use rs4a_vapix::{
     apis,
     apis::basic_device_info_1,
     basic_device_info_1::{ProductType, UnrestrictedProperties},
-    cassette::{Cassette, Mode},
+    cassette::{Cassette, CassetteClient, Mode},
     firmware_management_1::UpgradeRequest,
     http,
     json_rpc_http::{JsonRpcHttp, JsonRpcHttpLossless},
@@ -29,11 +29,11 @@ use rs4a_vapix::{
     siren_and_light_2_alpha::{
         GetMaintenanceModeRequest, StartMaintenanceModeRequest, StopMaintenanceModeRequest,
     },
-    Client, ClientBuilder, Scheme,
+    ClientBuilder,
 };
 use semver::VersionReq;
 use serde::{Deserialize, Serialize};
-use url::{Host, Url};
+use url::Url;
 // When a test fails, it may leave resources intact that will cause future runs to fail.
 // This must be cleaned up manually by either removing them individually or resetting the device.
 // This is tedious, but hopefully updating cassettes will be rare.
@@ -169,12 +169,6 @@ fn env_flag(key: &str) -> bool {
         Ok(s) => panic!("Expected value '0' or '1' but found '{s}' for {key}"),
         Err(_) => false,
     }
-}
-
-fn dummy_client() -> Client {
-    ClientBuilder::new(Host::parse("localhost").unwrap())
-        .build_with_scheme(Scheme::Secure)
-        .unwrap()
 }
 
 #[derive(Clone, Debug)]
@@ -332,7 +326,7 @@ fn finalize_recording(
     Ok(())
 }
 
-type TestFn = fn(Client, Cassette, Option<Prelude>) -> Pin<Box<dyn Future<Output = ()> + Send>>;
+type TestFn = fn(CassetteClient, Option<Prelude>) -> Pin<Box<dyn Future<Output = ()> + Send>>;
 type Substitutions = &'static [(&'static str, &'static str)];
 type TestEntry = (&'static str, TestFn, Substitutions);
 
@@ -340,8 +334,8 @@ macro_rules! cassette_tests {
     (@entry $name:ident => [$($sub:expr),* $(,)?]) => {
         (
             stringify!($name),
-            (|client, cassette, prelude| {
-                Box::pin($name(client, cassette, prelude))
+            (|client, prelude| {
+                Box::pin($name(client, prelude))
             }) as TestFn,
             &[$($sub),*] as Substitutions,
         )
@@ -433,7 +427,7 @@ fn record_trials(library: &Library) -> Vec<Trial> {
             let staging_dir = library.staging_dir(test_name);
             let cassette = Cassette::new(staging_dir.clone(), Mode::Write);
             cassette.clear().unwrap();
-            let client = client.clone();
+            let cassette_client = CassetteClient::for_recording(client.clone(), cassette);
             let prelude = prelude.clone();
             let library_dir = library.dir().to_path_buf();
             let device_key = device_key.clone();
@@ -444,7 +438,7 @@ fn record_trials(library: &Library) -> Vec<Trial> {
                     .enable_all()
                     .build()
                     .unwrap();
-                rt.block_on(test_fn(client, cassette, Some(prelude)));
+                rt.block_on(test_fn(cassette_client, Some(prelude)));
 
                 finalize_recording(
                     &library_dir,
@@ -461,7 +455,6 @@ fn record_trials(library: &Library) -> Vec<Trial> {
 }
 
 fn playback_trials(library: &Library) -> Vec<Trial> {
-    let client = dummy_client();
     let manifest_path = library.dir().join("manifest.json");
     let manifest = Manifest::load(&manifest_path).unwrap();
 
@@ -469,7 +462,6 @@ fn playback_trials(library: &Library) -> Vec<Trial> {
         .iter()
         .flat_map(|&(test_name, test_fn, _substitutions)| {
             let cassette_dirs = library.cassettes_for_test(test_name);
-            let client = client.clone();
             let manifest = &manifest;
 
             let cassette_trials = cassette_dirs.into_iter().map(move |cassette_dir| {
@@ -481,14 +473,14 @@ fn playback_trials(library: &Library) -> Vec<Trial> {
                     .to_string();
                 let label = manifest.resolve_label(test_name, &hash);
                 let trial_name = format!("{test_name}::{label}");
-                let client = client.clone();
                 Trial::test(trial_name, move || {
                     let cassette = Cassette::new(cassette_dir, Mode::Read);
+                    let cassette_client = CassetteClient::for_playback(cassette);
                     let rt = tokio::runtime::Builder::new_current_thread()
                         .enable_all()
                         .build()
                         .unwrap();
-                    rt.block_on(test_fn(client, cassette, None));
+                    rt.block_on(test_fn(cassette_client, None));
                     Ok(())
                 })
             });
@@ -576,14 +568,9 @@ fn main() {
     conclusion.exit();
 }
 
-async fn basic_device_info_get_all_properties(
-    client: Client,
-    cassette: Cassette,
-    _: Option<Prelude>,
-) {
-    let mut cassette = Some(cassette);
+async fn basic_device_info_get_all_properties(client: CassetteClient, _: Option<Prelude>) {
     let property_list = basic_device_info_1::get_all_properties()
-        .send_lossless(&client, cassette.as_mut())
+        .send_lossless(&client)
         .await
         .unwrap()
         .property_list;
@@ -592,13 +579,11 @@ async fn basic_device_info_get_all_properties(
 }
 
 async fn basic_device_info_get_all_unrestricted_properties(
-    client: Client,
-    cassette: Cassette,
+    client: CassetteClient,
     _: Option<Prelude>,
 ) {
-    let mut cassette = Some(cassette);
     let property_list = basic_device_info_1::get_all_unrestricted_properties()
-        .send_lossless(&client, cassette.as_mut())
+        .send_lossless(&client)
         .await
         .unwrap()
         .property_list;
@@ -608,8 +593,7 @@ async fn basic_device_info_get_all_unrestricted_properties(
 }
 
 async fn device_configuration_item_does_not_exist(
-    client: Client,
-    cassette: Cassette,
+    client: CassetteClient,
     prelude: Option<Prelude>,
 ) {
     if let Some(prelude) = prelude {
@@ -618,12 +602,10 @@ async fn device_configuration_item_does_not_exist(
         }
     }
 
-    let mut cassette = Some(cassette);
-
     let id = DestinationId::new("my_destination_id".to_string());
 
     let error = DeleteDestinationRequest::new(id.clone())
-        .send(&client, cassette.as_mut())
+        .send(&client)
         .await
         .unwrap_err();
 
@@ -634,30 +616,22 @@ async fn device_configuration_item_does_not_exist(
     assert_eq!(error.kind().unwrap(), ErrorKind::NotFound);
 }
 
-async fn device_configuration_validation_error(
-    client: Client,
-    cassette: Cassette,
-    prelude: Option<Prelude>,
-) {
+async fn device_configuration_validation_error(client: CassetteClient, prelude: Option<Prelude>) {
     if let Some(prelude) = prelude {
         if !prelude.supports_device_config() {
             return;
         }
     }
 
-    let mut cassette = Some(cassette);
-
-    let id = DestinationId::new("my_destination_id".to_string());
-
     let error = CreateDestinationRequest::azure(
-        id.clone(),
+        DestinationId::new("my_destination_id".to_string()),
         AzureDestination::new(
             "my-container".to_string(),
             "".to_string(),
             Url::parse("https://s3.eu-north-1.amazonaws.com").unwrap(),
         ),
     )
-    .send(&client, cassette.as_mut())
+    .send(&client)
     .await
     .unwrap_err();
 
@@ -669,8 +643,7 @@ async fn device_configuration_validation_error(
 }
 
 async fn device_configuration_item_already_exists(
-    client: Client,
-    cassette: Cassette,
+    client: CassetteClient,
     prelude: Option<Prelude>,
 ) {
     if let Some(prelude) = prelude {
@@ -678,8 +651,6 @@ async fn device_configuration_item_already_exists(
             return;
         }
     }
-
-    let mut cassette = Some(cassette);
 
     let id = DestinationId::new("my_destination_id".to_string());
 
@@ -691,7 +662,7 @@ async fn device_configuration_item_already_exists(
             Url::parse("https://s3.eu-north-1.amazonaws.com").unwrap(),
         ),
     )
-    .send(&client, cassette.as_mut())
+    .send(&client)
     .await
     .unwrap();
 
@@ -703,7 +674,7 @@ async fn device_configuration_item_already_exists(
             Url::parse("https://s3.eu-north-1.amazonaws.com").unwrap(),
         ),
     )
-    .send(&client, cassette.as_mut())
+    .send(&client)
     .await
     .unwrap_err();
 
@@ -720,22 +691,17 @@ async fn device_configuration_item_already_exists(
     // TODO: Consider running this only when recording and excluding it from the cassette.
 
     DeleteDestinationRequest::new(id.clone())
-        .send(&client, cassette.as_mut())
+        .send(&client)
         .await
         .unwrap();
 }
 
 // This normally happens if the firmware is for a different device model.
 // Apparently it also happens with an invalid firmware binary.
-async fn firmware_management_1_upgrade_mismatch(
-    client: Client,
-    cassette: Cassette,
-    _prelude: Option<Prelude>,
-) {
-    let mut cassette = Some(cassette);
+async fn firmware_management_1_upgrade_mismatch(client: CassetteClient, _prelude: Option<Prelude>) {
     let firmware = b"DUMMY_FIRMWARE_BYTES".to_vec();
     let error = UpgradeRequest::new(firmware)
-        .send(&client, cassette.as_mut())
+        .send(&client)
         .await
         .unwrap_err();
 
@@ -752,11 +718,7 @@ async fn firmware_management_1_upgrade_mismatch(
     );
 }
 
-async fn parameter_management_list_error(
-    client: Client,
-    cassette: Cassette,
-    prelude: Option<Prelude>,
-) {
+async fn parameter_management_list_error(client: CassetteClient, prelude: Option<Prelude>) {
     if let Some(prelude) = prelude {
         match prelude.props.parse_product_type().unwrap() {
             ProductType::BoxCamera => return,
@@ -769,9 +731,8 @@ async fn parameter_management_list_error(
         }
     }
 
-    let mut cassette = Some(cassette);
     let error = ListRequest::new::<ImageResolution>()
-        .send(&client, cassette.as_mut())
+        .send(&client)
         .await
         .unwrap_err();
 
@@ -780,8 +741,7 @@ async fn parameter_management_list_error(
 }
 
 async fn parameter_management_list_image_resolution(
-    client: Client,
-    cassette: Cassette,
+    client: CassetteClient,
     prelude: Option<Prelude>,
 ) {
     if let Some(prelude) = prelude {
@@ -793,27 +753,20 @@ async fn parameter_management_list_image_resolution(
         }
     }
 
-    let mut cassette = Some(cassette);
     let params = ListRequest::new::<ImageResolution>()
-        .send(&client, cassette.as_mut())
+        .send(&client)
         .await
         .unwrap();
     let resolutions = params.parse::<ImageResolution>().unwrap().unwrap();
     assert!(!resolutions.is_empty());
 }
 
-async fn remote_object_storage_1_beta_crud(
-    client: Client,
-    cassette: Cassette,
-    prelude: Option<Prelude>,
-) {
+async fn remote_object_storage_1_beta_crud(client: CassetteClient, prelude: Option<Prelude>) {
     if let Some(prelude) = prelude {
         if !prelude.supports_device_config() {
             return;
         }
     }
-
-    let mut cassette = Some(cassette);
 
     let id = DestinationId::new("my_destination_id".to_string());
 
@@ -827,17 +780,14 @@ async fn remote_object_storage_1_beta_crud(
         ),
     )
     .description("my-description".to_string())
-    .send(&client, cassette.as_mut())
+    .send(&client)
     .await
     .unwrap();
     assert_eq!(&created.id, &id);
     assert!(created.azure.is_some());
 
     // List
-    let all = ListDestinationsRequest::new()
-        .send(&client, cassette.as_mut())
-        .await
-        .unwrap();
+    let all = ListDestinationsRequest::new().send(&client).await.unwrap();
     assert!(all.iter().any(|d| d.id == created.id));
     assert_eq!(all.len(), 1);
 
@@ -852,40 +802,33 @@ async fn remote_object_storage_1_beta_crud(
             ..created.azure.unwrap()
         },
     )
-    .send(&client, cassette.as_mut())
+    .send(&client)
     .await
     .unwrap();
     // The effect of this update cannot be observed since the sas is redacted.
 
     let updated_description = format!("{}-updated", created.description.unwrap());
     let () = UpdateDestinationRequest::description(created.id.clone(), updated_description.clone())
-        .send(&client, cassette.as_mut())
+        .send(&client)
         .await
         .unwrap();
-    let all = ListDestinationsRequest::new()
-        .send(&client, cassette.as_mut())
-        .await
-        .unwrap();
+    let all = ListDestinationsRequest::new().send(&client).await.unwrap();
     let updated = all.into_iter().find(|d| d.id == created.id).unwrap();
     assert_eq!(updated.description.unwrap(), updated_description);
 
     // Delete
     let () = DeleteDestinationRequest::new(created.id.clone())
-        .send(&client, cassette.as_mut())
+        .send(&client)
         .await
         .unwrap();
 
     // Verify deletion
-    let all = ListDestinationsRequest::new()
-        .send(&client, cassette.as_mut())
-        .await
-        .unwrap();
+    let all = ListDestinationsRequest::new().send(&client).await.unwrap();
     assert!(!all.iter().any(|d| d.id == created.id));
 }
 
 async fn siren_and_light_2_alpha_maintenance_mode_not_supported(
-    client: Client,
-    cassette: Cassette,
+    client: CassetteClient,
     prelude: Option<Prelude>,
 ) {
     // TODO: Use the config discovery API to get capabilities and make this more robust.
@@ -901,15 +844,13 @@ async fn siren_and_light_2_alpha_maintenance_mode_not_supported(
         }
     }
 
-    let mut cassette = Some(cassette);
-
     GetMaintenanceModeRequest::new()
-        .send(&client, cassette.as_mut())
+        .send(&client)
         .await
         .unwrap();
 
     let error = StopMaintenanceModeRequest::new()
-        .send(&client, cassette.as_mut())
+        .send(&client)
         .await
         .unwrap_err();
 
@@ -920,7 +861,7 @@ async fn siren_and_light_2_alpha_maintenance_mode_not_supported(
     assert_eq!(error.kind(), Some(ErrorKind::InternalError));
 
     let error = StartMaintenanceModeRequest::new()
-        .send(&client, cassette.as_mut())
+        .send(&client)
         .await
         .unwrap_err();
 
@@ -931,14 +872,9 @@ async fn siren_and_light_2_alpha_maintenance_mode_not_supported(
     assert_eq!(error.kind(), Some(ErrorKind::InternalError));
 }
 
-async fn system_ready_1_system_ready(
-    client: Client,
-    cassette: Cassette,
-    _prelude: Option<Prelude>,
-) {
-    let mut cassette = Some(cassette);
+async fn system_ready_1_system_ready(client: CassetteClient, _prelude: Option<Prelude>) {
     let data = apis::system_ready_1::system_ready()
-        .send_lossless(&client, cassette.as_mut())
+        .send_lossless(&client)
         .await
         .unwrap();
     assert!(data.systemready);

--- a/crates/vapix/tests/smoke_tests.rs
+++ b/crates/vapix/tests/smoke_tests.rs
@@ -142,7 +142,7 @@ async fn recording_group_1_create_returns_ok() {
             session_token: None,
         },
     )
-    .send(&client, None)
+    .send(&client)
     .await
     .unwrap()
     .id;


### PR DESCRIPTION
The immediate benefit is that production code doesn't need to provide a `None` value.

The long term benefit of this change is being able to disentangle the production code from the cassette test infrastructure thanks to the new `HttpClient` trait. The cassette code isn't moved out of the crate yet though as I'm still deciding where to put it.

I have previously resisted a client trait because of the low utility combined with high overhead and indirection.

On the value side I have previously primarily considered the need to swap out the reqwest based client for one based on curl, which is still theoretical and could plausibly be achieved with features. When implementing the cassette tests I don't think I considered the benefits of introducing the trait since I initially used the `send_lossless` methods, which already mix testing and production concerns.

On the overhead side I have previously considered two implementations of the trait:
- Exposing individual entry points for creating request builders. I think this would require the request builder to be an associated type that implements a second trait.
- Depending on a universal request object, as in this commit. I was worried that this would make the client unusable for use cases that could not be captured in the custom request type.

Now I find that I like the cassette tests and that enabling them on a larger scale without impacting the experience of using the production APIs would be valuable. I also have a hunch that the request object will cover most use cases and that it will be possible to bypass it for APIs that don't fit the box.