### PR TITLE
chore: Use https for git submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "crates/vapix/tests/cassette_tests"]
 	path = crates/vapix/tests/cassette_tests
-	url = git@github.com:apljungquist/rs4acap.git
+	url = https://github.com/apljungquist/rs4acap.git
 	branch = cassettes


### PR DESCRIPTION
The installation instructions in the README no longer works:

```
error: failed to update submodule `crates/vapix/tests/cassette_tests`
```

I think the reason is that Cargo tries to fetch submodules but since it uses `libgit2` it is not aware of the credentials needed to authenticate with SSH.