### PR TITLE
feat(vapix)!: Use Builder::constructor style for remaining APIs

### DIFF
--- a/crates/cli4a/src/commands/install.rs
+++ b/crates/cli4a/src/commands/install.rs
@@ -51,7 +51,7 @@ impl InstallCommand {
 
         info!("Querying device for model and version");
         let client = netloc.connect().await?;
-        let props = rs4a_vapix::basic_device_info_1::get_all_unrestricted_properties()
+        let props = rs4a_vapix::basic_device_info_1::GetAllUnrestrictedPropertiesRequest::new()
             .send(&client)
             .await?
             .property_list;

--- a/crates/device-finder/src/commands/discover_devices.rs
+++ b/crates/device-finder/src/commands/discover_devices.rs
@@ -165,7 +165,9 @@ async fn probe(
         needsetup,
         systemready,
         ..
-    } = apis::system_ready_1::system_ready().send(&client).await?;
+    } = apis::system_ready_1::SystemReadyRequest::new()
+        .send(&client)
+        .await?;
     details
         .insert("Need Setup".to_string(), needsetup.to_string())
         .inspect(|_| panic!("Each key is created at most once"));
@@ -182,7 +184,7 @@ async fn probe(
         serial_number,
         version,
         ..
-    } = apis::basic_device_info_1::get_all_unrestricted_properties()
+    } = apis::basic_device_info_1::GetAllUnrestrictedPropertiesRequest::new()
         .send(&client)
         .await?
         .property_list;

--- a/crates/device-inventory/src/commands/list.rs
+++ b/crates/device-inventory/src/commands/list.rs
@@ -138,7 +138,7 @@ async fn probe_device(
             let AllProperties {
                 unrestricted,
                 restricted,
-            } = apis::basic_device_info_1::get_all_properties()
+            } = apis::basic_device_info_1::GetAllPropertiesRequest::new()
                 .send(&client)
                 .await?
                 .property_list;
@@ -153,10 +153,11 @@ async fn probe_device(
                 .await
                 .context("Could not create client")?;
 
-            let unrestricted = apis::basic_device_info_1::get_all_unrestricted_properties()
-                .send(&client)
-                .await?
-                .property_list;
+            let unrestricted =
+                apis::basic_device_info_1::GetAllUnrestrictedPropertiesRequest::new()
+                    .send(&client)
+                    .await?
+                    .property_list;
             Ok((fingerprint, unrestricted, None))
         }
     }

--- a/crates/device-manager/src/commands/init.rs
+++ b/crates/device-manager/src/commands/init.rs
@@ -1,8 +1,8 @@
 use anyhow::{bail, Context};
 use log::{debug, info, warn};
 use rs4a_vapix::{
-    applications_config, basic_device_info_1, parameter_management, pwdgrp, pwdgrp::AddUserRequest,
-    system_ready_1,
+    applications_config, basic_device_info_1::GetAllUnrestrictedPropertiesRequest,
+    parameter_management, pwdgrp, pwdgrp::AddUserRequest, system_ready_1::SystemReadyRequest,
 };
 use semver::Version;
 
@@ -42,7 +42,7 @@ fn parse_firmware_version(s: &str) -> anyhow::Result<Version> {
 }
 
 async fn apply_setup_profile(client: &rs4a_vapix::Client) -> anyhow::Result<()> {
-    let data = basic_device_info_1::get_all_unrestricted_properties()
+    let data = GetAllUnrestrictedPropertiesRequest::new()
         .send(client)
         .await
         .context("Failed to query firmware version")?;
@@ -71,7 +71,7 @@ pub async fn initialize(netloc: &Netloc) -> anyhow::Result<()> {
     // Device needs setup, no authentication possible or required
     let client = netloc.connect_anonymous().await?;
 
-    let data = system_ready_1::system_ready().send(&client).await?;
+    let data = SystemReadyRequest::new().send(&client).await?;
     if !data.needsetup {
         bail!("Expected device to be in setup mode, but needsetup is false");
     }

--- a/crates/device-manager/src/commands/restore.rs
+++ b/crates/device-manager/src/commands/restore.rs
@@ -1,7 +1,9 @@
 use std::time::Duration;
 
 use log::{debug, info};
-use rs4a_vapix::{firmware_management_1::FactoryDefaultRequest, system_ready_1};
+use rs4a_vapix::{
+    firmware_management_1::FactoryDefaultRequest, system_ready_1::SystemReadyRequest,
+};
 use tokio::time::timeout;
 
 use crate::{restart_detector::RestartDetector, Netloc};
@@ -24,7 +26,7 @@ pub async fn restore(netloc: &Netloc) -> anyhow::Result<()> {
     let client = netloc.connect().await?;
 
     debug!("Querying device state");
-    let data = system_ready_1::system_ready().send(&client).await?;
+    let data = SystemReadyRequest::new().send(&client).await?;
     if data.needsetup {
         info!("Already in setup mode, nothing to do");
         return Ok(());

--- a/crates/device-manager/src/restart_detector.rs
+++ b/crates/device-manager/src/restart_detector.rs
@@ -1,7 +1,7 @@
 use std::time::Duration;
 
 use log::{debug, trace, warn};
-use rs4a_vapix::{system_ready_1, system_ready_1::SystemreadyData};
+use rs4a_vapix::system_ready_1::{SystemReadyRequest, SystemreadyData};
 use tokio::time::sleep;
 
 #[derive(Clone, Copy, Debug)]
@@ -20,7 +20,7 @@ pub(crate) struct RestartDetector<'a> {
 
 impl<'a> RestartDetector<'a> {
     pub(crate) async fn try_new(client: &'a rs4a_vapix::Client) -> anyhow::Result<Self> {
-        let data = system_ready_1::system_ready().send(client).await?;
+        let data = SystemReadyRequest::new().send(client).await?;
         let boot_id = data.bootid.clone();
         let uptime = data.try_uptime()?;
         Ok(Self {
@@ -106,7 +106,7 @@ impl<'a> RestartDetector<'a> {
 
             let data = tokio::time::timeout(
                 Duration::from_secs(5),
-                system_ready_1::system_ready().send(self.client),
+                SystemReadyRequest::new().send(self.client),
             )
             .await
             .inspect_err(|_| debug!("system_ready request timed out"))

--- a/crates/vapix/src/apis.rs
+++ b/crates/vapix/src/apis.rs
@@ -12,19 +12,22 @@ pub mod applications_config {
 
 pub mod action_1 {
     pub use crate::action1::{
-        add_action_configuration, add_action_rule, get_action_configurations, get_action_rules,
+        AddActionConfigurationRequest, AddActionRuleRequest, GetActionConfigurationsRequest,
+        GetActionRulesRequest,
     };
 }
 pub mod basic_device_info_1 {
-    pub use crate::basic_device_info_1::{get_all_properties, get_all_unrestricted_properties};
+    pub use crate::basic_device_info_1::{
+        GetAllPropertiesRequest, GetAllUnrestrictedPropertiesRequest,
+    };
 }
 
 pub mod event_1 {
-    pub use crate::event1::get_event_instances;
+    pub use crate::event1::GetEventInstancesRequest;
 }
 
 pub mod jpg_3 {
-    pub use crate::axis_cgi::jpg_3::get_image;
+    pub use crate::axis_cgi::jpg_3::GetImageRequest;
 }
 
 pub mod remote_object_storage_1_beta {
@@ -35,7 +38,7 @@ pub mod remote_object_storage_1_beta {
 }
 
 pub mod recording_group_1 {
-    pub use crate::config::recording_group_1::create_recording_groups;
+    pub use crate::config::recording_group_1::CreateRecordingGroupsRequest;
 }
 
 pub mod siren_and_light_2_alpha {
@@ -45,11 +48,11 @@ pub mod siren_and_light_2_alpha {
 }
 
 pub mod ssh_1 {
-    pub use crate::config::ssh_1::{add_user, delete_user, set_user};
+    pub use crate::config::ssh_1::{AddUserRequest, DeleteUserRequest, SetUserRequest};
 }
 
 pub mod system_ready_1 {
-    pub use crate::system_ready_1::system_ready;
+    pub use crate::system_ready_1::SystemReadyRequest;
 }
 
 pub mod firmware_management_1 {

--- a/crates/vapix/src/axis_cgi/basic_device_info_1.rs
+++ b/crates/vapix/src/axis_cgi/basic_device_info_1.rs
@@ -169,23 +169,27 @@ pub struct GetAllUnrestrictedPropertiesRequest {
     method: &'static str,
 }
 
-impl Default for GetAllUnrestrictedPropertiesRequest {
-    fn default() -> Self {
+const PATH: &str = "axis-cgi/basicdeviceinfo.cgi";
+
+impl GetAllUnrestrictedPropertiesRequest {
+    pub fn new() -> Self {
         Self {
             api_version: "1.0",
             method: "getAllUnrestrictedProperties",
         }
     }
-}
 
-const PATH: &str = "axis-cgi/basicdeviceinfo.cgi";
-
-impl GetAllUnrestrictedPropertiesRequest {
     pub async fn send(
         self,
         client: &(impl HttpClient + Sync),
     ) -> Result<AllUnrestrictedPropertiesData, Error<json_rpc::Error>> {
         json_rpc_http::send_request(client, PATH, &self).await
+    }
+}
+
+impl Default for GetAllUnrestrictedPropertiesRequest {
+    fn default() -> Self {
+        Self::new()
     }
 }
 
@@ -349,16 +353,14 @@ pub struct GetAllPropertiesRequest {
     method: &'static str,
 }
 
-impl Default for GetAllPropertiesRequest {
-    fn default() -> Self {
+impl GetAllPropertiesRequest {
+    pub fn new() -> Self {
         Self {
             api_version: "1.0",
             method: "getAllProperties",
         }
     }
-}
 
-impl GetAllPropertiesRequest {
     pub async fn send(
         self,
         client: &(impl HttpClient + Sync),
@@ -367,12 +369,10 @@ impl GetAllPropertiesRequest {
     }
 }
 
-pub fn get_all_properties() -> GetAllPropertiesRequest {
-    GetAllPropertiesRequest::default()
-}
-
-pub fn get_all_unrestricted_properties() -> GetAllUnrestrictedPropertiesRequest {
-    GetAllUnrestrictedPropertiesRequest::default()
+impl Default for GetAllPropertiesRequest {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 #[cfg(test)]

--- a/crates/vapix/src/axis_cgi/jpg_3.rs
+++ b/crates/vapix/src/axis_cgi/jpg_3.rs
@@ -3,12 +3,20 @@ use anyhow::{bail, Context};
 
 use crate::Client;
 
-pub struct Request {
+/// Get a jpg encoded snapshot.
+pub struct GetImageRequest {
     resolution: Option<String>,
     compression: Option<u8>,
 }
 
-impl Request {
+impl GetImageRequest {
+    pub fn new() -> Self {
+        Self {
+            resolution: None,
+            compression: None,
+        }
+    }
+
     /// The image resolution in the format `"{width}x{height}"`.
     ///
     /// Example: `"640x360"`.
@@ -29,9 +37,7 @@ impl Request {
         self.compression = Some(compression);
         self
     }
-}
 
-impl Request {
     // TODO: Migrate to `HttpClient` when cassette tests support binary responses.
     pub async fn send(self, client: &Client) -> anyhow::Result<Vec<u8>> {
         let Self {
@@ -70,10 +76,8 @@ impl Request {
     }
 }
 
-/// Get a jpg encoded snapshot.
-pub fn get_image() -> Request {
-    Request {
-        resolution: None,
-        compression: None,
+impl Default for GetImageRequest {
+    fn default() -> Self {
+        Self::new()
     }
 }

--- a/crates/vapix/src/axis_cgi/system_ready_1.rs
+++ b/crates/vapix/src/axis_cgi/system_ready_1.rs
@@ -98,17 +98,15 @@ pub struct SystemReadyRequest {
 
 const PATH: &str = "axis-cgi/systemready.cgi";
 
-impl Default for SystemReadyRequest {
-    fn default() -> Self {
+impl SystemReadyRequest {
+    pub fn new() -> Self {
         Self {
-            method: "systemready",
             api_version: "1",
+            method: "systemready",
             params: None,
         }
     }
-}
 
-impl SystemReadyRequest {
     pub fn timeout(mut self, timeout: u16) -> Self {
         self.params.get_or_insert(SystemReadyParams { timeout });
         self
@@ -122,6 +120,8 @@ impl SystemReadyRequest {
     }
 }
 
-pub fn system_ready() -> SystemReadyRequest {
-    SystemReadyRequest::default()
+impl Default for SystemReadyRequest {
+    fn default() -> Self {
+        Self::new()
+    }
 }

--- a/crates/vapix/src/client.rs
+++ b/crates/vapix/src/client.rs
@@ -298,7 +298,7 @@ impl ClientBuilder {
         for (scheme, port) in schemes {
             candidate.scheme = *scheme;
             candidate.port = *port;
-            if apis::system_ready_1::system_ready()
+            if apis::system_ready_1::SystemReadyRequest::new()
                 .timeout(1)
                 .send(candidate)
                 .await

--- a/crates/vapix/src/config/recording_group_1.rs
+++ b/crates/vapix/src/config/recording_group_1.rs
@@ -55,12 +55,16 @@ pub struct SegmentSize {
     pub target: u64,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct CreateRecordingGroupsRequest {
     data: Value,
 }
 
 impl CreateRecordingGroupsRequest {
+    pub fn new() -> Self {
+        Self { data: Value::Null }
+    }
+
     pub fn data(mut self, data: Value) -> Self {
         self.data = data;
         self
@@ -81,8 +85,4 @@ impl CreateRecordingGroupsRequest {
     ) -> Result<CreateRecordingGroupResponse, Error<rest::Error>> {
         rest_http::send_request(client, self.into_request()).await
     }
-}
-
-pub fn create_recording_groups() -> CreateRecordingGroupsRequest {
-    CreateRecordingGroupsRequest { data: Value::Null }
 }

--- a/crates/vapix/src/config/ssh_1.rs
+++ b/crates/vapix/src/config/ssh_1.rs
@@ -21,6 +21,20 @@ pub struct AddUserRequest {
 }
 
 impl AddUserRequest {
+    /// Creates a new user.
+    ///
+    /// # Arguments
+    ///
+    /// - `username` no shorter than 1, no longer than 32 and matching `^[a-z_][a-z0-9-_]*[$]?$`.
+    /// - `password` no shorter than 1 and no longer than 256.
+    pub fn new(username: impl ToString, password: impl ToString) -> Self {
+        Self {
+            comment: None,
+            password: password.to_string(),
+            username: username.to_string(),
+        }
+    }
+
     /// Sets the full name or the comment of the SSH user.
     ///
     /// Must be no longer than 256 and must match `^[^:\n]*$`.
@@ -71,6 +85,21 @@ pub struct SetUserRequest {
 impl SetUserRequest {
     // TODO: Figure out how the config API measures length
 
+    /// Updates an existing user.
+    ///
+    /// # Arguments
+    ///
+    /// - `username` name of the user to update.
+    pub fn new(username: impl ToString) -> Self {
+        Self {
+            properties: SetUserProperties {
+                password: None,
+                comment: None,
+            },
+            username: username.to_string(),
+        }
+    }
+
     /// Sets the password of the SSH user.
     ///
     /// Must be no shorter than 1 and no longer than 256.
@@ -113,6 +142,17 @@ pub struct DeleteUserRequest {
 }
 
 impl DeleteUserRequest {
+    /// Deletes an existing user.
+    ///
+    /// # Arguments
+    ///
+    /// - `username` name of the user to delete.
+    pub fn new(username: impl ToString) -> Self {
+        Self {
+            username: username.to_string(),
+        }
+    }
+
     pub fn into_request(self) -> Request {
         Request::new(
             Method::DELETE,
@@ -126,43 +166,3 @@ impl DeleteUserRequest {
 }
 
 // TODO: Consider creating new types for comment, username, and password.
-
-/// Creates a new user.
-///
-/// # Arguments
-///
-/// - `username` no shorter than 1, no longer than 32 and matching `^[a-z_][a-z0-9-_]*[$]?$`.
-/// - `password` shorter than 1 and no longer than 256.
-pub fn add_user(username: impl ToString, password: impl ToString) -> AddUserRequest {
-    AddUserRequest {
-        comment: None,
-        password: password.to_string(),
-        username: username.to_string(),
-    }
-}
-
-/// Updates an existing user.
-///
-/// # Arguments
-///
-/// - `username` name of the user to update.
-pub fn set_user(username: impl ToString) -> SetUserRequest {
-    SetUserRequest {
-        properties: SetUserProperties {
-            password: None,
-            comment: None,
-        },
-        username: username.to_string(),
-    }
-}
-
-/// Deletes an existing user.
-///
-/// # Arguments
-///
-/// - `username` name of the user to delete.
-pub fn delete_user(username: impl ToString) -> DeleteUserRequest {
-    DeleteUserRequest {
-        username: username.to_string(),
-    }
-}

--- a/crates/vapix/src/services/action1.rs
+++ b/crates/vapix/src/services/action1.rs
@@ -5,28 +5,10 @@ mod action_configurations;
 mod action_rules;
 
 pub use action_configurations::{
-    AddActionConfigurationResponse, GetActionConfigurationsRequest, GetActionConfigurationsResponse,
+    AddActionConfigurationRequest, AddActionConfigurationResponse, GetActionConfigurationsRequest,
+    GetActionConfigurationsResponse,
 };
 pub use action_rules::{
-    AddActionRuleResponse, Condition, GetActionRulesRequest, GetActionRulesResponse,
+    AddActionRuleRequest, AddActionRuleResponse, Condition, GetActionRulesRequest,
+    GetActionRulesResponse,
 };
-
-use crate::action1::{
-    action_configurations::AddActionConfigurationRequest, action_rules::AddActionRuleRequest,
-};
-
-pub fn add_action_configuration(template_token: &str) -> AddActionConfigurationRequest {
-    AddActionConfigurationRequest::new(template_token)
-}
-
-pub fn add_action_rule(name: String, primary_action: u16) -> AddActionRuleRequest {
-    AddActionRuleRequest::new(name, primary_action)
-}
-
-pub fn get_action_configurations() -> GetActionConfigurationsRequest {
-    GetActionConfigurationsRequest
-}
-
-pub fn get_action_rules() -> GetActionRulesRequest {
-    GetActionRulesRequest
-}

--- a/crates/vapix/src/services/action1/action_configurations.rs
+++ b/crates/vapix/src/services/action1/action_configurations.rs
@@ -26,7 +26,7 @@ pub struct AddActionConfigurationRequest {
 
 // TODO: Consider enabling typed templates to give users early feedback about missing params
 impl AddActionConfigurationRequest {
-    pub(crate) fn new(template_token: &str) -> AddActionConfigurationRequest {
+    pub fn new(template_token: &str) -> AddActionConfigurationRequest {
         Self {
             name: None,
             template_token: template_token.to_string(),
@@ -126,10 +126,14 @@ pub struct Parameter {
     pub value: String,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct GetActionConfigurationsRequest;
 
 impl GetActionConfigurationsRequest {
+    pub fn new() -> Self {
+        Self
+    }
+
     pub fn into_envelope(self) -> String {
         soap::envelope(NAMESPACE, "GetActionConfigurations", None)
     }

--- a/crates/vapix/src/services/action1/action_rules.rs
+++ b/crates/vapix/src/services/action1/action_rules.rs
@@ -19,7 +19,7 @@ pub struct AddActionRuleRequest {
 }
 
 impl AddActionRuleRequest {
-    pub(crate) fn new(name: String, primary_action: u16) -> Self {
+    pub fn new(name: String, primary_action: u16) -> Self {
         Self {
             name,
             enabled: true,
@@ -133,10 +133,14 @@ pub struct GetActionRulesResponse {
     pub action_rules: ActionRules,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct GetActionRulesRequest;
 
 impl GetActionRulesRequest {
+    pub fn new() -> Self {
+        Self
+    }
+
     pub fn into_envelope(self) -> String {
         soap::envelope(NAMESPACE, "GetActionRules", None)
     }

--- a/crates/vapix/src/services/event1.rs
+++ b/crates/vapix/src/services/event1.rs
@@ -59,10 +59,14 @@ impl SoapResponse for EventInstances {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct GetEventInstancesRequest;
 
 impl GetEventInstancesRequest {
+    pub fn new() -> Self {
+        Self
+    }
+
     pub fn into_envelope(self) -> String {
         soap::envelope(
             "http://www.axis.com/vapix/ws/event1",
@@ -79,8 +83,4 @@ impl GetEventInstancesRequest {
             Request::new(reqwest::Method::POST, PATH.to_string()).soap(self.into_envelope());
         soap_http::send_request(client, request).await
     }
-}
-
-pub fn get_event_instances() -> GetEventInstancesRequest {
-    GetEventInstancesRequest
 }

--- a/crates/vapix/tests/cassette_tests.rs
+++ b/crates/vapix/tests/cassette_tests.rs
@@ -187,7 +187,7 @@ fn record_trials(library: &Library) -> Vec<Trial> {
     });
 
     let prelude = rt.block_on(async {
-        let props = apis::basic_device_info_1::get_all_unrestricted_properties()
+        let props = apis::basic_device_info_1::GetAllUnrestrictedPropertiesRequest::new()
             .send(&client)
             .await
             .unwrap()
@@ -286,14 +286,14 @@ fn main() {
 }
 
 async fn action1_get_action_configurations(client: &CassetteClient, _prelude: Option<Prelude>) {
-    apis::action_1::get_action_configurations()
+    apis::action_1::GetActionConfigurationsRequest
         .send(client)
         .await
         .unwrap();
 }
 
 async fn action1_get_action_rules(client: &CassetteClient, _prelude: Option<Prelude>) {
-    apis::action_1::get_action_rules()
+    apis::action_1::GetActionRulesRequest
         .send(client)
         .await
         .unwrap();
@@ -326,7 +326,7 @@ async fn api_discovery_1_get_supported_versions(client: &CassetteClient, _: Opti
 }
 
 async fn basic_device_info_get_all_properties(client: &CassetteClient, _: Option<Prelude>) {
-    let property_list = basic_device_info_1::get_all_properties()
+    let property_list = basic_device_info_1::GetAllPropertiesRequest::new()
         .send(client)
         .await
         .unwrap()
@@ -343,7 +343,7 @@ async fn basic_device_info_get_all_unrestricted_properties(
     client: &CassetteClient,
     _: Option<Prelude>,
 ) {
-    let property_list = basic_device_info_1::get_all_unrestricted_properties()
+    let property_list = basic_device_info_1::GetAllUnrestrictedPropertiesRequest::new()
         .send(client)
         .await
         .unwrap()
@@ -487,7 +487,7 @@ async fn device_configuration_item_already_exists(
 
 // TODO: Find a way to avoid the churn caused by XML lists not being consistently ordered
 async fn event1_get_event_instances(client: &CassetteClient, _prelude: Option<Prelude>) {
-    let data = apis::event_1::get_event_instances()
+    let data = apis::event_1::GetEventInstancesRequest
         .send(client)
         .await
         .unwrap();
@@ -715,19 +715,19 @@ async fn ssh_1_crud(client: &CassetteClient, prelude: Option<Prelude>) {
 
     let username = "dalliard";
 
-    apis::ssh_1::add_user(username, "Good morning")
+    apis::ssh_1::AddUserRequest::new(username, "Good morning")
         .comment("Good morning")
         .send(client)
         .await
         .unwrap();
 
-    apis::ssh_1::set_user(username)
+    apis::ssh_1::SetUserRequest::new(username)
         .comment("When's the day?")
         .send(client)
         .await
         .unwrap();
 
-    apis::ssh_1::delete_user(username)
+    apis::ssh_1::DeleteUserRequest::new(username)
         .send(client)
         .await
         .unwrap();
@@ -740,7 +740,7 @@ async fn ssh_1_set_user_does_not_exist(client: &CassetteClient, prelude: Option<
         }
     }
 
-    let error = apis::ssh_1::set_user("nonexistent_user")
+    let error = apis::ssh_1::SetUserRequest::new("nonexistent_user")
         .comment("should fail")
         .send(client)
         .await
@@ -762,14 +762,14 @@ async fn ssh_1_set_user_validation_error(client: &CassetteClient, prelude: Optio
 
     let username = "cassette_test_validation";
 
-    apis::ssh_1::add_user(username, "Good morning")
+    apis::ssh_1::AddUserRequest::new(username, "Good morning")
         .comment("Good morning")
         .send(client)
         .await
         .unwrap();
 
     // Empty string violates the minimum length of 1
-    let error = apis::ssh_1::set_user(username)
+    let error = apis::ssh_1::SetUserRequest::new(username)
         .password("")
         .send(client)
         .await
@@ -782,14 +782,14 @@ async fn ssh_1_set_user_validation_error(client: &CassetteClient, prelude: Optio
     assert_eq!(error.kind().unwrap(), ErrorKind::ValidationError);
 
     // Clean up
-    apis::ssh_1::delete_user(username)
+    apis::ssh_1::DeleteUserRequest::new(username)
         .send(client)
         .await
         .unwrap();
 }
 
 async fn system_ready_1_system_ready(client: &CassetteClient, _prelude: Option<Prelude>) {
-    let data = apis::system_ready_1::system_ready()
+    let data = apis::system_ready_1::SystemReadyRequest::new()
         .send(client)
         .await
         .unwrap();

--- a/crates/vapix/tests/serde.rs
+++ b/crates/vapix/tests/serde.rs
@@ -77,7 +77,7 @@ fn can_deserialize_system_ready_1_preview_mode() {
 #[test]
 fn can_serialize_action_1_requests() {
     expect_file!["./snapshots/add_action_configuration.xml"].assert_eq(
-        &apis::action_1::add_action_configuration("com.axis.action.fixed.ledcontrol")
+        &apis::action_1::AddActionConfigurationRequest::new("com.axis.action.fixed.ledcontrol")
             .name("Flash status LED")
             .param("led", "statusled")
             .param("color", "green,none")
@@ -87,7 +87,7 @@ fn can_serialize_action_1_requests() {
             .unwrap(),
     );
     expect_file!["./snapshots/add_action_rule.xml"].assert_eq(
-        &apis::action_1::add_action_rule("My Action Rule".to_string(), 123)
+        &apis::action_1::AddActionRuleRequest::new("My Action Rule".to_string(), 123)
             .condition(Condition {
                 topic_expression: "tns1:Device/tnsaxis:Status/SystemReady".to_string(),
                 message_content: r#"boolean(//SimpleItem[@Name="ready" and @Value="1"])"#
@@ -96,7 +96,7 @@ fn can_serialize_action_1_requests() {
             .into_envelope(),
     );
     expect_file!["./snapshots/get_action_configurations.xml"]
-        .assert_eq(&apis::action_1::get_action_configurations().into_envelope());
+        .assert_eq(&apis::action_1::GetActionConfigurationsRequest::new().into_envelope());
     expect_file!["./snapshots/get_action_rules.xml"]
-        .assert_eq(&apis::action_1::get_action_rules().into_envelope());
+        .assert_eq(&apis::action_1::GetActionRulesRequest::new().into_envelope());
 }

--- a/crates/vapix/tests/smoke_tests.rs
+++ b/crates/vapix/tests/smoke_tests.rs
@@ -38,7 +38,7 @@ async fn action_1_get_action_configurations_returns_ok() {
     let Some(client) = test_client().await else {
         return;
     };
-    apis::action_1::get_action_configurations()
+    apis::action_1::GetActionConfigurationsRequest::new()
         .send(&client)
         .await
         .unwrap();
@@ -51,7 +51,7 @@ async fn action_1_add_and_get_returns_ok() {
     };
 
     let action_configuration_id =
-        apis::action_1::add_action_configuration("com.axis.action.fixed.ledcontrol")
+        apis::action_1::AddActionConfigurationRequest::new("com.axis.action.fixed.ledcontrol")
             .param("led", "statusled")
             .param("color", "green,none")
             .param("duration", "1")
@@ -62,19 +62,20 @@ async fn action_1_add_and_get_returns_ok() {
             .configuration_id;
 
     let action_rule_name = "smoke test rule";
-    let action_rule_id =
-        apis::action_1::add_action_rule(action_rule_name.to_string(), action_configuration_id)
-            .condition(Condition {
-                topic_expression: "tns1:Device/tnsaxis:Status/SystemReady".to_string(),
-                message_content: r#"boolean(//SimpleItem[@Name="ready" and @Value="1"])"#
-                    .to_string(),
-            })
-            .send(&client)
-            .await
-            .unwrap()
-            .id;
+    let action_rule_id = apis::action_1::AddActionRuleRequest::new(
+        action_rule_name.to_string(),
+        action_configuration_id,
+    )
+    .condition(Condition {
+        topic_expression: "tns1:Device/tnsaxis:Status/SystemReady".to_string(),
+        message_content: r#"boolean(//SimpleItem[@Name="ready" and @Value="1"])"#.to_string(),
+    })
+    .send(&client)
+    .await
+    .unwrap()
+    .id;
 
-    let actions_rules = apis::action_1::get_action_rules()
+    let actions_rules = apis::action_1::GetActionRulesRequest::new()
         .send(&client)
         .await
         .unwrap()
@@ -94,7 +95,7 @@ async fn event_1_get_event_instances_returns_ok() {
     let Some(client) = test_client().await else {
         return;
     };
-    apis::event_1::get_event_instances()
+    apis::event_1::GetEventInstancesRequest::new()
         .send(&client)
         .await
         .unwrap();
@@ -105,7 +106,7 @@ async fn jpg_get_image_returns_ok() {
     let Some(client) = test_client().await else {
         return;
     };
-    apis::jpg_3::get_image()
+    apis::jpg_3::GetImageRequest::new()
         .compression(100)
         .send(&client)
         .await
@@ -142,7 +143,7 @@ async fn recording_group_1_create_returns_ok() {
         actual_recording_destination_id.into_string()
     );
 
-    apis::recording_group_1::create_recording_groups()
+    apis::recording_group_1::CreateRecordingGroupsRequest::new()
         .data(json!({
             "destinations": [{
                 "remoteObjectStorage":  {
@@ -160,7 +161,7 @@ async fn system_ready_system_ready_returns_ok() {
     let Some(client) = test_client().await else {
         return;
     };
-    apis::system_ready_1::system_ready()
+    apis::system_ready_1::SystemReadyRequest::new()
         .send(&client)
         .await
         .unwrap();


### PR DESCRIPTION
To make it easier for users and contributors alike to predict the shape of APIs.