### PR TITLE
feat(vapix)!: Remove `JsonRpcHttp*` traits

### DIFF
--- a/crates/device-finder/src/commands/discover_devices.rs
+++ b/crates/device-finder/src/commands/discover_devices.rs
@@ -6,8 +6,7 @@ use itertools::Itertools;
 use log::{debug, error, info, warn};
 use mdns::{RecordKind, Response};
 use rs4a_vapix::{
-    apis, basic_device_info_1::UnrestrictedProperties, json_rpc_http::JsonRpcHttp,
-    system_ready_1::SystemreadyData,
+    apis, basic_device_info_1::UnrestrictedProperties, system_ready_1::SystemreadyData,
 };
 use tokio::{
     task::JoinSet,

--- a/crates/device-inventory/src/commands/list.rs
+++ b/crates/device-inventory/src/commands/list.rs
@@ -5,7 +5,6 @@ use log::warn;
 use rs4a_vapix::{
     apis,
     basic_device_info_1::{AllProperties, RestrictedProperties, UnrestrictedProperties},
-    json_rpc_http::JsonRpcHttp,
 };
 use rs4a_vlt::requests;
 use tokio::task::JoinSet;

--- a/crates/device-manager/src/commands/init.rs
+++ b/crates/device-manager/src/commands/init.rs
@@ -1,8 +1,8 @@
 use anyhow::{bail, Context};
 use log::{debug, info, warn};
 use rs4a_vapix::{
-    applications_config, basic_device_info_1, json_rpc_http::JsonRpcHttp, parameter_management,
-    pwdgrp, pwdgrp::AddUserRequest, system_ready_1,
+    applications_config, basic_device_info_1, parameter_management, pwdgrp, pwdgrp::AddUserRequest,
+    system_ready_1,
 };
 use semver::Version;
 

--- a/crates/device-manager/src/commands/restore.rs
+++ b/crates/device-manager/src/commands/restore.rs
@@ -3,7 +3,6 @@ use std::time::Duration;
 use log::{debug, info};
 use rs4a_vapix::{
     firmware_management_1::{FactoryDefaultMode, FactoryDefaultRequest},
-    json_rpc_http::JsonRpcHttp,
     system_ready_1,
 };
 use tokio::time::timeout;

--- a/crates/device-manager/src/restart_detector.rs
+++ b/crates/device-manager/src/restart_detector.rs
@@ -1,7 +1,7 @@
 use std::time::Duration;
 
 use log::{debug, trace, warn};
-use rs4a_vapix::{json_rpc_http::JsonRpcHttp, system_ready_1, system_ready_1::SystemreadyData};
+use rs4a_vapix::{system_ready_1, system_ready_1::SystemreadyData};
 use tokio::time::sleep;
 
 #[derive(Clone, Copy, Debug)]

--- a/crates/vapix/src/axis_cgi/basic_device_info_1.rs
+++ b/crates/vapix/src/axis_cgi/basic_device_info_1.rs
@@ -3,6 +3,7 @@
 //! [Basic device information]: https://developer.axis.com/vapix/network-video/basic-device-information/
 
 use std::{
+    convert::Infallible,
     fmt::{Display, Formatter},
     str::FromStr,
 };
@@ -11,7 +12,10 @@ use anyhow::{anyhow, bail, Context};
 use semver::Version;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
-use crate::json_rpc_http::{JsonRpcHttp, JsonRpcHttpLossless};
+use crate::{
+    http::{Error, HttpClient},
+    json_rpc_http,
+};
 
 fn serialize_none_as_empty_string<T, S>(value: &Option<T>, serializer: S) -> Result<S::Ok, S::Error>
 where
@@ -138,13 +142,15 @@ impl Default for GetAllUnrestrictedPropertiesRequest {
     }
 }
 
-impl JsonRpcHttp for GetAllUnrestrictedPropertiesRequest {
-    type Data = AllUnrestrictedPropertiesData;
-    const PATH: &'static str = "axis-cgi/basicdeviceinfo.cgi";
-}
+const PATH: &str = "axis-cgi/basicdeviceinfo.cgi";
 
-impl JsonRpcHttpLossless for GetAllUnrestrictedPropertiesRequest {
-    type Data = AllUnrestrictedPropertiesData;
+impl GetAllUnrestrictedPropertiesRequest {
+    pub async fn send(
+        self,
+        client: &(impl HttpClient + Sync),
+    ) -> Result<AllUnrestrictedPropertiesData, Error<Infallible>> {
+        json_rpc_http::send_request(client, PATH, &self).await
+    }
 }
 
 #[non_exhaustive]
@@ -293,13 +299,13 @@ impl Default for GetAllPropertiesRequest {
     }
 }
 
-impl JsonRpcHttp for GetAllPropertiesRequest {
-    type Data = AllPropertiesData;
-    const PATH: &'static str = "axis-cgi/basicdeviceinfo.cgi";
-}
-
-impl JsonRpcHttpLossless for GetAllPropertiesRequest {
-    type Data = AllPropertiesData;
+impl GetAllPropertiesRequest {
+    pub async fn send(
+        self,
+        client: &(impl HttpClient + Sync),
+    ) -> Result<AllPropertiesData, Error<Infallible>> {
+        json_rpc_http::send_request(client, PATH, &self).await
+    }
 }
 
 pub fn get_all_properties() -> GetAllPropertiesRequest {

--- a/crates/vapix/src/axis_cgi/firmware_management_1.rs
+++ b/crates/vapix/src/axis_cgi/firmware_management_1.rs
@@ -8,13 +8,12 @@ use std::{
 };
 
 use anyhow::Context;
-use log::trace;
 use reqwest::Method;
 use serde::{Deserialize, Serialize};
 
 use crate::{
     http::{Error, HttpClient, Request},
-    json_rpc_http::{from_response, from_response_lossless, JsonRpcHttp, JsonRpcHttpLossless},
+    json_rpc_http,
 };
 
 const PATH: &str = "axis-cgi/firmwaremanagement.cgi";
@@ -65,15 +64,13 @@ impl FactoryDefaultRequest {
             },
         }
     }
-}
 
-impl JsonRpcHttp for FactoryDefaultRequest {
-    type Data = FactoryDefaultData;
-    const PATH: &'static str = PATH;
-}
-
-impl JsonRpcHttpLossless for FactoryDefaultRequest {
-    type Data = FactoryDefaultData;
+    pub async fn send(
+        self,
+        client: &(impl HttpClient + Sync),
+    ) -> Result<FactoryDefaultData, Error<Infallible>> {
+        json_rpc_http::send_request(client, PATH, &self).await
+    }
 }
 
 #[cfg_attr(feature = "clap", derive(clap::ValueEnum))]
@@ -197,7 +194,10 @@ impl UpgradeRequest {
         body
     }
 
-    pub async fn send(self, client: &impl HttpClient) -> Result<UpgradeData, Error<Infallible>> {
+    pub async fn send(
+        self,
+        client: &(impl HttpClient + Sync),
+    ) -> Result<UpgradeData, Error<Infallible>> {
         let boundary = "----FormBoundaryS6untlhO8j7poXo";
 
         let json = serde_json::to_string(&self.json)
@@ -215,17 +215,7 @@ impl UpgradeRequest {
 
         let text = response.body;
 
-        if cfg!(debug_assertions) {
-            if let Ok(text) = text.as_deref() {
-                trace!("Received {status}: {text}");
-            }
-        }
-
-        match cfg!(debug_assertions) {
-            true => from_response_lossless(status, text),
-            false => from_response(status, text),
-        }
-        .map_err(Error::Decode)
+        json_rpc_http::from_response(status, text).map_err(Error::Decode)
     }
 }
 

--- a/crates/vapix/src/axis_cgi/system_ready_1.rs
+++ b/crates/vapix/src/axis_cgi/system_ready_1.rs
@@ -2,11 +2,14 @@
 //!
 //! [Systemready API]: https://developer.axis.com/vapix/network-video/systemready-api/
 
-use std::time::Duration;
+use std::{convert::Infallible, time::Duration};
 
 use serde::{Deserialize, Serialize};
 
-use crate::json_rpc_http::{JsonRpcHttp, JsonRpcHttpLossless};
+use crate::{
+    http::{Error, HttpClient},
+    json_rpc_http,
+};
 
 fn deserialize_english_boolean<'de, D>(deserializer: D) -> Result<bool, D::Error>
 where
@@ -80,6 +83,8 @@ pub struct SystemReadyRequest {
     params: Option<SystemReadyParams>,
 }
 
+const PATH: &str = "axis-cgi/systemready.cgi";
+
 impl Default for SystemReadyRequest {
     fn default() -> Self {
         Self {
@@ -95,15 +100,13 @@ impl SystemReadyRequest {
         self.params.get_or_insert(SystemReadyParams { timeout });
         self
     }
-}
 
-impl JsonRpcHttp for SystemReadyRequest {
-    type Data = SystemreadyData;
-    const PATH: &'static str = "axis-cgi/systemready.cgi";
-}
-
-impl JsonRpcHttpLossless for SystemReadyRequest {
-    type Data = SystemreadyData;
+    pub async fn send(
+        self,
+        client: &(impl HttpClient + Sync),
+    ) -> Result<SystemreadyData, Error<Infallible>> {
+        json_rpc_http::send_request(client, PATH, &self).await
+    }
 }
 
 pub fn system_ready() -> SystemReadyRequest {

--- a/crates/vapix/src/client.rs
+++ b/crates/vapix/src/client.rs
@@ -10,7 +10,6 @@ use url::{Host, Url};
 use crate::{
     apis,
     http::{HttpClient, Request, Response},
-    json_rpc_http::JsonRpcHttp,
 };
 
 fn authorization_headers(username: &str, password: &str) -> HeaderMap {

--- a/crates/vapix/src/json_rpc_http.rs
+++ b/crates/vapix/src/json_rpc_http.rs
@@ -1,30 +1,17 @@
-//! Utilities for working with JSON RPC style APIs.
+//! Utilities for working with JSON RPC style APIs over HTTP.
 
-use std::{convert::Infallible, future::Future};
+use std::convert::Infallible;
 
 use anyhow::Context;
-use log::trace;
 use reqwest::{Method, StatusCode};
 use serde::{Deserialize, Serialize};
 
 use crate::{
     http::{Error, HttpClient, Request},
-    json_rpc::{parse_data, parse_data_lossless},
-    Client,
+    json_rpc::parse_data_lossless,
 };
 
 pub fn from_response<T>(status: StatusCode, text: reqwest::Result<String>) -> anyhow::Result<T>
-where
-    T: for<'a> Deserialize<'a>,
-{
-    let text = text.with_context(|| format!("Could not fetch text, status was {status}"))?;
-    parse_data(&text).with_context(|| format!("Could not parse data, status was {status}"))
-}
-
-pub fn from_response_lossless<T>(
-    status: StatusCode,
-    text: reqwest::Result<String>,
-) -> anyhow::Result<T>
 where
     T: for<'a> Deserialize<'a> + Serialize,
 {
@@ -32,53 +19,17 @@ where
     parse_data_lossless(&text).with_context(|| format!("Could not parse data, status was {status}"))
 }
 
-pub trait JsonRpcHttp: Serialize + Send + Sized {
-    type Data: for<'a> Deserialize<'a>;
-
-    const PATH: &'static str;
-
-    fn send(
-        self,
-        client: &Client,
-    ) -> impl Future<Output = Result<Self::Data, Error<Infallible>>> + Send {
-        async move {
-            let response = client
-                .post(Self::PATH)
-                .map_err(Error::Request)?
-                .json(&self)
-                .send()
-                .await
-                .context("Failed to send request")
-                .map_err(Error::Transport)?;
-            let status = response.status();
-            let text = response.text().await;
-
-            if cfg!(debug_assertions) {
-                if let Ok(text) = text.as_deref() {
-                    trace!("Received {status}: {text}");
-                }
-            }
-
-            from_response(status, text).map_err(Error::Decode)
-        }
-    }
-}
-
-/// Like [`JsonRpcHttp`], but panics during development if `T` does not encode all information in
-/// the response. This helps ensure that the Rust types can be used as documentation of what the API
-/// actually returns.
-pub trait JsonRpcHttpLossless: JsonRpcHttp {
-    type Data: for<'a> Deserialize<'a> + Serialize;
-
-    fn send_lossless(
-        self,
-        client: &(impl HttpClient + Sync),
-    ) -> impl Future<Output = anyhow::Result<<Self as JsonRpcHttpLossless>::Data>> + Send {
-        async move {
-            let body = serde_json::to_string_pretty(&self)?;
-            let request = Request::json(Method::POST, Self::PATH.to_string()).body(body);
-            let response = client.execute(request).await?;
-            from_response_lossless(response.status, response.body)
-        }
-    }
+pub async fn send_request<Req, Resp>(
+    client: &(impl HttpClient + Sync),
+    path: &str,
+    request: &Req,
+) -> Result<Resp, Error<Infallible>>
+where
+    Req: Serialize,
+    Resp: for<'a> Deserialize<'a> + Serialize,
+{
+    let body = serde_json::to_string_pretty(request).map_err(|e| Error::Request(e.into()))?;
+    let request = Request::json(Method::POST, path.to_string()).body(body);
+    let response = client.execute(request).await.map_err(Error::Transport)?;
+    from_response(response.status, response.body).map_err(Error::Decode)
 }

--- a/crates/vapix/src/lib.rs
+++ b/crates/vapix/src/lib.rs
@@ -5,7 +5,7 @@ mod client;
 mod config;
 pub mod http;
 pub mod json_rpc;
-pub mod json_rpc_http;
+pub(crate) mod json_rpc_http;
 pub mod rest;
 pub mod rest_http;
 pub mod rest_http2;

--- a/crates/vapix/tests/cassette_tests.rs
+++ b/crates/vapix/tests/cassette_tests.rs
@@ -18,7 +18,6 @@ use rs4a_vapix::{
     cassette::{Cassette, CassetteClient, Mode},
     firmware_management_1::UpgradeRequest,
     http,
-    json_rpc_http::{JsonRpcHttp, JsonRpcHttpLossless},
     parameter_management::{ImageResolution, ListRequest},
     remote_object_storage_1_beta::{
         AzureDestination, CreateDestinationRequest, DeleteDestinationRequest, DestinationData,
@@ -570,7 +569,7 @@ fn main() {
 
 async fn basic_device_info_get_all_properties(client: CassetteClient, _: Option<Prelude>) {
     let property_list = basic_device_info_1::get_all_properties()
-        .send_lossless(&client)
+        .send(&client)
         .await
         .unwrap()
         .property_list;
@@ -583,7 +582,7 @@ async fn basic_device_info_get_all_unrestricted_properties(
     _: Option<Prelude>,
 ) {
     let property_list = basic_device_info_1::get_all_unrestricted_properties()
-        .send_lossless(&client)
+        .send(&client)
         .await
         .unwrap()
         .property_list;
@@ -874,7 +873,7 @@ async fn siren_and_light_2_alpha_maintenance_mode_not_supported(
 
 async fn system_ready_1_system_ready(client: CassetteClient, _prelude: Option<Prelude>) {
     let data = apis::system_ready_1::system_ready()
-        .send_lossless(&client)
+        .send(&client)
         .await
         .unwrap();
     assert!(data.systemready);

--- a/crates/vapix/tests/smoke_tests.rs
+++ b/crates/vapix/tests/smoke_tests.rs
@@ -4,7 +4,6 @@ use log::LevelFilter;
 use rs4a_vapix::{
     action1::Condition,
     apis,
-    json_rpc_http::JsonRpcHttp,
     remote_object_storage_1_beta::{CreateDestinationRequest, DestinationId, S3Destination},
     rest_http::RestHttp,
     rest_http2::RestHttp2,


### PR DESCRIPTION
This improves the interface in the following ways:
- Users do not need to import a trait to get access to the `send` method.
- Users do not need to choose between the normal send and the lossless-checking send.
- The JSON RPC facilities don't use a trait which makes them easier to use and more consistent.
- The request builders can each decide if they are lossless instead of pushing this decision onto the user.

One potential downside is that users can no longer opt out of the lossless checking when running with debug assertions. If the need to do so resurfaces I plan to control it with a feature rather than a separate method.