### PR TITLE
fix(vapix)!: Set content type on Request with body

### DIFF
--- a/crates/vapix/src/axis_cgi/applications_config.rs
+++ b/crates/vapix/src/axis_cgi/applications_config.rs
@@ -52,7 +52,7 @@ impl ApplicationConfigRequest {
             None => format!("{PATH}?action=set&name={name}"),
             Some(value) => format!("{PATH}?action=set&name={name}&value={value}"),
         };
-        Request::no_content(Method::GET, path)
+        Request::new(Method::GET, path)
     }
 
     // TODO: Implement lossless self-checks

--- a/crates/vapix/src/axis_cgi/firmware_management_1.rs
+++ b/crates/vapix/src/axis_cgi/firmware_management_1.rs
@@ -211,8 +211,7 @@ impl UpgradeRequest {
 
         let body = Self::build_multipart_body(json.as_bytes(), &self.bin, boundary);
 
-        let request =
-            Request::multipart_form_data(Method::POST, PATH.to_string(), boundary).body_bytes(body);
+        let request = Request::new(Method::POST, PATH.to_string()).multipart(body, boundary);
 
         let response = client.execute(request).await.map_err(Error::Transport)?;
 

--- a/crates/vapix/src/axis_cgi/parameter_management.rs
+++ b/crates/vapix/src/axis_cgi/parameter_management.rs
@@ -105,7 +105,7 @@ impl ListRequest {
     pub async fn send(self, client: &impl HttpClient) -> anyhow::Result<ParamList> {
         let path = format!("{PATH}?action=list&group={}", self.group);
         let response = client
-            .execute(Request::no_content(Method::GET, path))
+            .execute(Request::new(Method::GET, path))
             .await
             .context("sending param.cgi request")?;
 

--- a/crates/vapix/src/axis_cgi/pwdgrp.rs
+++ b/crates/vapix/src/axis_cgi/pwdgrp.rs
@@ -70,7 +70,7 @@ impl AddUserRequest {
     fn into_request(self) -> Request {
         let group = self.group.to_string();
         let role = self.role.to_string();
-        Request::no_content(
+        Request::new(
             Method::GET,
             format!(
                 "{PATH}?action=add&user={}&pwd={}&grp={}&sgrp={}",

--- a/crates/vapix/src/config/recording_group_1.rs
+++ b/crates/vapix/src/config/recording_group_1.rs
@@ -68,11 +68,11 @@ impl CreateRecordingGroupsRequest {
 
     pub fn into_request(self) -> Request {
         let body = serde_json::to_string_pretty(&json!({"data": self.data})).unwrap();
-        Request::json(
+        Request::new(
             Method::POST,
             "config/rest/recording-group/v2beta/recordingGroups".to_string(),
         )
-        .body(body)
+        .json(body)
     }
 
     pub async fn send(

--- a/crates/vapix/src/config/remote_object_storage_1_beta.rs
+++ b/crates/vapix/src/config/remote_object_storage_1_beta.rs
@@ -142,8 +142,8 @@ impl CreateDestinationRequest {
     pub fn into_request(self) -> Request {
         // PANICS:
         // The `unwrap` will never panic because `self.data` can always be serialized to JSON.
-        Request::json(Method::POST, BASE_PATH.to_string())
-            .body(serde_json::to_string_pretty(&json!({"data":self.data})).unwrap())
+        Request::new(Method::POST, BASE_PATH.to_string())
+            .json(serde_json::to_string_pretty(&json!({"data":self.data})).unwrap())
     }
 
     pub async fn send(
@@ -163,7 +163,7 @@ impl ListDestinationsRequest {
     }
 
     pub fn into_request(self) -> Request {
-        Request::no_content(Method::GET, BASE_PATH.to_string())
+        Request::new(Method::GET, BASE_PATH.to_string())
     }
 
     pub async fn send(
@@ -202,11 +202,11 @@ impl UpdateDestinationRequest {
         // PANICS:
         // The `unwrap` will never panic because `self.data` is a `serde_json::Value` which can
         // always be serialized to JSON.
-        Request::json(
+        Request::new(
             Method::PATCH,
             format!("{BASE_PATH}/{}/{}", self.id.into_string(), self.property),
         )
-        .body(serde_json::to_string_pretty(&json!({"data":self.data})).unwrap())
+        .json(serde_json::to_string_pretty(&json!({"data":self.data})).unwrap())
     }
 
     pub async fn send(self, client: &(impl HttpClient + Sync)) -> Result<(), Error<rest::Error>> {
@@ -225,7 +225,7 @@ impl DeleteDestinationRequest {
     }
 
     pub fn into_request(self) -> Request {
-        Request::no_content(
+        Request::new(
             Method::DELETE,
             format!("{BASE_PATH}/{}", self.id.into_string()),
         )

--- a/crates/vapix/src/config/siren_and_light_2_alpha.rs
+++ b/crates/vapix/src/config/siren_and_light_2_alpha.rs
@@ -41,7 +41,7 @@ impl GetMaintenanceModeRequest {
     }
 
     pub fn into_request(self) -> Request {
-        Request::no_content(Method::GET, format!("{BASE_PATH}/maintenanceMode"))
+        Request::new(Method::GET, format!("{BASE_PATH}/maintenanceMode"))
     }
 
     pub async fn send(
@@ -67,8 +67,8 @@ impl StartMaintenanceModeRequest {
     pub fn into_request(self) -> Request {
         // PANICS:
         // The `unwrap` will never panic because `self.data` can always be serialized to JSON.
-        Request::json(Method::POST, format!("{BASE_PATH}/maintenanceMode/start"))
-            .body(serde_json::to_string_pretty(&json!({"data": self.data})).unwrap())
+        Request::new(Method::POST, format!("{BASE_PATH}/maintenanceMode/start"))
+            .json(serde_json::to_string_pretty(&json!({"data": self.data})).unwrap())
     }
 
     pub async fn send(
@@ -90,8 +90,8 @@ impl StopMaintenanceModeRequest {
     pub fn into_request(self) -> Request {
         // PANICS:
         // The `unwrap` will never panic because the body is a static JSON value.
-        Request::json(Method::POST, format!("{BASE_PATH}/maintenanceMode/stop"))
-            .body(serde_json::to_string_pretty(&json!({"data": {}})).unwrap())
+        Request::new(Method::POST, format!("{BASE_PATH}/maintenanceMode/stop"))
+            .json(serde_json::to_string_pretty(&json!({"data": {}})).unwrap())
     }
 
     pub async fn send(

--- a/crates/vapix/src/config/ssh_1.rs
+++ b/crates/vapix/src/config/ssh_1.rs
@@ -31,7 +31,7 @@ impl AddUserRequest {
 
     pub fn into_request(self) -> Request {
         let body = serde_json::to_string_pretty(&json!({"data": self})).unwrap();
-        Request::json(Method::POST, "config/rest/ssh/v1/users".to_string()).body(body)
+        Request::new(Method::POST, "config/rest/ssh/v1/users".to_string()).json(body)
     }
 
     pub async fn send(
@@ -94,7 +94,7 @@ impl SetUserRequest {
         } = self;
         let path = format!("config/rest/ssh/v1/users/{username}");
         let body = serde_json::to_string_pretty(&json!({"data": properties})).unwrap();
-        Request::json(Method::PATCH, path).body(body)
+        Request::new(Method::PATCH, path).json(body)
     }
 
     pub async fn send(
@@ -114,7 +114,7 @@ pub struct DeleteUserRequest {
 
 impl DeleteUserRequest {
     pub fn into_request(self) -> Request {
-        Request::no_content(
+        Request::new(
             Method::DELETE,
             format!("config/rest/ssh/v1/users/{}", self.username),
         )

--- a/crates/vapix/src/http.rs
+++ b/crates/vapix/src/http.rs
@@ -40,34 +40,7 @@ pub struct Request {
 }
 
 impl Request {
-    pub fn json(method: Method, path: String) -> Self {
-        Self {
-            method,
-            path,
-            body: None,
-            content_type: Some("application/json".to_string()),
-        }
-    }
-
-    pub fn application_soap_xml(method: Method, path: String) -> Self {
-        Self {
-            method,
-            path,
-            body: None,
-            content_type: Some("application/soap+xml; charset=utf-8".to_string()),
-        }
-    }
-
-    pub fn multipart_form_data(method: Method, path: String, boundary: &str) -> Self {
-        Self {
-            method,
-            path,
-            body: None,
-            content_type: Some(format!("multipart/form-data; boundary={boundary}")),
-        }
-    }
-
-    pub fn no_content(method: Method, path: String) -> Self {
+    pub fn new(method: Method, path: String) -> Self {
         Self {
             method,
             path,
@@ -76,12 +49,20 @@ impl Request {
         }
     }
 
-    pub fn body(mut self, body: String) -> Self {
+    pub fn json(mut self, body: String) -> Self {
+        self.content_type = Some("application/json".to_string());
         self.body = Some(body.into_bytes());
         self
     }
 
-    pub fn body_bytes(mut self, body: Vec<u8>) -> Self {
+    pub fn soap(mut self, body: String) -> Self {
+        self.content_type = Some("application/soap+xml; charset=utf-8".to_string());
+        self.body = Some(body.into_bytes());
+        self
+    }
+
+    pub fn multipart(mut self, body: Vec<u8>, boundary: &str) -> Self {
+        self.content_type = Some(format!("multipart/form-data; boundary={boundary}"));
         self.body = Some(body);
         self
     }

--- a/crates/vapix/src/json_rpc_http.rs
+++ b/crates/vapix/src/json_rpc_http.rs
@@ -29,7 +29,7 @@ where
     Resp: for<'a> Deserialize<'a> + Serialize,
 {
     let body = serde_json::to_string_pretty(request).map_err(|e| Error::Request(e.into()))?;
-    let request = Request::json(Method::POST, path.to_string()).body(body);
+    let request = Request::new(Method::POST, path.to_string()).json(body);
     let response = client.execute(request).await.map_err(Error::Transport)?;
     from_response(response.status, response.body).map_err(Error::Decode)
 }

--- a/crates/vapix/src/services/action1/action_configurations.rs
+++ b/crates/vapix/src/services/action1/action_configurations.rs
@@ -83,8 +83,7 @@ impl AddActionConfigurationRequest {
         client: &(impl HttpClient + Sync),
     ) -> Result<AddActionConfigurationResponse, Error<Infallible>> {
         let envelope = self.try_into_envelope().map_err(Error::Request)?;
-        let request =
-            Request::application_soap_xml(reqwest::Method::POST, PATH.to_string()).body(envelope);
+        let request = Request::new(reqwest::Method::POST, PATH.to_string()).soap(envelope);
         soap_http::send_request(client, request).await
     }
 }
@@ -139,8 +138,8 @@ impl GetActionConfigurationsRequest {
         self,
         client: &(impl HttpClient + Sync),
     ) -> Result<GetActionConfigurationsResponse, Error<Infallible>> {
-        let request = Request::application_soap_xml(reqwest::Method::POST, PATH.to_string())
-            .body(self.into_envelope());
+        let request =
+            Request::new(reqwest::Method::POST, PATH.to_string()).soap(self.into_envelope());
         soap_http::send_request(client, request).await
     }
 }

--- a/crates/vapix/src/services/action1/action_rules.rs
+++ b/crates/vapix/src/services/action1/action_rules.rs
@@ -82,8 +82,8 @@ impl AddActionRuleRequest {
         self,
         client: &(impl HttpClient + Sync),
     ) -> Result<AddActionRuleResponse, Error<Infallible>> {
-        let request = Request::application_soap_xml(reqwest::Method::POST, PATH.to_string())
-            .body(self.into_envelope());
+        let request =
+            Request::new(reqwest::Method::POST, PATH.to_string()).soap(self.into_envelope());
         soap_http::send_request(client, request).await
     }
 }
@@ -145,8 +145,8 @@ impl GetActionRulesRequest {
         self,
         client: &(impl HttpClient + Sync),
     ) -> Result<GetActionRulesResponse, Error<Infallible>> {
-        let request = Request::application_soap_xml(reqwest::Method::POST, PATH.to_string())
-            .body(self.into_envelope());
+        let request =
+            Request::new(reqwest::Method::POST, PATH.to_string()).soap(self.into_envelope());
         soap_http::send_request(client, request).await
     }
 }

--- a/crates/vapix/src/services/event1.rs
+++ b/crates/vapix/src/services/event1.rs
@@ -75,8 +75,8 @@ impl GetEventInstancesRequest {
         self,
         client: &(impl HttpClient + Sync),
     ) -> Result<EventInstances, Error<Infallible>> {
-        let request = Request::application_soap_xml(reqwest::Method::POST, PATH.to_string())
-            .body(self.into_envelope());
+        let request =
+            Request::new(reqwest::Method::POST, PATH.to_string()).soap(self.into_envelope());
         soap_http::send_request(client, request).await
     }
 }


### PR DESCRIPTION
The content type specific constructors were introduced after I discovered I had forgotten to set the content type on some Requests which caused problems on AXIS OS 11 [^1]. The current implementation is good because it documents the intent and makes mistakes easier to spot, but it doesn't structurally prevent mistakes. Changing so that the content type is decided when setting the body structurally prevents mistakes while making the API no bigger or more complex.

[^1]: 919ca3c3d7151778899d877e6d58c86d4a6c4e55