### PR TITLE
chore(vapix)!: Rename apis module

### DIFF
--- a/crates/device-finder/src/commands/discover_devices.rs
+++ b/crates/device-finder/src/commands/discover_devices.rs
@@ -6,7 +6,8 @@ use itertools::Itertools;
 use log::{debug, error, info, warn};
 use mdns::{RecordKind, Response};
 use rs4a_vapix::{
-    apis, basic_device_info_1::UnrestrictedProperties, system_ready_1::SystemreadyData,
+    basic_device_info_1::{GetAllUnrestrictedPropertiesRequest, UnrestrictedProperties},
+    system_ready_1::{SystemReadyRequest, SystemreadyData},
 };
 use tokio::{
     task::JoinSet,
@@ -165,9 +166,7 @@ async fn probe(
         needsetup,
         systemready,
         ..
-    } = apis::system_ready_1::SystemReadyRequest::new()
-        .send(&client)
-        .await?;
+    } = SystemReadyRequest::new().send(&client).await?;
     details
         .insert("Need Setup".to_string(), needsetup.to_string())
         .inspect(|_| panic!("Each key is created at most once"));
@@ -184,7 +183,7 @@ async fn probe(
         serial_number,
         version,
         ..
-    } = apis::basic_device_info_1::GetAllUnrestrictedPropertiesRequest::new()
+    } = GetAllUnrestrictedPropertiesRequest::new()
         .send(&client)
         .await?
         .property_list;

--- a/crates/device-inventory/src/commands/list.rs
+++ b/crates/device-inventory/src/commands/list.rs
@@ -2,9 +2,9 @@ use std::collections::{hash_map::Entry, HashMap};
 
 use anyhow::Context;
 use log::warn;
-use rs4a_vapix::{
-    apis,
-    basic_device_info_1::{AllProperties, RestrictedProperties, UnrestrictedProperties},
+use rs4a_vapix::basic_device_info_1::{
+    AllProperties, GetAllPropertiesRequest, GetAllUnrestrictedPropertiesRequest,
+    RestrictedProperties, UnrestrictedProperties,
 };
 use rs4a_vlt::requests;
 use tokio::task::JoinSet;
@@ -138,7 +138,7 @@ async fn probe_device(
             let AllProperties {
                 unrestricted,
                 restricted,
-            } = apis::basic_device_info_1::GetAllPropertiesRequest::new()
+            } = GetAllPropertiesRequest::new()
                 .send(&client)
                 .await?
                 .property_list;
@@ -153,11 +153,10 @@ async fn probe_device(
                 .await
                 .context("Could not create client")?;
 
-            let unrestricted =
-                apis::basic_device_info_1::GetAllUnrestrictedPropertiesRequest::new()
-                    .send(&client)
-                    .await?
-                    .property_list;
+            let unrestricted = GetAllUnrestrictedPropertiesRequest::new()
+                .send(&client)
+                .await?
+                .property_list;
             Ok((fingerprint, unrestricted, None))
         }
     }

--- a/crates/vapix/src/client.rs
+++ b/crates/vapix/src/client.rs
@@ -10,8 +10,8 @@ use reqwest::{
 use url::{Host, Position, Url};
 
 use crate::{
-    apis,
     http::{HttpClient, Request, Response},
+    system_ready_1::SystemReadyRequest,
 };
 
 #[derive(Clone)]
@@ -298,7 +298,7 @@ impl ClientBuilder {
         for (scheme, port) in schemes {
             candidate.scheme = *scheme;
             candidate.port = *port;
-            if apis::system_ready_1::SystemReadyRequest::new()
+            if SystemReadyRequest::new()
                 .timeout(1)
                 .send(candidate)
                 .await

--- a/crates/vapix/src/lib.rs
+++ b/crates/vapix/src/lib.rs
@@ -1,10 +1,10 @@
-pub mod apis;
 mod axis_cgi;
 mod client;
 mod config;
 pub mod http;
 pub mod json_rpc;
 pub(crate) mod json_rpc_http;
+pub mod requests;
 pub mod rest;
 pub mod rest_http;
 mod services;

--- a/crates/vapix/src/requests.rs
+++ b/crates/vapix/src/requests.rs
@@ -1,3 +1,8 @@
+//! Request builders for the APIs that have pre-built bindings.
+//!
+//! Each submodule re-exports the request builders for one API, making it easy to discover what is
+//! supported without navigating the full type surface of the crate.
+
 pub mod api_discovery_1 {
     pub use crate::api_discovery_1::{GetApiListRequest, GetSupportedVersionsRequest};
 }
@@ -66,9 +71,7 @@ pub mod network_settings_1 {
 }
 
 pub mod parameter_management {
-    pub use crate::parameter_management::{
-        ImageResolution, ListRequest, ParamList, Parameter, Resolution, UpdateRequest,
-    };
+    pub use crate::parameter_management::{ListRequest, UpdateRequest};
 }
 
 pub mod pwdgrp {

--- a/crates/vapix/tests/cassette_tests.rs
+++ b/crates/vapix/tests/cassette_tests.rs
@@ -5,17 +5,19 @@ use libtest_mimic::{Arguments, Trial};
 use log::{warn, LevelFilter};
 use rs4a_cassette_testing::{Cassette, CassetteClient, DeviceInfo, Library};
 use rs4a_vapix::{
-    api_discovery_1::{Api, ApiListData},
-    apis,
-    apis::basic_device_info_1,
-    basic_device_info_1::{ProductType, UnrestrictedProperties},
+    action1::{GetActionConfigurationsRequest, GetActionRulesRequest},
+    api_discovery_1::{Api, ApiListData, GetApiListRequest},
+    basic_device_info_1::{
+        GetAllPropertiesRequest, GetAllUnrestrictedPropertiesRequest, ProductType,
+        UnrestrictedProperties,
+    },
     discover::ApiState,
+    event1::GetEventInstancesRequest,
     firmware_management_1,
     firmware_management_1::UpgradeRequest,
     http,
     network_settings_1::{GetNetworkInfoRequest, SetGlobalProxyConfigurationRequest},
     parameter_management::{ImageResolution, ListRequest, NetworkSshEnabled, UpdateRequest},
-    pwdgrp::{Group, Role},
     remote_object_storage_1_beta::{
         AzureDestination, CreateDestinationRequest, DeleteDestinationRequest, DestinationData,
         DestinationId, ListDestinationsRequest, UpdateDestinationRequest,
@@ -24,6 +26,7 @@ use rs4a_vapix::{
     siren_and_light_2_alpha::{
         GetMaintenanceModeRequest, StartMaintenanceModeRequest, StopMaintenanceModeRequest,
     },
+    system_ready_1::SystemReadyRequest,
     ClientBuilder,
 };
 use semver::VersionReq;
@@ -246,15 +249,12 @@ fn record_trials(library: &Library) -> Vec<Trial> {
     });
 
     let prelude = rt.block_on(async {
-        let props = apis::basic_device_info_1::GetAllUnrestrictedPropertiesRequest::new()
+        let props = GetAllUnrestrictedPropertiesRequest::new()
             .send(&client)
             .await
             .unwrap()
             .property_list;
-        let api_list = apis::api_discovery_1::GetApiListRequest::default()
-            .send(&client)
-            .await
-            .unwrap();
+        let api_list = GetApiListRequest::default().send(&client).await.unwrap();
         Prelude { props, api_list }
     });
 
@@ -349,17 +349,11 @@ fn main() {
 }
 
 async fn action1_get_action_configurations(client: &CassetteClient, _prelude: Option<Prelude>) {
-    apis::action_1::GetActionConfigurationsRequest
-        .send(client)
-        .await
-        .unwrap();
+    GetActionConfigurationsRequest.send(client).await.unwrap();
 }
 
 async fn action1_get_action_rules(client: &CassetteClient, _prelude: Option<Prelude>) {
-    apis::action_1::GetActionRulesRequest
-        .send(client)
-        .await
-        .unwrap();
+    GetActionRulesRequest.send(client).await.unwrap();
 }
 
 async fn api_discovery_1_get_api_list(client: &CassetteClient, _: Option<Prelude>) {
@@ -393,7 +387,7 @@ async fn api_discovery_1_get_supported_versions(client: &CassetteClient, _: Opti
 }
 
 async fn basic_device_info_get_all_properties(client: &CassetteClient, _: Option<Prelude>) {
-    let property_list = basic_device_info_1::GetAllPropertiesRequest::new()
+    let property_list = GetAllPropertiesRequest::new()
         .send(client)
         .await
         .unwrap()
@@ -410,7 +404,7 @@ async fn basic_device_info_get_all_unrestricted_properties(
     client: &CassetteClient,
     _: Option<Prelude>,
 ) {
-    let property_list = basic_device_info_1::GetAllUnrestrictedPropertiesRequest::new()
+    let property_list = GetAllUnrestrictedPropertiesRequest::new()
         .send(client)
         .await
         .unwrap()
@@ -554,10 +548,7 @@ async fn device_configuration_item_already_exists(
 
 // TODO: Find a way to avoid the churn caused by XML lists not being consistently ordered
 async fn event1_get_event_instances(client: &CassetteClient, _prelude: Option<Prelude>) {
-    let data = apis::event_1::GetEventInstancesRequest
-        .send(client)
-        .await
-        .unwrap();
+    let data = GetEventInstancesRequest.send(client).await.unwrap();
     assert!(!data.message_instances.is_empty());
 }
 
@@ -661,18 +652,18 @@ async fn parameter_management_update_network_ssh_enabled(
 }
 
 async fn pwdgrp_add_user_already_exists(client: &CassetteClient, _prelude: Option<Prelude>) {
+    use rs4a_vapix::pwdgrp::{AddUserRequest, Group, RemoveUserRequest, Role};
     let username = "cassettetest";
 
-    apis::pwdgrp::AddUserRequest::new(username, "Good morning", Group::Users, Role::Viewer)
+    AddUserRequest::new(username, "Good morning", Group::Users, Role::Viewer)
         .send(client)
         .await
         .unwrap();
 
-    let err =
-        apis::pwdgrp::AddUserRequest::new(username, "Good morning", Group::Users, Role::Viewer)
-            .send(client)
-            .await
-            .unwrap_err();
+    let err = AddUserRequest::new(username, "Good morning", Group::Users, Role::Viewer)
+        .send(client)
+        .await
+        .unwrap_err();
 
     let http::Error::Service(err) = err else {
         panic!("Expected Service error but got {err:?}");
@@ -683,14 +674,13 @@ async fn pwdgrp_add_user_already_exists(client: &CassetteClient, _prelude: Optio
     );
 
     // Cleanup
-    apis::pwdgrp::RemoveUserRequest::new(username)
-        .send(client)
-        .await
-        .unwrap();
+    RemoveUserRequest::new(username).send(client).await.unwrap();
 }
 
 async fn pwdgrp_add_user_invalid_password(client: &CassetteClient, _prelude: Option<Prelude>) {
-    let err = apis::pwdgrp::AddUserRequest::new("testuser", "", Group::Users, Role::Viewer)
+    use rs4a_vapix::pwdgrp::{AddUserRequest, Group, Role};
+
+    let err = AddUserRequest::new("testuser", "", Group::Users, Role::Viewer)
         .send(client)
         .await
         .unwrap_err();
@@ -702,11 +692,12 @@ async fn pwdgrp_add_user_invalid_password(client: &CassetteClient, _prelude: Opt
 }
 
 async fn pwdgrp_add_user_invalid_username(client: &CassetteClient, _prelude: Option<Prelude>) {
-    let err =
-        apis::pwdgrp::AddUserRequest::new("user!", "Good morning", Group::Users, Role::Viewer)
-            .send(client)
-            .await
-            .unwrap_err();
+    use rs4a_vapix::pwdgrp::{AddUserRequest, Group, Role};
+
+    let err = AddUserRequest::new("user!", "Good morning", Group::Users, Role::Viewer)
+        .send(client)
+        .await
+        .unwrap_err();
 
     let http::Error::Service(err) = err else {
         panic!("Expected Service error but got {err:?}");
@@ -715,7 +706,9 @@ async fn pwdgrp_add_user_invalid_username(client: &CassetteClient, _prelude: Opt
 }
 
 async fn pwdgrp_remove_user_does_not_exist(client: &CassetteClient, _prelude: Option<Prelude>) {
-    let err = apis::pwdgrp::RemoveUserRequest::new("nonexistent_user")
+    use rs4a_vapix::pwdgrp::RemoveUserRequest;
+
+    let err = RemoveUserRequest::new("nonexistent_user")
         .send(client)
         .await
         .unwrap_err();
@@ -840,6 +833,8 @@ async fn siren_and_light_2_alpha_maintenance_mode_not_supported(
 }
 
 async fn ssh_1_crud(client: &CassetteClient, prelude: Option<Prelude>) {
+    use rs4a_vapix::ssh_1::{AddUserRequest, DeleteUserRequest, SetUserRequest};
+
     if let Some(prelude) = &prelude {
         if !prelude.supports_device_config() {
             return;
@@ -848,32 +843,30 @@ async fn ssh_1_crud(client: &CassetteClient, prelude: Option<Prelude>) {
 
     let username = "dalliard";
 
-    apis::ssh_1::AddUserRequest::new(username, "Good morning")
+    AddUserRequest::new(username, "Good morning")
         .comment("Good morning")
         .send(client)
         .await
         .unwrap();
 
-    apis::ssh_1::SetUserRequest::new(username)
+    SetUserRequest::new(username)
         .comment("When's the day?")
         .send(client)
         .await
         .unwrap();
 
-    apis::ssh_1::DeleteUserRequest::new(username)
-        .send(client)
-        .await
-        .unwrap();
+    DeleteUserRequest::new(username).send(client).await.unwrap();
 }
 
 async fn ssh_1_set_user_does_not_exist(client: &CassetteClient, prelude: Option<Prelude>) {
+    use rs4a_vapix::ssh_1::SetUserRequest;
     if let Some(prelude) = &prelude {
         if !prelude.supports_device_config() {
             return;
         }
     }
 
-    let error = apis::ssh_1::SetUserRequest::new("nonexistent_user")
+    let error = SetUserRequest::new("nonexistent_user")
         .comment("should fail")
         .send(client)
         .await
@@ -887,6 +880,8 @@ async fn ssh_1_set_user_does_not_exist(client: &CassetteClient, prelude: Option<
 }
 
 async fn ssh_1_set_user_validation_error(client: &CassetteClient, prelude: Option<Prelude>) {
+    use rs4a_vapix::ssh_1::{AddUserRequest, DeleteUserRequest, SetUserRequest};
+
     if let Some(prelude) = &prelude {
         if !prelude.supports_device_config() {
             return;
@@ -895,14 +890,14 @@ async fn ssh_1_set_user_validation_error(client: &CassetteClient, prelude: Optio
 
     let username = "cassette_test_validation";
 
-    apis::ssh_1::AddUserRequest::new(username, "Good morning")
+    AddUserRequest::new(username, "Good morning")
         .comment("Good morning")
         .send(client)
         .await
         .unwrap();
 
     // Empty string violates the minimum length of 1
-    let error = apis::ssh_1::SetUserRequest::new(username)
+    let error = SetUserRequest::new(username)
         .password("")
         .send(client)
         .await
@@ -915,10 +910,7 @@ async fn ssh_1_set_user_validation_error(client: &CassetteClient, prelude: Optio
     assert_eq!(error.kind().unwrap(), ErrorKind::ValidationError);
 
     // Clean up
-    apis::ssh_1::DeleteUserRequest::new(username)
-        .send(client)
-        .await
-        .unwrap();
+    DeleteUserRequest::new(username).send(client).await.unwrap();
 }
 
 async fn network_settings_1_get_network_info(client: &CassetteClient, prelude: Option<Prelude>) {
@@ -977,9 +969,6 @@ async fn network_settings_1_set_global_proxy_configuration(
 }
 
 async fn system_ready_1_system_ready(client: &CassetteClient, _prelude: Option<Prelude>) {
-    let data = apis::system_ready_1::SystemReadyRequest::new()
-        .send(client)
-        .await
-        .unwrap();
+    let data = SystemReadyRequest::new().send(client).await.unwrap();
     assert!(data.systemready);
 }

--- a/crates/vapix/tests/serde.rs
+++ b/crates/vapix/tests/serde.rs
@@ -2,8 +2,11 @@ use std::time::Duration;
 
 use expect_test::expect_file;
 use rs4a_vapix::{
-    action1::{AddActionConfigurationResponse, Condition},
-    apis, basic_device_info_1,
+    action1::{
+        AddActionConfigurationRequest, AddActionConfigurationResponse, AddActionRuleRequest,
+        Condition, GetActionConfigurationsRequest, GetActionRulesRequest,
+    },
+    basic_device_info_1,
     basic_device_info_1::{AllPropertiesData, AllUnrestrictedPropertiesData, Architecture},
     firmware_management_1,
     firmware_management_1::UpgradeData,
@@ -77,7 +80,7 @@ fn can_deserialize_system_ready_1_preview_mode() {
 #[test]
 fn can_serialize_action_1_requests() {
     expect_file!["./snapshots/add_action_configuration.xml"].assert_eq(
-        &apis::action_1::AddActionConfigurationRequest::new("com.axis.action.fixed.ledcontrol")
+        &AddActionConfigurationRequest::new("com.axis.action.fixed.ledcontrol")
             .name("Flash status LED")
             .param("led", "statusled")
             .param("color", "green,none")
@@ -87,7 +90,7 @@ fn can_serialize_action_1_requests() {
             .unwrap(),
     );
     expect_file!["./snapshots/add_action_rule.xml"].assert_eq(
-        &apis::action_1::AddActionRuleRequest::new("My Action Rule".to_string(), 123)
+        &AddActionRuleRequest::new("My Action Rule".to_string(), 123)
             .condition(Condition {
                 topic_expression: "tns1:Device/tnsaxis:Status/SystemReady".to_string(),
                 message_content: r#"boolean(//SimpleItem[@Name="ready" and @Value="1"])"#
@@ -96,7 +99,7 @@ fn can_serialize_action_1_requests() {
             .into_envelope(),
     );
     expect_file!["./snapshots/get_action_configurations.xml"]
-        .assert_eq(&apis::action_1::GetActionConfigurationsRequest::new().into_envelope());
+        .assert_eq(&GetActionConfigurationsRequest::new().into_envelope());
     expect_file!["./snapshots/get_action_rules.xml"]
-        .assert_eq(&apis::action_1::GetActionRulesRequest::new().into_envelope());
+        .assert_eq(&GetActionRulesRequest::new().into_envelope());
 }

--- a/crates/vapix/tests/smoke_tests.rs
+++ b/crates/vapix/tests/smoke_tests.rs
@@ -2,9 +2,15 @@ use std::{ops::Rem, time::SystemTime};
 
 use log::LevelFilter;
 use rs4a_vapix::{
-    action1::Condition,
-    apis,
+    action1::{
+        AddActionConfigurationRequest, AddActionRuleRequest, Condition,
+        GetActionConfigurationsRequest, GetActionRulesRequest,
+    },
+    event1::GetEventInstancesRequest,
+    recording_group_1::CreateRecordingGroupsRequest,
     remote_object_storage_1_beta::{CreateDestinationRequest, DestinationId, S3Destination},
+    requests::jpg_3::GetImageRequest,
+    system_ready_1::SystemReadyRequest,
     Client, ClientBuilder,
 };
 use serde_json::json;
@@ -38,7 +44,7 @@ async fn action_1_get_action_configurations_returns_ok() {
     let Some(client) = test_client().await else {
         return;
     };
-    apis::action_1::GetActionConfigurationsRequest::new()
+    GetActionConfigurationsRequest::new()
         .send(&client)
         .await
         .unwrap();
@@ -51,7 +57,7 @@ async fn action_1_add_and_get_returns_ok() {
     };
 
     let action_configuration_id =
-        apis::action_1::AddActionConfigurationRequest::new("com.axis.action.fixed.ledcontrol")
+        AddActionConfigurationRequest::new("com.axis.action.fixed.ledcontrol")
             .param("led", "statusled")
             .param("color", "green,none")
             .param("duration", "1")
@@ -62,20 +68,19 @@ async fn action_1_add_and_get_returns_ok() {
             .configuration_id;
 
     let action_rule_name = "smoke test rule";
-    let action_rule_id = apis::action_1::AddActionRuleRequest::new(
-        action_rule_name.to_string(),
-        action_configuration_id,
-    )
-    .condition(Condition {
-        topic_expression: "tns1:Device/tnsaxis:Status/SystemReady".to_string(),
-        message_content: r#"boolean(//SimpleItem[@Name="ready" and @Value="1"])"#.to_string(),
-    })
-    .send(&client)
-    .await
-    .unwrap()
-    .id;
+    let action_rule_id =
+        AddActionRuleRequest::new(action_rule_name.to_string(), action_configuration_id)
+            .condition(Condition {
+                topic_expression: "tns1:Device/tnsaxis:Status/SystemReady".to_string(),
+                message_content: r#"boolean(//SimpleItem[@Name="ready" and @Value="1"])"#
+                    .to_string(),
+            })
+            .send(&client)
+            .await
+            .unwrap()
+            .id;
 
-    let actions_rules = apis::action_1::GetActionRulesRequest::new()
+    let actions_rules = GetActionRulesRequest::new()
         .send(&client)
         .await
         .unwrap()
@@ -95,10 +100,7 @@ async fn event_1_get_event_instances_returns_ok() {
     let Some(client) = test_client().await else {
         return;
     };
-    apis::event_1::GetEventInstancesRequest::new()
-        .send(&client)
-        .await
-        .unwrap();
+    GetEventInstancesRequest::new().send(&client).await.unwrap();
 }
 
 #[tokio::test]
@@ -106,7 +108,7 @@ async fn jpg_get_image_returns_ok() {
     let Some(client) = test_client().await else {
         return;
     };
-    apis::jpg_3::GetImageRequest::new()
+    GetImageRequest::new()
         .compression(100)
         .send(&client)
         .await
@@ -143,7 +145,7 @@ async fn recording_group_1_create_returns_ok() {
         actual_recording_destination_id.into_string()
     );
 
-    apis::recording_group_1::CreateRecordingGroupsRequest::new()
+    CreateRecordingGroupsRequest::new()
         .data(json!({
             "destinations": [{
                 "remoteObjectStorage":  {
@@ -161,8 +163,5 @@ async fn system_ready_system_ready_returns_ok() {
     let Some(client) = test_client().await else {
         return;
     };
-    apis::system_ready_1::SystemReadyRequest::new()
-        .send(&client)
-        .await
-        .unwrap();
+    SystemReadyRequest::new().send(&client).await.unwrap();
 }


### PR DESCRIPTION
Agents repeatedly try to re-export items that are not request builders leading me to think that the name could be more clear.

Also:
- Added a docstring to help agent and human contributors and users alike
- Removed some re-exports that are not request builders and therefore do not belong.

Call sites are updated to import the type and reference it directly since that follows the suggestion from the rust book, is more concise and generally unambiguous.