### PR TITLE
fix(vapix)!: Remove default variants in firmware management

### DIFF
--- a/crates/device-manager/src/commands/restore.rs
+++ b/crates/device-manager/src/commands/restore.rs
@@ -1,10 +1,7 @@
 use std::time::Duration;
 
 use log::{debug, info};
-use rs4a_vapix::{
-    firmware_management_1::{FactoryDefaultMode, FactoryDefaultRequest},
-    system_ready_1,
-};
+use rs4a_vapix::{firmware_management_1::FactoryDefaultRequest, system_ready_1};
 use tokio::time::timeout;
 
 use crate::{restart_detector::RestartDetector, Netloc};
@@ -35,9 +32,7 @@ pub async fn restore(netloc: &Netloc) -> anyhow::Result<()> {
     let restart_detector = RestartDetector::try_new(&client).await?;
 
     info!("Sending factory default request");
-    FactoryDefaultRequest::new(FactoryDefaultMode::Soft)
-        .send(&client)
-        .await?;
+    FactoryDefaultRequest::new().send(&client).await?;
 
     info!("Waiting for restart");
     let () = timeout(Duration::from_secs(120), restart_detector.wait()).await?;

--- a/crates/device-manager/src/commands/upgrade.rs
+++ b/crates/device-manager/src/commands/upgrade.rs
@@ -12,7 +12,6 @@ use crate::{restart_detector::RestartDetector, Netloc};
 fn parse_auto_rollback(s: &str) -> anyhow::Result<AutoRollback> {
     match s {
         "never" => Ok(AutoRollback::Never),
-        "default" => Ok(AutoRollback::Default),
         other => {
             let minutes: u32 = other.parse().with_context(|| {
                 format!("expected 'never', 'default', or a number of minutes, got '{other}'")
@@ -29,19 +28,23 @@ pub struct UpgradeCommand {
     /// Path to the firmware image
     firmware: PathBuf,
     /// Factory default mode to apply during upgrade
-    #[arg(long, short, default_value_t = FactoryDefaultMode::None)]
-    factory_default_mode: FactoryDefaultMode,
+    #[arg(long, short = 'm')]
+    factory_default_mode: Option<FactoryDefaultMode>,
     /// Auto-commit behavior after upgrade
-    #[arg(long, short='c', default_value_t = AutoCommit::Default)]
-    auto_commit: AutoCommit,
-    /// Auto-rollback behavior: "never", "default", or minutes
-    #[arg(long, short = 'r', default_value = "default")]
-    auto_rollback: String,
+    #[arg(long, short = 'c')]
+    auto_commit: Option<AutoCommit>,
+    /// Auto-rollback behavior: "never", or minutes
+    #[arg(long, short = 'r')]
+    auto_rollback: Option<String>,
 }
 
 impl UpgradeCommand {
     pub async fn exec(self) -> anyhow::Result<()> {
-        let auto_rollback = parse_auto_rollback(&self.auto_rollback)?;
+        let auto_rollback = self
+            .auto_rollback
+            .as_deref()
+            .map(parse_auto_rollback)
+            .transpose()?;
 
         info!("Reading firmware from {:?}", self.firmware);
         let firmware = tokio::fs::read(&self.firmware)
@@ -54,12 +57,17 @@ impl UpgradeCommand {
         let restart_detector = RestartDetector::try_new(&client).await?;
 
         info!("Sending upgrade request");
-        let data = UpgradeRequest::new(firmware)
-            .factory_default_mode(self.factory_default_mode)
-            .auto_commit(self.auto_commit)
-            .auto_rollback(auto_rollback)
-            .send(&client)
-            .await?;
+        let mut request = UpgradeRequest::new(firmware);
+        if let Some(mode) = self.factory_default_mode {
+            request = request.factory_default_mode(mode);
+        }
+        if let Some(auto_commit) = self.auto_commit {
+            request = request.auto_commit(auto_commit);
+        }
+        if let Some(auto_rollback) = auto_rollback {
+            request = request.auto_rollback(auto_rollback);
+        }
+        let data = request.send(&client).await?;
 
         info!(
             "Upgrade accepted, firmware version: {}",

--- a/crates/vapix/src/axis_cgi/firmware_management_1.rs
+++ b/crates/vapix/src/axis_cgi/firmware_management_1.rs
@@ -22,7 +22,6 @@ const PATH: &str = "axis-cgi/firmwaremanagement.cgi";
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub enum FactoryDefaultMode {
-    None,
     Soft,
     Hard,
 }
@@ -30,7 +29,6 @@ pub enum FactoryDefaultMode {
 impl Display for FactoryDefaultMode {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::None => write!(f, "none"),
             Self::Soft => write!(f, "soft"),
             Self::Hard => write!(f, "hard"),
         }
@@ -55,14 +53,19 @@ pub struct FactoryDefaultRequest {
 }
 
 impl FactoryDefaultRequest {
-    pub fn new(mode: FactoryDefaultMode) -> Self {
+    pub fn new() -> Self {
         Self {
             api_version: "1.0",
             method: "factoryDefault",
             params: FactoryDefaultParams {
-                factory_default_mode: mode,
+                factory_default_mode: FactoryDefaultMode::Soft,
             },
         }
+    }
+
+    pub fn hard(mut self) -> Self {
+        self.params.factory_default_mode = FactoryDefaultMode::Hard;
+        self
     }
 
     pub async fn send(
@@ -73,6 +76,12 @@ impl FactoryDefaultRequest {
     }
 }
 
+impl Default for FactoryDefaultRequest {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 #[cfg_attr(feature = "clap", derive(clap::ValueEnum))]
 #[derive(Clone, Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -80,7 +89,6 @@ pub enum AutoCommit {
     Never,
     Boot,
     Started,
-    Default,
 }
 
 impl Display for AutoCommit {
@@ -89,7 +97,6 @@ impl Display for AutoCommit {
             Self::Never => write!(f, "never"),
             Self::Boot => write!(f, "boot"),
             Self::Started => write!(f, "started"),
-            Self::Default => write!(f, "default"),
         }
     }
 }
@@ -98,7 +105,6 @@ impl Display for AutoCommit {
 pub enum AutoRollback {
     Never,
     Minutes(u32),
-    Default,
 }
 
 impl Serialize for AutoRollback {
@@ -106,7 +112,6 @@ impl Serialize for AutoRollback {
         match self {
             Self::Never => serializer.serialize_str("never"),
             Self::Minutes(m) => serializer.serialize_str(&m.to_string()),
-            Self::Default => serializer.serialize_str("default"),
         }
     }
 }
@@ -228,8 +233,8 @@ mod tests {
     #[test]
     fn upgrade_request_json_envelope() {
         let request = UpgradeRequest::new(Vec::new())
-            .factory_default_mode(FactoryDefaultMode::None)
-            .auto_commit(AutoCommit::Default)
+            .factory_default_mode(FactoryDefaultMode::Soft)
+            .auto_commit(AutoCommit::Never)
             .auto_rollback(AutoRollback::Minutes(15));
         let json = serde_json::to_string_pretty(&request.json).unwrap();
         expect![[r#"
@@ -237,8 +242,8 @@ mod tests {
               "apiVersion": "1.0",
               "method": "upgrade",
               "params": {
-                "factoryDefaultMode": "none",
-                "autoCommit": "default",
+                "factoryDefaultMode": "soft",
+                "autoCommit": "never",
                 "autoRollback": "15"
               }
             }"#]]

--- a/snapshots/device-manager-docs
+++ b/snapshots/device-manager-docs
@@ -86,11 +86,11 @@ Options:
           The username to use for authentication [env: AXIS_DEVICE_USER=] [default: root]
   -p, --pass <PASS>
           The password to use for authentication [env: AXIS_DEVICE_PASS=] [default: pass]
-  -f, --factory-default-mode <FACTORY_DEFAULT_MODE>
-          Factory default mode to apply during upgrade [default: none] [possible values: none, soft, hard]
+  -m, --factory-default-mode <FACTORY_DEFAULT_MODE>
+          Factory default mode to apply during upgrade [possible values: soft, hard]
   -c, --auto-commit <AUTO_COMMIT>
-          Auto-commit behavior after upgrade [default: default] [possible values: never, boot, started, default]
+          Auto-commit behavior after upgrade [possible values: never, boot, started]
   -r, --auto-rollback <AUTO_ROLLBACK>
-          Auto-rollback behavior: "never", "default", or minutes [default: default]
+          Auto-rollback behavior: "never", or minutes
   -h, --help
           Print help


### PR DESCRIPTION
This was prompted by me discovering that `none` is not a valid option for the `factoryDefault` method according to the documentation.

Encode the mode for upgrades as an `Option` instead of a separate enum because this makes sense semantically (factory default mode none means settings are preserved i.e. no factory default is performed) and it results in a smaller API surface.

Since the enums are never included in the response from the server we don't need to be able to represent any of the default options and since their name don't provide any information I thought they may as well be removed.

---

`crates/vapix/src/axis_cgi/firmware_management_1.rs`:
- Since the API defaults to soft, it makes sense for the bindings to do the same for the sake of ergonomics.
- Since there is only one variant besides the default the setter is called `hard` instead of `mode` to make calling code more concise.

`crates/device-manager/src/commands/upgrade.rs`:
- Since the other options have a short form based on the last word because the first word would conflict, using the last word also for the mode makes some sense. This also makes decreases the risk that it will be interpre
    ted as meaning "firmware".