### PR TITLE
fix(c): Remap product number with empty listing

### DIFF
--- a/crates/cli4a/src/commands/install.rs
+++ b/crates/cli4a/src/commands/install.rs
@@ -56,7 +56,10 @@ impl InstallCommand {
             .await?
             .property_list;
         let current = props.parse_version()?;
-        let model = props.prod_nbr;
+        let model = match props.prod_nbr {
+            s if s == "P8815-2" => "P8815-2_3D_People_Counter".to_string(),
+            s => s,
+        };
         info!("Device model: {model}, version: {current}");
 
         let product = glob::Pattern::new(&model)


### PR DESCRIPTION
P8815-2 appears twice in the FTP listing with different names:
- As `P8815-2` with only _latest_ pointing to 10.6.
- As `P8815-2_3D_People_Counter` which the proper versions.

This causes `cli4a upgrade 11` to fail because it matches the first listing and finds no matching versions.

I discarded some ideas for doing this remapping universally:
- Treating a listing the same as another if one is a prefix of the other fails on Mk II
- Assuming the listing name is derived from the full product name fails on M1075 which ends with _Box Camera_
- Assuming the listing name is derived from the short product name fails on P8815-2 which does not end with _3D People Counter_

I'm not discarding the idea that there is a pattern to the listing, but for now I just want it to work for the models I work with.