### PR TITLE
feat(dm): Expose Cli as a library

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -548,20 +548,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "device-manager"
-version = "0.1.0"
-dependencies = [
- "anyhow",
- "clap",
- "log",
- "rs4a-bin-utils",
- "rs4a-vapix",
- "semver",
- "tokio",
- "url",
-]
-
-[[package]]
 name = "dirs"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1805,6 +1791,20 @@ dependencies = [
  "rs4a-vapix",
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "rs4a-device-manager"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "clap",
+ "log",
+ "rs4a-bin-utils",
+ "rs4a-vapix",
+ "semver",
+ "tokio",
+ "url",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ rs4a-bin-utils = {path = "crates/bin-utils" }
 rs4a-dut = { version = "0.1", path = "crates/dut" }
 rs4a-vapix = { path = "crates/vapix" }
 rs4a-cassette-testing = { path = "crates/cassette-testing" }
+rs4a-device-manager = { path = "crates/device-manager" }
 rs4a-vlt = { path = "crates/vlt" }
 
 [workspace.package]

--- a/crates/device-manager/Cargo.toml
+++ b/crates/device-manager/Cargo.toml
@@ -1,8 +1,12 @@
 [package]
-name = "device-manager"
+name = "rs4a-device-manager"
 version = "0.1.0"
 edition.workspace = true
 license = "MIT"
+
+[[bin]]
+name = "device-manager"
+path = "src/main.rs"
 
 [dependencies]
 anyhow = { workspace = true }

--- a/crates/device-manager/src/commands/init.rs
+++ b/crates/device-manager/src/commands/init.rs
@@ -11,13 +11,14 @@ use crate::Netloc;
 #[derive(Clone, Debug, clap::Args)]
 pub struct InitCommand {
     #[command(flatten)]
-    netloc: Netloc,
+    pub netloc: Netloc,
 }
 
 impl InitCommand {
-    pub async fn exec(self) -> anyhow::Result<()> {
+    pub async fn exec(self) -> anyhow::Result<String> {
         require_root_user(&self.netloc)?;
-        initialize(&self.netloc).await
+        initialize(&self.netloc).await?;
+        Ok(String::new())
     }
 }
 

--- a/crates/device-manager/src/commands/reinit.rs
+++ b/crates/device-manager/src/commands/reinit.rs
@@ -3,14 +3,14 @@ use crate::Netloc;
 #[derive(Clone, Debug, clap::Args)]
 pub struct ReinitCommand {
     #[command(flatten)]
-    netloc: Netloc,
+    pub netloc: Netloc,
 }
 
 impl ReinitCommand {
-    pub async fn exec(self) -> anyhow::Result<()> {
+    pub async fn exec(self) -> anyhow::Result<String> {
         super::init::require_root_user(&self.netloc)?;
         super::restore::restore(&self.netloc).await?;
         super::init::initialize(&self.netloc).await?;
-        Ok(())
+        Ok(String::new())
     }
 }

--- a/crates/device-manager/src/commands/restore.rs
+++ b/crates/device-manager/src/commands/restore.rs
@@ -9,12 +9,13 @@ use crate::{restart_detector::RestartDetector, Netloc};
 #[derive(Clone, Debug, clap::Args)]
 pub struct RestoreCommand {
     #[command(flatten)]
-    netloc: Netloc,
+    pub netloc: Netloc,
 }
 
 impl RestoreCommand {
-    pub async fn exec(self) -> anyhow::Result<()> {
-        restore(&self.netloc).await
+    pub async fn exec(self) -> anyhow::Result<String> {
+        restore(&self.netloc).await?;
+        Ok(String::new())
     }
 }
 

--- a/crates/device-manager/src/commands/upgrade.rs
+++ b/crates/device-manager/src/commands/upgrade.rs
@@ -24,22 +24,22 @@ fn parse_auto_rollback(s: &str) -> anyhow::Result<AutoRollback> {
 #[derive(Clone, Debug, clap::Args)]
 pub struct UpgradeCommand {
     #[command(flatten)]
-    netloc: Netloc,
+    pub netloc: Netloc,
     /// Path to the firmware image
-    firmware: PathBuf,
+    pub firmware: PathBuf,
     /// Factory default mode to apply during upgrade
     #[arg(long, short = 'm')]
-    factory_default_mode: Option<FactoryDefaultMode>,
+    pub factory_default_mode: Option<FactoryDefaultMode>,
     /// Auto-commit behavior after upgrade
     #[arg(long, short = 'c')]
-    auto_commit: Option<AutoCommit>,
+    pub auto_commit: Option<AutoCommit>,
     /// Auto-rollback behavior: "never", or minutes
     #[arg(long, short = 'r')]
-    auto_rollback: Option<String>,
+    pub auto_rollback: Option<String>,
 }
 
 impl UpgradeCommand {
-    pub async fn exec(self) -> anyhow::Result<()> {
+    pub async fn exec(self) -> anyhow::Result<String> {
         let auto_rollback = self
             .auto_rollback
             .as_deref()
@@ -78,6 +78,6 @@ impl UpgradeCommand {
         let () = timeout(Duration::from_secs(300), restart_detector.wait()).await?;
 
         info!("Upgrade complete");
-        Ok(())
+        Ok(String::new())
     }
 }

--- a/crates/device-manager/src/lib.rs
+++ b/crates/device-manager/src/lib.rs
@@ -1,0 +1,90 @@
+#![forbid(unsafe_code)]
+
+pub mod commands;
+mod restart_detector;
+mod ssh_keygen;
+
+use clap::{Parser, Subcommand};
+use rs4a_bin_utils::completions_command::CompletionsCommand;
+use url::Host;
+
+pub use crate::commands::{
+    init::InitCommand, reinit::ReinitCommand, restore::RestoreCommand, upgrade::UpgradeCommand,
+};
+
+#[derive(Clone, Debug, clap::Args)]
+pub struct Netloc {
+    /// Hostname or IP address of the device.
+    #[arg(long, value_parser = url::Host::parse, env = "AXIS_DEVICE_IP")]
+    pub host: Host,
+    /// Override the default port for HTTP.
+    #[arg(long, env = "AXIS_DEVICE_HTTP_PORT")]
+    pub http_port: Option<u16>,
+    /// Override the default port for HTTPS.
+    #[arg(long, env = "AXIS_DEVICE_HTTPS_PORT")]
+    pub https_port: Option<u16>,
+    /// The username to use for authentication.
+    #[arg(short, long, env = "AXIS_DEVICE_USER", default_value = "root")]
+    pub user: String,
+    /// The password to use for authentication.
+    #[arg(short, long, env = "AXIS_DEVICE_PASS", default_value = "pass")]
+    pub pass: String,
+}
+
+impl Netloc {
+    pub async fn connect(&self) -> anyhow::Result<rs4a_vapix::Client> {
+        rs4a_vapix::ClientBuilder::new(self.host.clone())
+            .plain_port(self.http_port)
+            .secure_port(self.https_port)
+            .basic_authentication(&self.user, &self.pass)
+            .with_inner(|b| b.danger_accept_invalid_certs(true))
+            .build_with_automatic_scheme()
+            .await
+    }
+
+    pub async fn connect_anonymous(&self) -> anyhow::Result<rs4a_vapix::Client> {
+        rs4a_vapix::ClientBuilder::new(self.host.clone())
+            .plain_port(self.http_port)
+            .secure_port(self.https_port)
+            .with_inner(|b| b.danger_accept_invalid_certs(true))
+            .build_with_automatic_scheme()
+            .await
+    }
+}
+
+#[derive(Parser)]
+pub struct Cli {
+    #[command(subcommand)]
+    pub command: Commands,
+}
+
+impl Cli {
+    pub async fn exec(self) -> anyhow::Result<String> {
+        match self.command {
+            Commands::Restore(cmd) => cmd.exec().await,
+            Commands::Init(cmd) => cmd.exec().await,
+            Commands::Reinit(cmd) => cmd.exec().await,
+            Commands::Upgrade(cmd) => cmd.exec().await,
+            Commands::Completions(cmd) => {
+                cmd.exec::<Self>()?;
+                Ok(String::new())
+            }
+        }
+    }
+}
+
+#[derive(Subcommand)]
+pub enum Commands {
+    /// Restore the device to a clean state (factory default)
+    Restore(RestoreCommand),
+    /// Initialize a device in setup mode
+    Init(InitCommand),
+    /// Restore and initialize the device to a known, useful state
+    Reinit(ReinitCommand),
+    /// Upgrade the device firmware
+    Upgrade(UpgradeCommand),
+    /// Generate shell completions
+    ///
+    /// Example: `device-manager completions zsh | source /dev/stdin`
+    Completions(CompletionsCommand),
+}

--- a/crates/device-manager/src/main.rs
+++ b/crates/device-manager/src/main.rs
@@ -1,96 +1,14 @@
 #![forbid(unsafe_code)]
 
-mod commands;
-mod restart_detector;
-mod ssh_keygen;
-
-use clap::{Parser, Subcommand};
-use rs4a_bin_utils::completions_command::CompletionsCommand;
-use url::Host;
-
-use crate::commands::{
-    init::InitCommand, reinit::ReinitCommand, restore::RestoreCommand, upgrade::UpgradeCommand,
-};
-
-#[derive(Clone, Debug, clap::Args)]
-pub struct Netloc {
-    /// Hostname or IP address of the device.
-    #[arg(long, value_parser = url::Host::parse, env = "AXIS_DEVICE_IP")]
-    pub host: Host,
-    /// Override the default port for HTTP.
-    #[arg(long, env = "AXIS_DEVICE_HTTP_PORT")]
-    pub http_port: Option<u16>,
-    /// Override the default port for HTTPS.
-    #[arg(long, env = "AXIS_DEVICE_HTTPS_PORT")]
-    pub https_port: Option<u16>,
-    /// The username to use for authentication.
-    #[arg(short, long, env = "AXIS_DEVICE_USER", default_value = "root")]
-    pub user: String,
-    /// The password to use for authentication.
-    #[arg(short, long, env = "AXIS_DEVICE_PASS", default_value = "pass")]
-    pub pass: String,
-}
-
-impl Netloc {
-    pub async fn connect(&self) -> anyhow::Result<rs4a_vapix::Client> {
-        rs4a_vapix::ClientBuilder::new(self.host.clone())
-            .plain_port(self.http_port)
-            .secure_port(self.https_port)
-            .basic_authentication(&self.user, &self.pass)
-            .with_inner(|b| b.danger_accept_invalid_certs(true))
-            .build_with_automatic_scheme()
-            .await
-    }
-
-    pub async fn connect_anonymous(&self) -> anyhow::Result<rs4a_vapix::Client> {
-        rs4a_vapix::ClientBuilder::new(self.host.clone())
-            .plain_port(self.http_port)
-            .secure_port(self.https_port)
-            .with_inner(|b| b.danger_accept_invalid_certs(true))
-            .build_with_automatic_scheme()
-            .await
-    }
-}
-
-#[derive(Parser)]
-struct Cli {
-    #[command(subcommand)]
-    command: Commands,
-}
-
-impl Cli {
-    pub async fn exec(self) -> anyhow::Result<()> {
-        match self.command {
-            Commands::Restore(cmd) => cmd.exec().await?,
-            Commands::Init(cmd) => cmd.exec().await?,
-            Commands::Reinit(cmd) => cmd.exec().await?,
-            Commands::Upgrade(cmd) => cmd.exec().await?,
-            Commands::Completions(cmd) => cmd.exec::<Self>()?,
-        }
-        Ok(())
-    }
-}
-
-#[derive(Subcommand)]
-enum Commands {
-    /// Restore the device to a clean state (factory default)
-    Restore(RestoreCommand),
-    /// Initialize a device in setup mode
-    Init(InitCommand),
-    /// Restore and initialize the device to a known, useful state
-    Reinit(ReinitCommand),
-    /// Upgrade the device firmware
-    Upgrade(UpgradeCommand),
-    /// Generate shell completions
-    ///
-    /// Example: `device-manager completions zsh | source /dev/stdin`
-    Completions(CompletionsCommand),
-}
+use clap::Parser;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     let mut guard = rs4a_bin_utils::logger::init();
-    Cli::parse().exec().await?;
+    let out = rs4a_device_manager::Cli::parse().exec().await?;
+    if !out.is_empty() {
+        print!("{out}");
+    }
     guard.disarm();
     Ok(())
 }

--- a/docs/commit-messages.md
+++ b/docs/commit-messages.md
@@ -9,6 +9,7 @@ Commit messages ...
 |-------|------------------------|--------------------|
 | a     | rs4a-authentication    |                    |
 | di    | device-inventory       | device-inventory   |
+| dm    | device-manager         |                    |
 | dut   | rs4a-dut               |                    |
 | fi    | firmware-inventory     |                    |
 | vapix | rs4a-vapix             | v                  |


### PR DESCRIPTION
This will make it easier to build porcelain programs that combine the functionality of existing programs without creating more code paths that have to be tested and maintained.

---

`docs/commit-messages.md`:
- Register `dm` as a scope because every crate should be on the list .