### PR TITLE
fix: Add prefix to package name in installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,8 +135,8 @@ The tools in this project can be installed using Cargo:
 cargo install --locked --git https://github.com/apljungquist/rs4a.git cli4a
 cargo install --locked --git https://github.com/apljungquist/rs4a.git device-finder
 cargo install --locked --git https://github.com/apljungquist/rs4a.git device-inventory
-cargo install --locked --git https://github.com/apljungquist/rs4a.git device-manager
-cargo install --locked --git https://github.com/apljungquist/rs4a.git firmware-inventory
+cargo install --locked --git https://github.com/apljungquist/rs4a.git rs4a-device-manager
+cargo install --locked --git https://github.com/apljungquist/rs4a.git rs4a-firmware-inventory
 ```
 
 If you want to install them another way, open an issue and I may be able to help.


### PR DESCRIPTION
These packages were renamed when they became libraries in f607970a5856c452909ee0d0523d2a8158784ee9 and
7989e16ff33296427b05e818be70bbe2ce5059d3. The installation commands need to be updated, even if the binary name did not change.