### PR TITLE
feat(dm): Add VLT profile

### DIFF
--- a/crates/cli4a/src/commands/install.rs
+++ b/crates/cli4a/src/commands/install.rs
@@ -26,6 +26,9 @@ pub struct InstallCommand {
     /// Auto-rollback behavior: "never", or minutes
     #[arg(long, short = 'r')]
     auto_rollback: Option<String>,
+    /// Device initialization profile
+    #[arg(long, default_value_t)]
+    profile: rs4a_device_manager::Profile,
 }
 
 fn version_from_firmware_path(path: &Path) -> anyhow::Result<Version> {
@@ -47,6 +50,7 @@ impl InstallCommand {
             offline,
             auto_commit,
             auto_rollback,
+            profile,
         } = self;
 
         info!("Querying device for model and version");
@@ -120,6 +124,7 @@ impl InstallCommand {
             let init_cli = rs4a_device_manager::Cli {
                 command: rs4a_device_manager::Commands::Init(rs4a_device_manager::InitCommand {
                     netloc,
+                    profile,
                 }),
             };
             init_cli.exec().await?;

--- a/crates/device-manager/src/commands/init.rs
+++ b/crates/device-manager/src/commands/init.rs
@@ -1,36 +1,48 @@
 use anyhow::{bail, Context};
 use log::{debug, info, warn};
 use rs4a_vapix::{
-    applications_config, basic_device_info_1::GetAllUnrestrictedPropertiesRequest,
-    parameter_management, pwdgrp, pwdgrp::AddUserRequest, system_ready_1::SystemReadyRequest,
+    applications_config,
+    basic_device_info_1::GetAllUnrestrictedPropertiesRequest,
+    http::Error,
+    network_settings_1::{SetGlobalProxyConfigurationData, SetGlobalProxyConfigurationRequest},
+    parameter_management, pwdgrp,
+    pwdgrp::AddUserRequest,
+    system_ready_1::SystemReadyRequest,
+    Client,
 };
 use semver::Version;
 
 use crate::Netloc;
 
+#[derive(Clone, Debug, Default, clap::ValueEnum)]
+pub enum Profile {
+    #[default]
+    Default,
+    Vlt,
+}
+
+impl std::fmt::Display for Profile {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Profile::Default => write!(f, "default"),
+            Profile::Vlt => write!(f, "vlt"),
+        }
+    }
+}
+
 #[derive(Clone, Debug, clap::Args)]
 pub struct InitCommand {
     #[command(flatten)]
     pub netloc: Netloc,
+    #[arg(long, default_value_t)]
+    pub profile: Profile,
 }
 
 impl InitCommand {
     pub async fn exec(self) -> anyhow::Result<String> {
-        require_root_user(&self.netloc)?;
-        initialize(&self.netloc).await?;
+        initialize(&self.netloc, &self.profile).await?;
         Ok(String::new())
     }
-}
-
-pub fn require_root_user(netloc: &Netloc) -> anyhow::Result<()> {
-    if netloc.user != "root" {
-        bail!(
-            "The --user must be 'root' (got '{}'); the initial user is always 'root' \
-             because older firmware requires it",
-            netloc.user
-        );
-    }
-    Ok(())
 }
 
 fn parse_firmware_version(s: &str) -> anyhow::Result<Version> {
@@ -65,28 +77,65 @@ async fn apply_setup_profile(client: &rs4a_vapix::Client) -> anyhow::Result<()> 
     Ok(())
 }
 
-pub async fn initialize(netloc: &Netloc) -> anyhow::Result<()> {
-    info!("Initializing device...");
+async fn create_user(netloc: &Netloc, anonymous_client: &Client) -> anyhow::Result<()> {
+    debug!("adding initial user");
+    let result = AddUserRequest::new(
+        &netloc.user,
+        &netloc.pass,
+        pwdgrp::Group::Root,
+        pwdgrp::Role::AdminOperatorViewerPtz,
+    )
+    .send(anonymous_client)
+    .await;
 
-    // Device needs setup, no authentication possible or required
-    let client = netloc.connect_anonymous().await?;
-
-    let data = SystemReadyRequest::new().send(&client).await?;
-    if !data.needsetup {
-        bail!("Expected device to be in setup mode, but needsetup is false");
+    match result {
+        Ok(()) => return Ok(()),
+        Err(Error::Service(e)) if e.message() == "not a valid initial admin user" => {}
+        Err(e) => return Err(e).context("Failed to create user"),
     }
 
-    info!("Adding root user...");
+    debug!("adding root user");
     AddUserRequest::new(
         "root",
         &netloc.pass,
         pwdgrp::Group::Root,
         pwdgrp::Role::AdminOperatorViewerPtz,
     )
-    .send(&client)
-    .await?;
+    .send(anonymous_client)
+    .await
+    .context("create root user failed")?;
 
-    // Device no longer needs setup, authentication is required
+    debug!("connecting as root");
+    let root_client = netloc.connect_as("root").await?;
+
+    debug!("adding initial user using root as springboard");
+    AddUserRequest::new(
+        &netloc.user,
+        &netloc.pass,
+        pwdgrp::Group::Root,
+        pwdgrp::Role::AdminOperatorViewerPtz,
+    )
+    .send(&root_client)
+    .await
+    .context("create initial user failed")?;
+
+    Ok(())
+}
+
+pub async fn initialize(netloc: &Netloc, profile: &Profile) -> anyhow::Result<()> {
+    info!("Initializing device...");
+
+    let anonymous_client = netloc.connect_anonymous().await?;
+
+    let data = SystemReadyRequest::new().send(&anonymous_client).await?;
+    if data.needsetup {
+        create_user(netloc, &anonymous_client).await?;
+    } else if matches!(profile, Profile::Vlt) {
+        info!("Device already set up, skipping root user creation");
+    } else {
+        bail!("Expected device to be in setup mode, but needsetup is false");
+    }
+
     let client = netloc.connect().await?;
 
     info!("Enabling SSH...");
@@ -102,6 +151,17 @@ pub async fn initialize(netloc: &Netloc) -> anyhow::Result<()> {
     }
 
     apply_setup_profile(&client).await?;
+
+    if matches!(profile, Profile::Vlt) {
+        // FIXME: Skip when not supported by firmware
+        info!("Setting global proxy configuration...");
+        let SetGlobalProxyConfigurationData { .. } = SetGlobalProxyConfigurationRequest::new()
+            .http_proxy("http://localhost:8118")
+            .https_proxy("http://localhost:8118")
+            .no_proxy("127.0.0.12")
+            .send(&client)
+            .await?;
+    }
 
     info!("Device initialized");
     Ok(())

--- a/crates/device-manager/src/commands/reinit.rs
+++ b/crates/device-manager/src/commands/reinit.rs
@@ -1,16 +1,18 @@
+use super::init::Profile;
 use crate::Netloc;
 
 #[derive(Clone, Debug, clap::Args)]
 pub struct ReinitCommand {
     #[command(flatten)]
     pub netloc: Netloc,
+    #[arg(long, default_value_t)]
+    pub profile: Profile,
 }
 
 impl ReinitCommand {
     pub async fn exec(self) -> anyhow::Result<String> {
-        super::init::require_root_user(&self.netloc)?;
         super::restore::restore(&self.netloc).await?;
-        super::init::initialize(&self.netloc).await?;
+        super::init::initialize(&self.netloc, &self.profile).await?;
         Ok(String::new())
     }
 }

--- a/crates/device-manager/src/lib.rs
+++ b/crates/device-manager/src/lib.rs
@@ -7,7 +7,10 @@ use rs4a_bin_utils::completions_command::CompletionsCommand;
 use url::Host;
 
 pub use crate::commands::{
-    init::InitCommand, reinit::ReinitCommand, restore::RestoreCommand, upgrade::UpgradeCommand,
+    init::{InitCommand, Profile},
+    reinit::ReinitCommand,
+    restore::RestoreCommand,
+    upgrade::UpgradeCommand,
 };
 
 #[derive(Clone, Debug, clap::Args)]
@@ -34,10 +37,14 @@ pub struct Netloc {
 
 impl Netloc {
     pub async fn connect(&self) -> anyhow::Result<rs4a_vapix::Client> {
+        self.connect_as(&self.user).await
+    }
+
+    pub async fn connect_as(&self, user: &str) -> anyhow::Result<rs4a_vapix::Client> {
         rs4a_vapix::ClientBuilder::new(self.host.clone())
             .plain_port(self.http_port)
             .secure_port(self.https_port)
-            .username_password(&self.user, &self.pass)
+            .username_password(user, &self.pass)
             .with_inner(|b| b.danger_accept_invalid_certs(self.https_self_signed))
             .build()
             .await

--- a/snapshots/cli4a-docs
+++ b/snapshots/cli4a-docs
@@ -92,5 +92,11 @@ Options:
   -r, --auto-rollback <AUTO_ROLLBACK>
           Auto-rollback behavior: "never", or minutes
 
+      --profile <PROFILE>
+          Device initialization profile
+          
+          [default: default]
+          [possible values: default, vlt]
+
   -h, --help
           Print help (see a summary with '-h')

--- a/snapshots/device-manager-docs
+++ b/snapshots/device-manager-docs
@@ -43,6 +43,7 @@ Options:
   -u, --user <USER>              The username to use for authentication [env: AXIS_DEVICE_USER=] [default: root]
   -p, --pass <PASS>              The password to use for authentication [env: AXIS_DEVICE_PASS=] [default: pass]
       --https-self-signed        Accept self-signed HTTPS certificates [env: AXIS_DEVICE_HTTPS_SELF_SIGNED=]
+      --profile <PROFILE>        [default: default] [possible values: default, vlt]
   -h, --help                     Print help
 + device-manager help reinit
 Restore and initialize the device to a known, useful state
@@ -56,6 +57,7 @@ Options:
   -u, --user <USER>              The username to use for authentication [env: AXIS_DEVICE_USER=] [default: root]
   -p, --pass <PASS>              The password to use for authentication [env: AXIS_DEVICE_PASS=] [default: pass]
       --https-self-signed        Accept self-signed HTTPS certificates [env: AXIS_DEVICE_HTTPS_SELF_SIGNED=]
+      --profile <PROFILE>        [default: default] [possible values: default, vlt]
   -h, --help                     Print help
 + device-manager help restore
 Restore the device to a clean state (factory default)


### PR DESCRIPTION
Devices from the virtual loan tool (VLT) have some properties that make them a bad fit for device-manager up until now, mainly that they start with the VLTuser and that user must never be removed.

The global proxies are also configured to enable internet access via SSH. The API is available from AXIS OS 11, but the settings aren't available in the GUI before AXIS OS 12 and it's unclear what effect they have - getting the OAK appears to not work.