### PR TITLE
chore: Deny unsafe code at the workspace level

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,3 +43,6 @@ rs4a-vlt = { path = "crates/vlt" }
 
 [workspace.package]
 edition = "2021"
+
+[workspace.lints.rust]
+unsafe_code = "forbid"

--- a/crates/authentication/Cargo.toml
+++ b/crates/authentication/Cargo.toml
@@ -4,6 +4,9 @@ version = "0.1.0"
 edition.workspace = true
 license = "MIT"
 
+[lints]
+workspace = true
+
 [dependencies]
 anyhow = { workspace = true }
 base32 = { workspace = true }

--- a/crates/bin-utils/Cargo.toml
+++ b/crates/bin-utils/Cargo.toml
@@ -4,6 +4,9 @@ version = "0.1.0"
 edition.workspace = true
 license = "MIT"
 
+[lints]
+workspace = true
+
 [dependencies]
 anyhow = { workspace = true }
 clap = { workspace = true, features = ["derive"] }

--- a/crates/cassette-testing/Cargo.toml
+++ b/crates/cassette-testing/Cargo.toml
@@ -5,6 +5,9 @@ edition.workspace = true
 license = "MIT"
 description = "Cassette recording and playback infrastructure for rs4a-vapix"
 
+[lints]
+workspace = true
+
 [dependencies]
 anyhow = { workspace = true }
 log = { workspace = true }

--- a/crates/cli4a/Cargo.toml
+++ b/crates/cli4a/Cargo.toml
@@ -4,6 +4,9 @@ version = "0.1.0"
 edition.workspace = true
 license = "MIT"
 
+[lints]
+workspace = true
+
 [dependencies]
 anyhow = { workspace = true }
 clap = { workspace = true, features = ["derive", "env"] }

--- a/crates/cli4a/src/main.rs
+++ b/crates/cli4a/src/main.rs
@@ -1,5 +1,3 @@
-#![forbid(unsafe_code)]
-
 mod commands;
 
 use clap::{Parser, Subcommand};

--- a/crates/device-finder/Cargo.toml
+++ b/crates/device-finder/Cargo.toml
@@ -4,6 +4,9 @@ version = "0.1.0"
 edition.workspace = true
 license = "MIT"
 
+[lints]
+workspace = true
+
 [dependencies]
 anyhow = { workspace = true }
 clap = { workspace = true, features = ["derive"] }

--- a/crates/device-finder/src/main.rs
+++ b/crates/device-finder/src/main.rs
@@ -1,5 +1,3 @@
-#![forbid(unsafe_code)]
-
 use clap::{Parser, Subcommand};
 use rs4a_bin_utils::completions_command::CompletionsCommand;
 

--- a/crates/device-inventory/Cargo.toml
+++ b/crates/device-inventory/Cargo.toml
@@ -4,6 +4,9 @@ version = "0.1.1"
 edition.workspace = true
 license = "MIT"
 
+[lints]
+workspace = true
+
 [dependencies]
 anyhow = { workspace = true }
 clap = { workspace = true, features = ["derive", "env"] }

--- a/crates/device-inventory/src/main.rs
+++ b/crates/device-inventory/src/main.rs
@@ -1,5 +1,3 @@
-#![forbid(unsafe_code)]
-
 mod commands;
 mod db;
 mod db_vlt;

--- a/crates/device-manager/Cargo.toml
+++ b/crates/device-manager/Cargo.toml
@@ -4,6 +4,9 @@ version = "0.1.0"
 edition.workspace = true
 license = "MIT"
 
+[lints]
+workspace = true
+
 [[bin]]
 name = "device-manager"
 path = "src/main.rs"

--- a/crates/device-manager/src/lib.rs
+++ b/crates/device-manager/src/lib.rs
@@ -1,5 +1,3 @@
-#![forbid(unsafe_code)]
-
 pub mod commands;
 mod restart_detector;
 mod ssh_keygen;

--- a/crates/device-manager/src/main.rs
+++ b/crates/device-manager/src/main.rs
@@ -1,5 +1,3 @@
-#![forbid(unsafe_code)]
-
 use clap::Parser;
 
 #[tokio::main]

--- a/crates/dut/Cargo.toml
+++ b/crates/dut/Cargo.toml
@@ -5,6 +5,9 @@ edition.workspace = true
 license = "MIT"
 description = "Framework for specifying and inferring what DUT to target"
 
+[lints]
+workspace = true
+
 [dependencies]
 anyhow = { workspace = true }
 url = { workspace = true }

--- a/crates/firmware-inventory/Cargo.toml
+++ b/crates/firmware-inventory/Cargo.toml
@@ -4,6 +4,9 @@ version = "0.1.0"
 edition.workspace = true
 license = "MIT"
 
+[lints]
+workspace = true
+
 [[bin]]
 name = "firmware-inventory"
 path = "src/main.rs"

--- a/crates/firmware-inventory/src/lib.rs
+++ b/crates/firmware-inventory/src/lib.rs
@@ -1,5 +1,3 @@
-#![forbid(unsafe_code)]
-
 pub mod commands;
 mod db;
 mod scrape;

--- a/crates/firmware-inventory/src/main.rs
+++ b/crates/firmware-inventory/src/main.rs
@@ -1,5 +1,3 @@
-#![forbid(unsafe_code)]
-
 use clap::Parser;
 
 #[tokio::main]

--- a/crates/vapix/Cargo.toml
+++ b/crates/vapix/Cargo.toml
@@ -5,6 +5,9 @@ edition.workspace = true
 license = "MIT"
 description = "Utilities for working with VAPIX"
 
+[lints]
+workspace = true
+
 [dependencies]
 anyhow = { workspace = true }
 base32 = { workspace = true }

--- a/crates/vlt/Cargo.toml
+++ b/crates/vlt/Cargo.toml
@@ -3,6 +3,9 @@ name = "rs4a-vlt"
 version = "0.2.0"
 edition.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 anyhow = { workspace = true }
 chrono = { workspace = true, features = ["serde"] }


### PR DESCRIPTION
At present this doesn't make much of a difference; either way there's one line that has to be added to each crate.

But in principle I like the idea that sharing standards among crates is the norm and that deviating is the exception. In practice it will only become an improvement if more lints are customized.