### PR TITLE
feat(vapix): Add API bindings for device configuration discovery

### DIFF
--- a/crates/vapix/Cargo.toml
+++ b/crates/vapix/Cargo.toml
@@ -15,7 +15,7 @@ serde = { workspace = true, features = ["derive"] }
 base64 = { workspace = true }
 quick-xml = { workspace = true, features = ["serialize"] }
 rs4a-dut = { workspace = true }
-semver = { workspace = true }
+semver = { workspace = true, features = ["serde"] }
 serde_json = { workspace = true, features = ["raw_value"] }
 thiserror = { workspace = true }
 tokio = { workspace = true }

--- a/crates/vapix/src/apis.rs
+++ b/crates/vapix/src/apis.rs
@@ -2,6 +2,10 @@ pub mod api_discovery_1 {
     pub use crate::api_discovery_1::{GetApiListRequest, GetSupportedVersionsRequest};
 }
 
+pub mod discover {
+    pub use crate::discover::DiscoverRequest;
+}
+
 pub mod applications_config {
     pub use crate::applications_config::ApplicationConfigRequest;
 }

--- a/crates/vapix/src/config.rs
+++ b/crates/vapix/src/config.rs
@@ -1,3 +1,4 @@
+pub mod discover;
 pub mod recording_group_1;
 pub mod remote_object_storage_1_beta;
 pub mod siren_and_light_2_alpha;

--- a/crates/vapix/src/config/discover.rs
+++ b/crates/vapix/src/config/discover.rs
@@ -1,0 +1,118 @@
+//! The [Device Configuration Discovery] API.
+//!
+//! [Device Configuration Discovery]: https://developer.axis.com/vapix/device-configuration/device-configuration-apis/#discovery
+
+use std::collections::HashMap;
+
+use anyhow::Context;
+use reqwest::Method;
+use semver::Version;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use crate::http::{Error, HttpClient, Request};
+
+const PATH: &str = "config/discover";
+
+#[non_exhaustive]
+#[derive(Debug, Deserialize, Serialize)]
+pub struct DiscoverData {
+    pub framework_version: Version,
+    pub apis: HashMap<String, HashMap<String, ApiVersionInfo>>,
+    pub device: DeviceInfo,
+}
+
+#[non_exhaustive]
+#[derive(Debug, Deserialize, Serialize)]
+pub struct DeviceInfo {
+    pub rest_openapi: String,
+    pub rest_ui: String,
+}
+
+#[non_exhaustive]
+#[derive(Debug, Deserialize, Serialize)]
+pub struct ApiVersionInfo {
+    pub state: String,
+    pub version: Version,
+    pub doc: String,
+    pub doc_html: String,
+    pub model: String,
+    pub rest_api: String,
+    pub rest_openapi: String,
+    pub rest_ui: String,
+}
+
+impl ApiVersionInfo {
+    pub fn parse_state(&self) -> Result<ApiState, anyhow::Error> {
+        self.state.parse()
+    }
+}
+
+#[non_exhaustive]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ApiState {
+    Alpha,
+    Beta,
+    Released,
+}
+
+impl std::fmt::Display for ApiState {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Alpha => write!(f, "alpha"),
+            Self::Beta => write!(f, "beta"),
+            Self::Released => write!(f, "released"),
+        }
+    }
+}
+
+impl std::str::FromStr for ApiState {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "alpha" => Ok(Self::Alpha),
+            "beta" => Ok(Self::Beta),
+            "released" => Ok(Self::Released),
+            _ => Err(anyhow::anyhow!("unrecognized API state '{s}'")),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct DiscoverRequest;
+
+impl Default for DiscoverRequest {
+    fn default() -> Self {
+        Self
+    }
+}
+
+fn parse_lossless<T>(text: &str) -> anyhow::Result<T>
+where
+    T: for<'de> Deserialize<'de> + Serialize,
+{
+    let data: T = serde_json::from_str(text).context("parsing response")?;
+    if cfg!(debug_assertions) {
+        let expected: Value =
+            serde_json::from_str(text).expect("already deserialized successfully");
+        let actual: Value = serde_json::from_str(&serde_json::to_string(&data)?)?;
+        debug_assert_eq!(actual, expected);
+    }
+    Ok(data)
+}
+
+impl DiscoverRequest {
+    pub async fn send(
+        self,
+        client: &(impl HttpClient + Sync),
+    ) -> Result<DiscoverData, Error<std::convert::Infallible>> {
+        let request = Request::new(Method::GET, PATH.to_string());
+        let response = client.execute(request).await.map_err(Error::Transport)?;
+        let text = response
+            .body
+            .context("reading discover response")
+            .map_err(Error::Decode)?;
+        parse_lossless(&text).map_err(Error::Decode)
+    }
+}

--- a/crates/vapix/src/lib.rs
+++ b/crates/vapix/src/lib.rs
@@ -16,5 +16,7 @@ pub use axis_cgi::{
     parameter_management, pwdgrp, system_ready_1,
 };
 pub use client::{Client, ClientBuilder, Scheme};
-pub use config::{recording_group_1, remote_object_storage_1_beta, siren_and_light_2_alpha, ssh_1};
+pub use config::{
+    discover, recording_group_1, remote_object_storage_1_beta, siren_and_light_2_alpha, ssh_1,
+};
 pub use services::{action1, event1};

--- a/crates/vapix/tests/cassette_tests.rs
+++ b/crates/vapix/tests/cassette_tests.rs
@@ -8,6 +8,7 @@ use rs4a_vapix::{
     apis,
     apis::basic_device_info_1,
     basic_device_info_1::{ProductType, UnrestrictedProperties},
+    discover::ApiState,
     firmware_management_1::UpgradeRequest,
     http,
     parameter_management::{ImageResolution, ListRequest, NetworkSshEnabled, UpdateRequest},
@@ -131,6 +132,7 @@ cassette_tests! {
             r#""SerialNumber": "0123456789AB""#,
         ),
     ],
+    device_configuration_discover,
     device_configuration_item_does_not_exist,
     device_configuration_validation_error,
     device_configuration_item_already_exists,
@@ -318,6 +320,34 @@ async fn basic_device_info_get_all_unrestricted_properties(
 
     property_list.parse_product_type().unwrap();
     property_list.parse_version().unwrap();
+}
+
+async fn device_configuration_discover(client: &CassetteClient, prelude: Option<Prelude>) {
+    use rs4a_vapix::discover::DiscoverRequest;
+
+    if let Some(prelude) = prelude {
+        if !prelude.supports_device_config() {
+            return;
+        }
+    }
+
+    let data = DiscoverRequest.send(client).await.unwrap();
+    assert!(!data.apis.is_empty());
+
+    for versions in data.apis.values() {
+        for info in versions.values() {
+            let pre = info.version.pre.as_str();
+            let state = info.parse_state().unwrap();
+
+            match state {
+                ApiState::Alpha | ApiState::Beta => {
+                    assert!(pre.starts_with(state.to_string().as_str()))
+                }
+                ApiState::Released => assert!(pre.is_empty()),
+                _ => todo!("{state:?}"),
+            }
+        }
+    }
 }
 
 async fn device_configuration_item_does_not_exist(


### PR DESCRIPTION
`crates/vapix/src/config/discover.rs`:
- Version is parsed eagerly because this provides stronger guarantees to the user and I am virtually certain that these strings will always be a valid semantic version.