### PR TITLE
feat(vapix)!: Remove `SoapHttp*` traits

### DIFF
--- a/crates/vapix/src/http.rs
+++ b/crates/vapix/src/http.rs
@@ -49,6 +49,15 @@ impl Request {
         }
     }
 
+    pub fn application_soap_xml(method: Method, path: String) -> Self {
+        Self {
+            method,
+            path,
+            body: None,
+            content_type: Some("application/soap+xml; charset=utf-8".to_string()),
+        }
+    }
+
     pub fn multipart_form_data(method: Method, path: String, boundary: &str) -> Self {
         Self {
             method,

--- a/crates/vapix/src/services/action1.rs
+++ b/crates/vapix/src/services/action1.rs
@@ -4,14 +4,15 @@
 mod action_configurations;
 mod action_rules;
 
-pub use action_configurations::{AddActionConfigurationResponse, GetActionConfigurationsResponse};
-pub use action_rules::{AddActionRuleResponse, Condition, GetActionRulesResponse};
+pub use action_configurations::{
+    AddActionConfigurationResponse, GetActionConfigurationsRequest, GetActionConfigurationsResponse,
+};
+pub use action_rules::{
+    AddActionRuleResponse, Condition, GetActionRulesRequest, GetActionRulesResponse,
+};
 
-use crate::{
-    action1::{
-        action_configurations::AddActionConfigurationRequest, action_rules::AddActionRuleRequest,
-    },
-    soap::SimpleRequest,
+use crate::action1::{
+    action_configurations::AddActionConfigurationRequest, action_rules::AddActionRuleRequest,
 };
 
 pub fn add_action_configuration(template_token: &str) -> AddActionConfigurationRequest {
@@ -22,13 +23,10 @@ pub fn add_action_rule(name: String, primary_action: u16) -> AddActionRuleReques
     AddActionRuleRequest::new(name, primary_action)
 }
 
-pub fn get_action_configurations() -> SimpleRequest<GetActionConfigurationsResponse> {
-    SimpleRequest::new(
-        "http://www.axis.com/vapix/ws/action1",
-        "GetActionConfigurations",
-    )
+pub fn get_action_configurations() -> GetActionConfigurationsRequest {
+    GetActionConfigurationsRequest
 }
 
-pub fn get_action_rules() -> SimpleRequest<GetActionRulesResponse> {
-    SimpleRequest::new("http://www.axis.com/vapix/ws/action1", "GetActionRules")
+pub fn get_action_rules() -> GetActionRulesRequest {
+    GetActionRulesRequest
 }

--- a/crates/vapix/src/services/action1/action_configurations.rs
+++ b/crates/vapix/src/services/action1/action_configurations.rs
@@ -1,9 +1,15 @@
+use std::convert::Infallible;
+
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    soap::SimpleRequest,
-    soap_http::{SoapHttpRequest, SoapRequest},
+    http::{Error, HttpClient, Request},
+    soap, soap_http,
 };
+
+const PATH: &str = "vapix/services";
+
+const NAMESPACE: &str = "http://www.axis.com/vapix/ws/action1";
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "PascalCase")]
@@ -42,10 +48,8 @@ impl AddActionConfigurationRequest {
         });
         self
     }
-}
 
-impl SoapRequest for AddActionConfigurationRequest {
-    fn to_envelope(self) -> anyhow::Result<String> {
+    fn build_params(self) -> anyhow::Result<String> {
         let Self {
             name,
             template_token,
@@ -63,17 +67,26 @@ impl SoapRequest for AddActionConfigurationRequest {
         params.push_str(r#"</TemplateToken>"#);
         params.push_str(&quick_xml::se::to_string(&parameters)?);
         params.push_str(r#"</NewActionConfiguration>"#);
-        SimpleRequest::<()>::new(
-            "http://www.axis.com/vapix/ws/action1",
-            "AddActionConfiguration",
-        )
-        .params(params)
-        .to_envelope()
+        Ok(params)
     }
-}
 
-impl SoapHttpRequest for AddActionConfigurationRequest {
-    type Data = AddActionConfigurationResponse;
+    pub fn try_into_envelope(self) -> anyhow::Result<String> {
+        Ok(soap::envelope(
+            NAMESPACE,
+            "AddActionConfiguration",
+            Some(&self.build_params()?),
+        ))
+    }
+
+    pub async fn send(
+        self,
+        client: &(impl HttpClient + Sync),
+    ) -> Result<AddActionConfigurationResponse, Error<Infallible>> {
+        let envelope = self.try_into_envelope().map_err(Error::Request)?;
+        let request =
+            Request::application_soap_xml(reqwest::Method::POST, PATH.to_string()).body(envelope);
+        soap_http::send_request(client, request).await
+    }
 }
 
 #[derive(Debug, Deserialize)]
@@ -112,6 +125,24 @@ pub struct Parameter {
 
     #[serde(rename = "@Value")]
     pub value: String,
+}
+
+#[derive(Debug)]
+pub struct GetActionConfigurationsRequest;
+
+impl GetActionConfigurationsRequest {
+    pub fn into_envelope(self) -> String {
+        soap::envelope(NAMESPACE, "GetActionConfigurations", None)
+    }
+
+    pub async fn send(
+        self,
+        client: &(impl HttpClient + Sync),
+    ) -> Result<GetActionConfigurationsResponse, Error<Infallible>> {
+        let request = Request::application_soap_xml(reqwest::Method::POST, PATH.to_string())
+            .body(self.into_envelope());
+        soap_http::send_request(client, request).await
+    }
 }
 
 #[cfg(test)]

--- a/crates/vapix/src/services/action1/action_rules.rs
+++ b/crates/vapix/src/services/action1/action_rules.rs
@@ -1,9 +1,15 @@
+use std::convert::Infallible;
+
 use serde::Deserialize;
 
 use crate::{
-    soap::SimpleRequest,
-    soap_http::{SoapHttpRequest, SoapRequest},
+    http::{Error, HttpClient, Request},
+    soap, soap_http,
 };
+
+const PATH: &str = "vapix/services";
+
+const NAMESPACE: &str = "http://www.axis.com/vapix/ws/action1";
 
 pub struct AddActionRuleRequest {
     pub name: String,
@@ -33,10 +39,8 @@ impl AddActionRuleRequest {
         self.conditions.condition.push(condition);
         self
     }
-}
 
-impl SoapRequest for AddActionRuleRequest {
-    fn to_envelope(self) -> anyhow::Result<String> {
+    pub fn into_envelope(self) -> String {
         let Self {
             name,
             enabled,
@@ -71,14 +75,17 @@ impl SoapRequest for AddActionRuleRequest {
         params.push_str(&primary_action.to_string());
         params.push_str(r#"</PrimaryAction>"#);
         params.push_str(r#"</NewActionRule>"#);
-        SimpleRequest::<()>::new("http://www.axis.com/vapix/ws/action1", "AddActionRule")
-            .params(params)
-            .to_envelope()
+        soap::envelope(NAMESPACE, "AddActionRule", Some(&params))
     }
-}
 
-impl SoapHttpRequest for AddActionRuleRequest {
-    type Data = AddActionRuleResponse;
+    pub async fn send(
+        self,
+        client: &(impl HttpClient + Sync),
+    ) -> Result<AddActionRuleResponse, Error<Infallible>> {
+        let request = Request::application_soap_xml(reqwest::Method::POST, PATH.to_string())
+            .body(self.into_envelope());
+        soap_http::send_request(client, request).await
+    }
 }
 
 #[derive(Debug, Deserialize)]
@@ -124,6 +131,24 @@ pub struct ActionRules {
 #[serde(rename_all = "PascalCase")]
 pub struct GetActionRulesResponse {
     pub action_rules: ActionRules,
+}
+
+#[derive(Debug)]
+pub struct GetActionRulesRequest;
+
+impl GetActionRulesRequest {
+    pub fn into_envelope(self) -> String {
+        soap::envelope(NAMESPACE, "GetActionRules", None)
+    }
+
+    pub async fn send(
+        self,
+        client: &(impl HttpClient + Sync),
+    ) -> Result<GetActionRulesResponse, Error<Infallible>> {
+        let request = Request::application_soap_xml(reqwest::Method::POST, PATH.to_string())
+            .body(self.into_envelope());
+        soap_http::send_request(client, request).await
+    }
 }
 
 #[cfg(test)]

--- a/crates/vapix/src/services/event1.rs
+++ b/crates/vapix/src/services/event1.rs
@@ -2,9 +2,17 @@
 //!
 //! [event service API]: https://developer.axis.com/vapix/network-video/event-and-action-services
 
+use std::convert::Infallible;
+
 use quick_xml::{events::Event, Reader};
 
-use crate::{soap::SimpleRequest, soap_http::SoapResponse};
+use crate::{
+    http::{Error, HttpClient, Request},
+    soap, soap_http,
+    soap_http::SoapResponse,
+};
+
+const PATH: &str = "vapix/services";
 
 #[derive(Debug)]
 pub struct MessageInstance {
@@ -51,6 +59,28 @@ impl SoapResponse for EventInstances {
     }
 }
 
-pub fn get_event_instances() -> SimpleRequest<EventInstances> {
-    SimpleRequest::new("http://www.axis.com/vapix/ws/event1", "GetEventInstances")
+#[derive(Debug)]
+pub struct GetEventInstancesRequest;
+
+impl GetEventInstancesRequest {
+    pub fn into_envelope(self) -> String {
+        soap::envelope(
+            "http://www.axis.com/vapix/ws/event1",
+            "GetEventInstances",
+            None,
+        )
+    }
+
+    pub async fn send(
+        self,
+        client: &(impl HttpClient + Sync),
+    ) -> Result<EventInstances, Error<Infallible>> {
+        let request = Request::application_soap_xml(reqwest::Method::POST, PATH.to_string())
+            .body(self.into_envelope());
+        soap_http::send_request(client, request).await
+    }
+}
+
+pub fn get_event_instances() -> GetEventInstancesRequest {
+    GetEventInstancesRequest
 }

--- a/crates/vapix/src/soap.rs
+++ b/crates/vapix/src/soap.rs
@@ -1,10 +1,7 @@
 //! Utilities for working with SOAP style APIs.
-use std::marker::PhantomData;
 
 use anyhow::Context;
 use serde::{Deserialize, Serialize};
-
-use crate::soap_http::SoapRequest;
 
 #[derive(Deserialize, Serialize, PartialEq, Debug)]
 #[serde(rename_all = "PascalCase")]
@@ -28,56 +25,24 @@ where
     Ok(inner)
 }
 
-pub struct SimpleRequest<T> {
-    namespace: &'static str,
-    method: &'static str,
-    params: Option<String>,
-    _phantom: PhantomData<T>,
-}
-
-impl<T> SimpleRequest<T> {
-    pub fn new(namespace: &'static str, method: &'static str) -> Self {
-        Self {
-            namespace,
-            method,
-            params: None,
-            _phantom: PhantomData,
-        }
-    }
-
-    pub fn params(mut self, params: String) -> Self {
-        self.params = Some(params);
-        self
-    }
-}
-
-impl<T> SoapRequest for SimpleRequest<T> {
-    fn to_envelope(self) -> anyhow::Result<String> {
-        let Self {
-            namespace,
-            method,
-            params,
-            _phantom,
-        } = self;
-        let mut s = String::new();
-        s.push_str(r#"<soap:Envelope xmlns:soap="http://www.w3.org/2003/05/soap-envelope">"#);
-        s.push_str(r#"<soap:Body>"#);
-
-        s.push('<');
+pub fn envelope(namespace: &str, method: &str, params: Option<&str>) -> String {
+    let mut s = String::new();
+    s.push_str(r#"<soap:Envelope xmlns:soap="http://www.w3.org/2003/05/soap-envelope">"#);
+    s.push_str(r#"<soap:Body>"#);
+    s.push('<');
+    s.push_str(method);
+    s.push_str(r#" xmlns=""#);
+    s.push_str(namespace);
+    if let Some(params) = params {
+        s.push_str(r#"">"#);
+        s.push_str(params);
+        s.push_str(r#"</"#);
         s.push_str(method);
-        s.push_str(r#" xmlns=""#);
-        s.push_str(namespace);
-        if let Some(params) = params.as_deref() {
-            s.push_str(r#"">"#);
-            s.push_str(params);
-            s.push_str(r#"</"#);
-            s.push_str(method);
-            s.push('>');
-        } else {
-            s.push_str(r#""/>"#);
-        }
-        s.push_str(r#"</soap:Body>"#);
-        s.push_str(r#"</soap:Envelope>"#);
-        Ok(s)
+        s.push('>');
+    } else {
+        s.push_str(r#""/>"#);
     }
+    s.push_str(r#"</soap:Body>"#);
+    s.push_str(r#"</soap:Envelope>"#);
+    s
 }

--- a/crates/vapix/src/soap_http.rs
+++ b/crates/vapix/src/soap_http.rs
@@ -1,63 +1,15 @@
 //! Utilities for working with SOAP style APIs over HTTP.
 
-use std::{convert::Infallible, future::Future};
+use std::convert::Infallible;
 
 use anyhow::Context;
-use log::{trace, warn};
+use log::warn;
 use serde::Deserialize;
 
 use crate::{
-    http::Error,
-    soap::{parse_soap, SimpleRequest},
-    Client,
+    http::{Error, HttpClient, Request},
+    soap::parse_soap,
 };
-
-const PATH: &str = "vapix/services";
-
-pub trait SoapHttpRequest: SoapRequest + Send + Sized {
-    type Data: SoapResponse;
-
-    fn send(
-        self,
-        client: &Client,
-    ) -> impl Future<Output = Result<Self::Data, Error<Infallible>>> + Send {
-        async move {
-            let body = self.to_envelope().map_err(Error::Request)?;
-            if cfg!(debug_assertions) {
-                trace!("Sending to {PATH}: {body}");
-            }
-            let response = client
-                .post(PATH)
-                .map_err(Error::Request)?
-                .header("Content-Type", "application/soap+xml; charset=utf-8")
-                .body(body)
-                .send()
-                .await
-                .context("Failed to send request")
-                .map_err(Error::Transport)?;
-            let status = response.status();
-            let text = response
-                .text()
-                .await
-                .context(status)
-                .map_err(Error::Transport)?;
-            if cfg!(debug_assertions) {
-                trace!("Received {status}: {text}");
-            }
-            let result = Self::Data::from_envelope(&text)
-                .context(status)
-                .map_err(Error::Decode);
-            if status.is_success() != result.is_ok() {
-                warn!("HTTP status {status} does not match SOAP response");
-            }
-            result
-        }
-    }
-}
-
-pub trait SoapRequest {
-    fn to_envelope(self) -> anyhow::Result<String>;
-}
 
 pub trait SoapResponse: Sized {
     fn from_envelope(s: &str) -> anyhow::Result<Self>;
@@ -72,9 +24,18 @@ where
     }
 }
 
-impl<T> SoapHttpRequest for SimpleRequest<T>
-where
-    T: SoapResponse + Send + Sized,
-{
-    type Data = T;
+pub(crate) async fn send_request<T: SoapResponse>(
+    client: &(impl HttpClient + Sync),
+    request: Request,
+) -> Result<T, Error<Infallible>> {
+    let response = client.execute(request).await.map_err(Error::Transport)?;
+    let status = response.status;
+    let text = response.body.context(status).map_err(Error::Transport)?;
+    let result = T::from_envelope(&text)
+        .context(status)
+        .map_err(Error::Decode);
+    if status.is_success() != result.is_ok() {
+        warn!("HTTP status {status} does not match SOAP response");
+    }
+    result
 }

--- a/crates/vapix/tests/serde.rs
+++ b/crates/vapix/tests/serde.rs
@@ -8,7 +8,6 @@ use rs4a_vapix::{
     firmware_management_1::UpgradeData,
     json_rpc::{parse_data, parse_data_lossless},
     soap::parse_soap,
-    soap_http::SoapRequest,
     system_ready_1::SystemreadyData,
 };
 
@@ -72,7 +71,7 @@ fn can_serialize_action_1_requests() {
             .param("color", "green,none")
             .param("duration", "1")
             .param("interval", "250")
-            .to_envelope()
+            .try_into_envelope()
             .unwrap(),
     );
     expect_file!["./snapshots/add_action_rule.xml"].assert_eq(
@@ -82,14 +81,10 @@ fn can_serialize_action_1_requests() {
                 message_content: r#"boolean(//SimpleItem[@Name="ready" and @Value="1"])"#
                     .to_string(),
             })
-            .to_envelope()
-            .unwrap(),
+            .into_envelope(),
     );
-    expect_file!["./snapshots/get_action_configurations.xml"].assert_eq(
-        &apis::action_1::get_action_configurations()
-            .to_envelope()
-            .unwrap(),
-    );
+    expect_file!["./snapshots/get_action_configurations.xml"]
+        .assert_eq(&apis::action_1::get_action_configurations().into_envelope());
     expect_file!["./snapshots/get_action_rules.xml"]
-        .assert_eq(&apis::action_1::get_action_rules().to_envelope().unwrap());
+        .assert_eq(&apis::action_1::get_action_rules().into_envelope());
 }

--- a/crates/vapix/tests/smoke_tests.rs
+++ b/crates/vapix/tests/smoke_tests.rs
@@ -5,7 +5,6 @@ use rs4a_vapix::{
     action1::Condition,
     apis,
     remote_object_storage_1_beta::{CreateDestinationRequest, DestinationId, S3Destination},
-    soap_http::SoapHttpRequest,
     Client, ClientBuilder,
 };
 use serde_json::json;


### PR DESCRIPTION
The summary line of this commit is a little bit misleading since the main objective of these changes is to route all request building through the new `HttpClient` trait such that they can be used in cassette tests. I lost sight of this when writing commit messages for the corresponding commits for JSON RPC and REST style API bindings and I keep the inaccurate title here to signal that the three commits are related.

Rather than rewriting the existing traits to work with the new trait I take this opportunity to remove them since I haven't been entirely happy with them. I can think of two reasons:
1. Having to import multiple traits to access the `send` method makes for a confusing API - the only reason it works is that my IDE can usually figure out what I want once I have written out the entire function name.
2. It creates a kind of non-linear / monotonic implementation that I find is more difficult to follow.