### PR TITLE
fix(vapix): Add thermal camera product type

### DIFF
--- a/crates/vapix/src/axis_cgi/basic_device_info_1.rs
+++ b/crates/vapix/src/axis_cgi/basic_device_info_1.rs
@@ -53,6 +53,7 @@ pub enum ProductType {
     NetworkStrobeSpeaker,
     PeopleCounter3D,
     Radar,
+    ThermalCamera,
 }
 
 impl Display for ProductType {
@@ -65,6 +66,7 @@ impl Display for ProductType {
             Self::NetworkStrobeSpeaker => write!(f, "Network Strobe Speaker"),
             Self::PeopleCounter3D => write!(f, "3D People Counter"),
             Self::Radar => write!(f, "Radar"),
+            Self::ThermalCamera => write!(f, "Thermal Camera"),
         }
     }
 }
@@ -81,6 +83,7 @@ impl FromStr for ProductType {
             "Network Strobe Speaker" => Ok(Self::NetworkStrobeSpeaker),
             "3D People Counter" => Ok(Self::PeopleCounter3D),
             "Radar" => Ok(Self::Radar),
+            "Thermal Camera" => Ok(Self::ThermalCamera),
             _ => Err(anyhow!("unrecognized product type '{s}'")),
         }
     }
@@ -169,14 +172,16 @@ pub enum Architecture {
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum SocSerialNumber {
     Plain(u64),
-    Dashed(u128),
+    Dashed64(u64),
+    Dashed128(u128),
 }
 
 impl Display for SocSerialNumber {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::Plain(v) => write!(f, "{v:016X}"),
-            Self::Dashed(v) => write!(
+            Self::Dashed64(v) => write!(f, "{:08X}-{:08X}", (*v >> 32) as u32, *v as u32),
+            Self::Dashed128(v) => write!(
                 f,
                 "{:08X}-{:08X}-{:08X}-{:08X}",
                 (*v >> 96) as u32,
@@ -188,7 +193,7 @@ impl Display for SocSerialNumber {
     }
 }
 
-fn parse_dashed_soc_serial(s: &str) -> anyhow::Result<u128> {
+fn parse_dashed_soc_serial_128(s: &str) -> anyhow::Result<u128> {
     let parts: Vec<&str> = s.split('-').collect();
     if parts.len() != 4 {
         bail!("Expected 4 segments, got {}", parts.len());
@@ -208,6 +213,26 @@ fn parse_dashed_soc_serial(s: &str) -> anyhow::Result<u128> {
     Ok(bits)
 }
 
+fn parse_dashed_soc_serial_64(s: &str) -> anyhow::Result<u64> {
+    let parts: Vec<&str> = s.split('-').collect();
+    if parts.len() != 2 {
+        bail!("Expected 2 segments, got {}", parts.len());
+    }
+    let mut bits: u64 = 0;
+    for (i, part) in parts.iter().enumerate() {
+        if part.len() != 8 {
+            bail!(
+                "Expected each segment to be 8 characters long, but segment {} is {}",
+                i + 1,
+                part.len()
+            );
+        }
+        let segment = u32::from_str_radix(part, 16)?;
+        bits |= (segment as u64) << (32 - i * 32);
+    }
+    Ok(bits)
+}
+
 fn parse_plain_soc_serial(s: &str) -> anyhow::Result<u64> {
     if s.len() != 16 {
         bail!("Expected 16 characters long, got {}", s.len());
@@ -219,10 +244,11 @@ impl FromStr for SocSerialNumber {
     type Err = anyhow::Error;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        if s.contains('-') {
-            Ok(Self::Dashed(parse_dashed_soc_serial(s)?))
-        } else {
-            Ok(Self::Plain(parse_plain_soc_serial(s)?))
+        match s.chars().filter(|c| *c == '-').count() {
+            0 => Ok(Self::Plain(parse_plain_soc_serial(s)?)),
+            1 => Ok(Self::Dashed64(parse_dashed_soc_serial_64(s)?)),
+            3 => Ok(Self::Dashed128(parse_dashed_soc_serial_128(s)?)),
+            n => Err(anyhow!("Expected 1, 2 or 4 segments, got {}", n + 1)),
         }
     }
 }
@@ -346,7 +372,7 @@ mod tests {
                 .unwrap_err()
                 .to_string(),
         );
-        expect!("Expected 4 segments, got 3").assert_eq(
+        expect!("Expected 1, 2 or 4 segments, got 3").assert_eq(
             &SocSerialNumber::from_str("00000000-00000000-0000000000000000")
                 .unwrap_err()
                 .to_string(),

--- a/crates/vapix/tests/cassette_tests.rs
+++ b/crates/vapix/tests/cassette_tests.rs
@@ -1,5 +1,6 @@
 use std::{future::Future, pin::Pin};
 
+use anyhow::Context;
 use libtest_mimic::{Arguments, Trial};
 use log::{warn, LevelFilter};
 use rs4a_cassette_testing::{Cassette, CassetteClient, DeviceInfo, Library};
@@ -116,6 +117,10 @@ cassette_tests! {
         (
             r#""SocSerialNumber": "[0-9A-F]{8}-[0-9A-F]{8}-[0-9A-F]{8}-[0-9A-F]{8}""#,
             r#""SocSerialNumber": "00000000-00000000-01234567-89ABCDEF""#,
+        ),
+        (
+            r#""SocSerialNumber": "[0-9A-F]{8}-[0-9A-F]{8}""#,
+            r#""SocSerialNumber": "01234567-89ABCDEF""#,
         ),
         (
             r#""SocSerialNumber": "[0-9A-F]{16}""#,
@@ -305,7 +310,11 @@ async fn basic_device_info_get_all_properties(client: &CassetteClient, _: Option
         .unwrap()
         .property_list;
 
-    assert!(property_list.restricted.parse_soc_serial_number().is_ok())
+    let _ = property_list
+        .restricted
+        .parse_soc_serial_number()
+        .context(format!("{:?}", property_list.restricted.soc_serial_number))
+        .unwrap();
 }
 
 async fn basic_device_info_get_all_unrestricted_properties(
@@ -488,6 +497,7 @@ async fn parameter_management_list_error(client: &CassetteClient, prelude: Optio
             ProductType::NetworkStrobeSpeaker => {}
             ProductType::Radar => return,
             ProductType::PeopleCounter3D => return,
+            ProductType::ThermalCamera => return,
             _ => {}
         }
     }
@@ -637,7 +647,7 @@ async fn siren_and_light_2_alpha_maintenance_mode_not_supported(
         if !prelude.version_matches(">=12.5.0") {
             return;
         }
-        if ["M1075-L", "D2210-VE"].contains(&prelude.props.prod_nbr.as_str()) {
+        if ["M1075-L", "D2210-VE", "Q1961-TE"].contains(&prelude.props.prod_nbr.as_str()) {
             return;
         }
     }


### PR DESCRIPTION
Prompted by failures to record cassettes which in turn are done to make sure all the APIs work as expected to the extent there is test coverage.

---

`crates/vapix/src/axis_cgi/basic_device_info_1.rs`:
- Update the SoC serial parsing to work with the two-segment format encountered on Q1961-TE

`crates/vapix/tests/cassette_tests.rs`:
- A couple of tests are updated to provide more context when the parsing fail to speed up troubleshooting and fixing.