### PR TITLE
fix(vapix): Add preview mode to system ready 1

### DIFF
--- a/crates/vapix/src/axis_cgi/system_ready_1.rs
+++ b/crates/vapix/src/axis_cgi/system_ready_1.rs
@@ -52,6 +52,8 @@ pub struct SystemreadyData {
     pub uptime: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub bootid: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub previewmode: Option<String>,
     /// New in 1.5
     #[serde(skip_serializing_if = "Option::is_none")]
     pub passphrasepolicy: Option<String>,
@@ -64,6 +66,17 @@ impl SystemreadyData {
         self.uptime
             .as_deref()
             .map(|s| s.parse::<u64>().map(Duration::from_secs))
+            .transpose()
+    }
+
+    pub fn parse_preview_mode(&self) -> Result<Option<Duration>, std::num::ParseIntError> {
+        self.previewmode
+            .as_deref()
+            .map(|s| {
+                s.parse::<u64>()
+                    .map(Duration::from_secs)
+                    .map_err(Into::into)
+            })
             .transpose()
     }
 }

--- a/crates/vapix/tests/serde.rs
+++ b/crates/vapix/tests/serde.rs
@@ -1,3 +1,5 @@
+use std::time::Duration;
+
 use expect_test::expect_file;
 use rs4a_vapix::{
     action1::{AddActionConfigurationResponse, Condition},
@@ -49,6 +51,16 @@ fn can_deserialize_system_ready_1_examples() {
     let text = include_str!("../src/axis_cgi/system_ready_1/system_ready_200.json");
     let data = parse_data::<SystemreadyData>(text).unwrap();
     assert!(!data.needsetup);
+}
+
+#[test]
+fn can_deserialize_system_ready_1_preview_mode() {
+    let text = include_str!("serde/system_ready_1_preview_mode.json");
+    let data = parse_data::<SystemreadyData>(text).unwrap();
+    assert_eq!(
+        data.parse_preview_mode().unwrap(),
+        Some(Duration::from_secs(7200))
+    );
 }
 
 #[test]

--- a/crates/vapix/tests/serde/system_ready_1_preview_mode.json
+++ b/crates/vapix/tests/serde/system_ready_1_preview_mode.json
@@ -1,0 +1,11 @@
+{
+  "apiVersion": "1.4",
+  "method": "systemready",
+  "data": {
+    "systemready": "yes",
+    "needsetup": "yes",
+    "uptime": "106",
+    "bootid": "7a156260-6967-4e71-87bb-04eb9652a083",
+    "previewmode": "7200"
+  }
+}


### PR DESCRIPTION
After switching all code to use the lossless checking path I noticed that this was missing when running `device-manager reinit`.

`crates/vapix/tests/serde.rs`:
- Since this is difficult to reproduce automatically a manually recorded example is added (technically reproducing it is easy, but reversing the effect of a reset is tedious which makes it difficult to make a cassette test out of it). The example was recorded on P8815-2@11.11.192.