### PR TITLE
feat(vapix): Add API Discovery service bindings

### DIFF
--- a/crates/device-manager/src/commands/upgrade.rs
+++ b/crates/device-manager/src/commands/upgrade.rs
@@ -14,7 +14,7 @@ fn parse_auto_rollback(s: &str) -> anyhow::Result<AutoRollback> {
         "never" => Ok(AutoRollback::Never),
         other => {
             let minutes: u32 = other.parse().with_context(|| {
-                format!("expected 'never', 'default', or a number of minutes, got '{other}'")
+                format!("expected 'never' or a number of minutes, got '{other}'")
             })?;
             Ok(AutoRollback::Minutes(minutes))
         }

--- a/crates/vapix/src/apis.rs
+++ b/crates/vapix/src/apis.rs
@@ -1,3 +1,7 @@
+pub mod api_discovery_1 {
+    pub use crate::api_discovery_1::{GetApiListRequest, GetSupportedVersionsRequest};
+}
+
 pub mod applications_config {
     pub use crate::applications_config::ApplicationConfigRequest;
 }

--- a/crates/vapix/src/axis_cgi.rs
+++ b/crates/vapix/src/axis_cgi.rs
@@ -1,4 +1,5 @@
 //! A collection of APIs that can be found under the `/axis-cgi/` path.
+pub mod api_discovery_1;
 pub mod applications_config;
 pub mod basic_device_info_1;
 pub mod firmware_management_1;

--- a/crates/vapix/src/axis_cgi/api_discovery_1.rs
+++ b/crates/vapix/src/axis_cgi/api_discovery_1.rs
@@ -1,0 +1,130 @@
+//! The [API Discovery] service.
+//!
+//! [API Discovery]: https://developer.axis.com/vapix/network-video/api-discovery-service/
+
+use std::convert::Infallible;
+
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    http::{Error, HttpClient},
+    json_rpc_http,
+};
+
+#[non_exhaustive]
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ApiListData {
+    pub api_list: Vec<Api>,
+}
+
+#[non_exhaustive]
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Api {
+    pub id: String,
+    pub version: String,
+    pub name: String,
+    pub doc_link: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub status: Option<String>,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GetApiListRequest {
+    api_version: &'static str,
+    method: &'static str,
+}
+
+impl Default for GetApiListRequest {
+    fn default() -> Self {
+        Self {
+            api_version: "1.0",
+            method: "getApiList",
+        }
+    }
+}
+
+const PATH: &str = "axis-cgi/apidiscovery.cgi";
+
+impl GetApiListRequest {
+    pub async fn send(
+        self,
+        client: &(impl HttpClient + Sync),
+    ) -> Result<ApiListData, Error<Infallible>> {
+        json_rpc_http::send_request(client, PATH, &self).await
+    }
+}
+
+#[non_exhaustive]
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SupportedVersionsData {
+    pub api_versions: Vec<String>,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GetSupportedVersionsRequest {
+    method: &'static str,
+}
+
+impl Default for GetSupportedVersionsRequest {
+    fn default() -> Self {
+        Self {
+            method: "getSupportedVersions",
+        }
+    }
+}
+
+impl GetSupportedVersionsRequest {
+    pub async fn send(
+        self,
+        client: &(impl HttpClient + Sync),
+    ) -> Result<SupportedVersionsData, Error<Infallible>> {
+        json_rpc_http::send_request(client, PATH, &self).await
+    }
+}
+
+impl Api {
+    pub fn parse_version(&self) -> Result<semver::Version, semver::Error> {
+        // API versions are typically major.minor; coerce to semver by appending .0
+        let v = &self.version;
+        let semver_str = match v.matches('.').count() {
+            1 => format!("{v}.0"),
+            _ => v.clone(),
+        };
+        semver::Version::parse(&semver_str)
+    }
+
+    pub fn parse_status(&self) -> Result<Option<ApiStatus>, anyhow::Error> {
+        self.status
+            .as_deref()
+            .map(|s| s.parse::<ApiStatus>())
+            .transpose()
+    }
+}
+
+#[non_exhaustive]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ApiStatus {
+    Official,
+    Alpha,
+    Beta,
+    Deprecated,
+}
+
+impl std::str::FromStr for ApiStatus {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "official" => Ok(Self::Official),
+            "alpha" => Ok(Self::Alpha),
+            "beta" => Ok(Self::Beta),
+            "deprecated" => Ok(Self::Deprecated),
+            _ => Err(anyhow::anyhow!("unrecognized API status '{s}'")),
+        }
+    }
+}

--- a/crates/vapix/src/lib.rs
+++ b/crates/vapix/src/lib.rs
@@ -12,8 +12,8 @@ pub mod soap;
 pub mod soap_http;
 
 pub use axis_cgi::{
-    applications_config, basic_device_info_1, firmware_management_1, parameter_management, pwdgrp,
-    system_ready_1,
+    api_discovery_1, applications_config, basic_device_info_1, firmware_management_1,
+    parameter_management, pwdgrp, system_ready_1,
 };
 pub use client::{Client, ClientBuilder, Scheme};
 pub use config::{recording_group_1, remote_object_storage_1_beta, siren_and_light_2_alpha, ssh_1};

--- a/crates/vapix/tests/cassette_tests.rs
+++ b/crates/vapix/tests/cassette_tests.rs
@@ -4,6 +4,7 @@ use libtest_mimic::{Arguments, Trial};
 use log::{warn, LevelFilter};
 use rs4a_cassette_testing::{Cassette, CassetteClient, DeviceInfo, Library};
 use rs4a_vapix::{
+    api_discovery_1::Api,
     apis,
     apis::basic_device_info_1,
     basic_device_info_1::{ProductType, UnrestrictedProperties},
@@ -22,7 +23,6 @@ use rs4a_vapix::{
 };
 use semver::VersionReq;
 use url::Url;
-
 // When a test fails, it may leave resources intact that will cause future runs to fail.
 // This must be cleaned up manually by either removing them individually or resetting the device.
 // This is tedious, but hopefully updating cassettes will be rare.
@@ -109,6 +109,8 @@ macro_rules! cassette_tests {
 }
 
 cassette_tests! {
+    api_discovery_1_get_api_list,
+    api_discovery_1_get_supported_versions,
     basic_device_info_get_all_properties => [
         (
             r#""SocSerialNumber": "[0-9A-F]{8}-[0-9A-F]{8}-[0-9A-F]{8}-[0-9A-F]{8}""#,
@@ -266,6 +268,32 @@ fn main() {
         library.cleanup_unreferenced().unwrap();
     }
     conclusion.exit();
+}
+
+async fn api_discovery_1_get_api_list(client: &CassetteClient, _: Option<Prelude>) {
+    use rs4a_vapix::api_discovery_1::GetApiListRequest;
+
+    let data = GetApiListRequest::default().send(client).await.unwrap();
+    let Api { .. } = data
+        .api_list
+        .iter()
+        .find(|a| a.id == "api-discovery" && a.parse_version().unwrap().major == 1)
+        .expect("api-discovery should be in its own list");
+
+    for api in &data.api_list {
+        api.parse_version().unwrap();
+        api.parse_status().unwrap();
+    }
+}
+
+async fn api_discovery_1_get_supported_versions(client: &CassetteClient, _: Option<Prelude>) {
+    use rs4a_vapix::api_discovery_1::GetSupportedVersionsRequest;
+
+    let data = GetSupportedVersionsRequest::default()
+        .send(client)
+        .await
+        .unwrap();
+    assert!(!data.api_versions.is_empty());
 }
 
 async fn basic_device_info_get_all_properties(client: &CassetteClient, _: Option<Prelude>) {


### PR DESCRIPTION
Prompted by me wanting to compare the available APIs on different devices. Follows the same patterns as other recent additions to the collection of VAPIX API bindings.