### PR TITLE
feat(vapix)!: Use the `HttpClient` trait in parameter management

### DIFF
--- a/crates/vapix/src/axis_cgi/jpg_3.rs
+++ b/crates/vapix/src/axis_cgi/jpg_3.rs
@@ -32,6 +32,7 @@ impl Request {
 }
 
 impl Request {
+    // TODO: Migrate to `HttpClient` when cassette tests support binary responses.
     pub async fn send(self, client: &Client) -> anyhow::Result<Vec<u8>> {
         let Self {
             resolution,

--- a/crates/vapix/src/axis_cgi/parameter_management.rs
+++ b/crates/vapix/src/axis_cgi/parameter_management.rs
@@ -5,12 +5,9 @@
 use std::{collections::HashMap, fmt, fmt::Debug};
 
 use anyhow::{bail, Context};
-use reqwest::{Method, StatusCode};
+use reqwest::Method;
 
-use crate::{
-    http::{HttpClient, Request},
-    Client,
-};
+use crate::http::{HttpClient, Request};
 
 const PATH: &str = "axis-cgi/param.cgi";
 
@@ -18,6 +15,14 @@ fn bool2str(b: bool) -> &'static str {
     match b {
         true => "yes",
         false => "no",
+    }
+}
+
+fn str2bool(s: &str) -> anyhow::Result<bool> {
+    match s {
+        "yes" => Ok(true),
+        "no" => Ok(false),
+        other => bail!("expected 'yes' or 'no', got '{other}'"),
     }
 }
 
@@ -73,6 +78,17 @@ impl Parameter for ImageResolution {
     }
 }
 
+pub struct NetworkSshEnabled;
+
+impl Parameter for NetworkSshEnabled {
+    type Value = bool;
+    const KEY: &'static str = "root.Network.SSH.Enabled";
+    fn parse(raw: &str) -> anyhow::Result<bool> {
+        str2bool(raw)
+    }
+}
+
+// TODO: Implement lossless checking
 /// The response from a parameter list request.
 #[derive(Clone, Debug)]
 pub struct ParamList(HashMap<String, String>);
@@ -134,24 +150,26 @@ impl UpdateRequest {
         self
     }
 
-    pub async fn send(self, client: &Client) -> anyhow::Result<()> {
-        let mut query: Vec<(&str, &str)> = vec![("action", "update")];
+    pub async fn send(self, client: &(impl HttpClient + Sync)) -> anyhow::Result<()> {
+        let mut path = format!("{PATH}?action=update");
         for (k, v) in &self.parameters {
-            query.push((k, v));
+            path.push('&');
+            path.push_str(k);
+            path.push('=');
+            path.push_str(v);
         }
-        let response = client.get(PATH)?.query(&query).send().await?;
-        let status = response.status();
-        let text = response
-            .text()
+        let response = client
+            .execute(Request::new(Method::GET, path))
             .await
-            .with_context(|| format!("status code: {status}"))?;
+            .context("sending param.cgi update request")?;
+        let text = response.body.context("reading param.cgi update response")?;
 
-        if status == StatusCode::OK && text.trim() == "OK" {
+        if response.status.is_success() && text.trim() == "OK" {
             Ok(())
         } else if let Some(e) = text.trim().strip_prefix("# Error: ") {
             bail!("{e}")
         } else {
-            bail!("Unexpected response: {status} {text}")
+            bail!("Unexpected response: {} {text}", response.status)
         }
     }
 }

--- a/crates/vapix/tests/cassette_tests.rs
+++ b/crates/vapix/tests/cassette_tests.rs
@@ -18,7 +18,7 @@ use rs4a_vapix::{
     cassette::{Cassette, CassetteClient, Mode},
     firmware_management_1::UpgradeRequest,
     http,
-    parameter_management::{ImageResolution, ListRequest},
+    parameter_management::{ImageResolution, ListRequest, NetworkSshEnabled, UpdateRequest},
     remote_object_storage_1_beta::{
         AzureDestination, CreateDestinationRequest, DeleteDestinationRequest, DestinationData,
         DestinationId, ListDestinationsRequest, UpdateDestinationRequest,
@@ -375,6 +375,7 @@ cassette_tests! {
     firmware_management_1_upgrade_mismatch,
     parameter_management_list_error,
     parameter_management_list_image_resolution,
+    parameter_management_update_network_ssh_enabled,
     remote_object_storage_1_beta_crud,
     siren_and_light_2_alpha_maintenance_mode_not_supported,
     ssh_1_crud,
@@ -760,6 +761,42 @@ async fn parameter_management_list_image_resolution(
         .unwrap();
     let resolutions = params.parse::<ImageResolution>().unwrap().unwrap();
     assert!(!resolutions.is_empty());
+}
+
+async fn parameter_management_update_network_ssh_enabled(
+    client: CassetteClient,
+    _prelude: Option<Prelude>,
+) {
+    let read = || {
+        let client = &client;
+        async move {
+            ListRequest::new::<NetworkSshEnabled>()
+                .send(client)
+                .await
+                .unwrap()
+                .parse::<NetworkSshEnabled>()
+                .unwrap()
+                .unwrap()
+        }
+    };
+
+    let initial = read().await;
+
+    UpdateRequest::default()
+        .network_ssh_enabled(!initial)
+        .send(&client)
+        .await
+        .unwrap();
+
+    assert_eq!(read().await, !initial);
+
+    UpdateRequest::default()
+        .network_ssh_enabled(initial)
+        .send(&client)
+        .await
+        .unwrap();
+
+    assert_eq!(read().await, initial);
 }
 
 async fn remote_object_storage_1_beta_crud(client: CassetteClient, prelude: Option<Prelude>) {


### PR DESCRIPTION
The main objective is to make them compatible with cassette tests which we exploit straight away by adding a new cassette test exercising the functionality.