### PR TITLE
feat(vapix)!: Add remove request and error to pwdgrp

### DIFF
--- a/crates/vapix/src/apis.rs
+++ b/crates/vapix/src/apis.rs
@@ -72,5 +72,5 @@ pub mod parameter_management {
 }
 
 pub mod pwdgrp {
-    pub use crate::pwdgrp::AddUserRequest;
+    pub use crate::pwdgrp::{AddUserRequest, RemoveUserRequest};
 }

--- a/crates/vapix/src/axis_cgi/pwdgrp.rs
+++ b/crates/vapix/src/axis_cgi/pwdgrp.rs
@@ -6,7 +6,7 @@ use std::fmt::{Display, Formatter};
 
 use reqwest::{Method, StatusCode};
 
-use crate::http::{Error, HttpClient, Request};
+use crate::http::{Error as HttpError, HttpClient, Request};
 
 const PATH: &str = "axis-cgi/pwdgrp.cgi";
 
@@ -16,6 +16,26 @@ fn extract_body(html: &str) -> Option<&str> {
     let content_end = html[content_start..].find("</body>")? + content_start;
     Some(&html[content_start..content_end])
 }
+
+/// An error returned by the user management CGI.
+#[derive(Clone, Debug)]
+pub struct Error {
+    message: String,
+}
+
+impl Error {
+    pub fn message(&self) -> &str {
+        &self.message
+    }
+}
+
+impl Display for Error {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.message)
+    }
+}
+
+impl std::error::Error for Error {}
 
 #[derive(Clone, Copy, Debug)]
 pub enum Role {
@@ -79,23 +99,70 @@ impl AddUserRequest {
         )
     }
 
-    pub async fn send(
-        self,
-        client: &impl HttpClient,
-    ) -> Result<(), Error<std::convert::Infallible>> {
+    pub async fn send(self, client: &impl HttpClient) -> Result<(), HttpError<Error>> {
         let expected = format!("Created account {}.", self.username);
         let response = client
             .execute(self.into_request())
             .await
-            .map_err(Error::Transport)?;
-        let body = response.body.map_err(|e| Error::Transport(e.into()))?;
-        if response.status == StatusCode::OK {
-            let html_body = extract_body(&body).unwrap_or("");
-            if html_body.trim() == expected {
-                return Ok(());
-            }
+            .map_err(HttpError::Transport)?;
+        let body = response.body.map_err(|e| HttpError::Transport(e.into()))?;
+        let html_body = extract_body(&body).unwrap_or("");
+        let trimmed = html_body.trim();
+        if let Some(message) = trimmed.strip_prefix("Error: ") {
+            let message = message.strip_suffix('.').unwrap_or(message);
+            return Err(HttpError::Service(Error {
+                message: message.to_string(),
+            }));
         }
-        Err(Error::Decode(anyhow::anyhow!(
+        if response.status == StatusCode::OK && trimmed == expected {
+            return Ok(());
+        }
+        Err(HttpError::Decode(anyhow::anyhow!(
+            "Unexpected response: {} {}",
+            response.status,
+            body.trim()
+        )))
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct RemoveUserRequest {
+    username: String,
+}
+
+impl RemoveUserRequest {
+    pub fn new(username: &str) -> Self {
+        Self {
+            username: username.to_string(),
+        }
+    }
+
+    fn into_request(self) -> Request {
+        Request::new(
+            Method::GET,
+            format!("{PATH}?action=remove&user={}", self.username),
+        )
+    }
+
+    pub async fn send(self, client: &impl HttpClient) -> Result<(), HttpError<Error>> {
+        let expected = format!("Removed account {}.", self.username);
+        let response = client
+            .execute(self.into_request())
+            .await
+            .map_err(HttpError::Transport)?;
+        let body = response.body.map_err(|e| HttpError::Transport(e.into()))?;
+        let html_body = extract_body(&body).unwrap_or("");
+        let trimmed = html_body.trim();
+        if let Some(message) = trimmed.strip_prefix("Error: ") {
+            let message = message.strip_suffix('.').unwrap_or(message);
+            return Err(HttpError::Service(Error {
+                message: message.to_string(),
+            }));
+        }
+        if response.status == StatusCode::OK && trimmed == expected {
+            return Ok(());
+        }
+        Err(HttpError::Decode(anyhow::anyhow!(
             "Unexpected response: {} {}",
             response.status,
             body.trim()

--- a/crates/vapix/tests/cassette_tests.rs
+++ b/crates/vapix/tests/cassette_tests.rs
@@ -15,6 +15,7 @@ use rs4a_vapix::{
     http,
     network_settings_1::{GetNetworkInfoRequest, SetGlobalProxyConfigurationRequest},
     parameter_management::{ImageResolution, ListRequest, NetworkSshEnabled, UpdateRequest},
+    pwdgrp::{Group, Role},
     remote_object_storage_1_beta::{
         AzureDestination, CreateDestinationRequest, DeleteDestinationRequest, DestinationData,
         DestinationId, ListDestinationsRequest, UpdateDestinationRequest,
@@ -205,6 +206,10 @@ cassette_tests! {
     parameter_management_list_error,
     parameter_management_list_image_resolution,
     parameter_management_update_network_ssh_enabled,
+    pwdgrp_add_user_already_exists,
+    pwdgrp_add_user_invalid_password,
+    pwdgrp_add_user_invalid_username,
+    pwdgrp_remove_user_does_not_exist,
     remote_object_storage_1_beta_crud,
     siren_and_light_2_alpha_maintenance_mode_not_supported,
     ssh_1_crud,
@@ -642,6 +647,72 @@ async fn parameter_management_update_network_ssh_enabled(
         .unwrap();
 
     assert_eq!(read().await, initial);
+}
+
+async fn pwdgrp_add_user_already_exists(client: &CassetteClient, _prelude: Option<Prelude>) {
+    let username = "cassettetest";
+
+    apis::pwdgrp::AddUserRequest::new(username, "Good morning", Group::Users, Role::Viewer)
+        .send(client)
+        .await
+        .unwrap();
+
+    let err =
+        apis::pwdgrp::AddUserRequest::new(username, "Good morning", Group::Users, Role::Viewer)
+            .send(client)
+            .await
+            .unwrap_err();
+
+    let http::Error::Service(err) = err else {
+        panic!("Expected Service error but got {err:?}");
+    };
+    assert_eq!(
+        err.message(),
+        "this user name already exists, consult the system log file"
+    );
+
+    // Cleanup
+    apis::pwdgrp::RemoveUserRequest::new(username)
+        .send(client)
+        .await
+        .unwrap();
+}
+
+async fn pwdgrp_add_user_invalid_password(client: &CassetteClient, _prelude: Option<Prelude>) {
+    let err = apis::pwdgrp::AddUserRequest::new("testuser", "", Group::Users, Role::Viewer)
+        .send(client)
+        .await
+        .unwrap_err();
+
+    let http::Error::Service(err) = err else {
+        panic!("Expected Service error but got {err:?}");
+    };
+    assert_eq!(err.message(), "invalid password");
+}
+
+async fn pwdgrp_add_user_invalid_username(client: &CassetteClient, _prelude: Option<Prelude>) {
+    let err =
+        apis::pwdgrp::AddUserRequest::new("user!", "Good morning", Group::Users, Role::Viewer)
+            .send(client)
+            .await
+            .unwrap_err();
+
+    let http::Error::Service(err) = err else {
+        panic!("Expected Service error but got {err:?}");
+    };
+    assert_eq!(err.message(), "account user name");
+}
+
+async fn pwdgrp_remove_user_does_not_exist(client: &CassetteClient, _prelude: Option<Prelude>) {
+    let err = apis::pwdgrp::RemoveUserRequest::new("nonexistent_user")
+        .send(client)
+        .await
+        .unwrap_err();
+
+    let http::Error::Service(err) = err else {
+        panic!("Expected Service error but got {err:?}");
+    };
+    assert_eq!(err.message(), "account user name");
 }
 
 async fn remote_object_storage_1_beta_crud(client: &CassetteClient, prelude: Option<Prelude>) {


### PR DESCRIPTION
The error is added to allow callers to choose which errors to handle. I briefly made use of this in a device-manager, but ended up with a solution that does not need it.

The remove request is added mainly to enable writing more cassette tests since I want all test cases to clean up after themselves.