### PR TITLE
feat(vapix)!: Add missing fields in add recording group response

### DIFF
--- a/crates/vapix/src/config/recording_group_1.rs
+++ b/crates/vapix/src/config/recording_group_1.rs
@@ -11,8 +11,48 @@ use crate::{
 };
 
 #[derive(Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct CreateRecordingGroupResponse {
     pub id: String,
+    pub container_format: String,
+    pub description: String,
+    pub destinations: Vec<Destination>,
+    pub max_retention_time: u64,
+    pub nice_name: String,
+    pub post_duration: u64,
+    pub pre_duration: u64,
+    pub segment_duration: SegmentDuration,
+    pub segment_size: SegmentSize,
+    pub span_duration: u64,
+    pub stream_options: String,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Destination {
+    pub remote_object_storage: RemoteObjectStorage,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RemoteObjectStorage {
+    pub id: String,
+    #[serde(default)]
+    pub prefix: String,
+    #[serde(default)]
+    pub postfix: String,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct SegmentDuration {
+    pub max: u64,
+    pub target: u64,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct SegmentSize {
+    pub max: u64,
+    pub target: u64,
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
The smoke tests have started failing because the response deserialization is not lossless. This is probably a regression in 622fa9dbd70547b54b4befc348af71eab0e72a58 which caused all config requests to take the lossless checking path.