### PR TITLE
feat: Make developer tools available through nix flake

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -20,3 +20,5 @@ jobs:
         run: nix develop --ignore-env --command make
       - name: Run checks
         run: nix develop --ignore-env --command make check
+      - name: Check flake
+        run: nix flake check

--- a/crates/cli4a/Cargo.toml
+++ b/crates/cli4a/Cargo.toml
@@ -3,6 +3,7 @@ name = "cli4a"
 version = "0.1.0"
 edition.workspace = true
 license = "MIT"
+description = "A collection of development tools"
 
 [lints]
 workspace = true

--- a/crates/device-finder/Cargo.toml
+++ b/crates/device-finder/Cargo.toml
@@ -3,13 +3,14 @@ name = "device-finder"
 version = "0.1.0"
 edition.workspace = true
 license = "MIT"
+description = "Discover devices on the local network using mDNS"
 
 [lints]
 workspace = true
 
 [dependencies]
 anyhow = { workspace = true }
-clap = { workspace = true, features = ["derive"] }
+clap = { workspace = true, features = ["derive", "env"] }
 env_logger = { workspace = true }
 futures-util = { workspace = true }
 itertools = { workspace = true }

--- a/crates/device-inventory/Cargo.toml
+++ b/crates/device-inventory/Cargo.toml
@@ -3,6 +3,7 @@ name = "device-inventory"
 version = "0.1.1"
 edition.workspace = true
 license = "MIT"
+description = "Utilities for tracking multiple devices"
 
 [lints]
 workspace = true

--- a/crates/device-manager/Cargo.toml
+++ b/crates/device-manager/Cargo.toml
@@ -3,6 +3,7 @@ name = "rs4a-device-manager"
 version = "0.1.0"
 edition.workspace = true
 license = "MIT"
+description = "Utilities for managing devices"
 
 [lints]
 workspace = true

--- a/crates/firmware-inventory/Cargo.toml
+++ b/crates/firmware-inventory/Cargo.toml
@@ -3,6 +3,7 @@ name = "rs4a-firmware-inventory"
 version = "0.1.0"
 edition.workspace = true
 license = "MIT"
+description = "Utilities for filtering, downloading and caching firmware"
 
 [lints]
 workspace = true

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,26 @@
+{
+  lib,
+  rustPlatform,
+  dir,
+}:
+let
+  cargoToml = builtins.fromTOML (builtins.readFile ./crates/${dir}/Cargo.toml);
+in
+rustPlatform.buildRustPackage {
+  pname = cargoToml.package.name;
+  inherit (cargoToml.package) version;
+  src = lib.fileset.toSource {
+    root = ./.;
+    fileset = lib.fileset.unions [
+      ./Cargo.lock
+      ./Cargo.toml
+      ./crates
+    ];
+  };
+  cargoLock.lockFile = ./Cargo.lock;
+  cargoBuildFlags = [
+    "-p"
+    cargoToml.package.name
+  ];
+  doCheck = false;
+}

--- a/flake.nix
+++ b/flake.nix
@@ -32,10 +32,25 @@
           overlays = [ (import rust-overlay) ];
         };
         rustToolchain = pkgs.rust-bin.fromRustupToolchainFile ./rust-toolchain.toml;
+        rustPlatform = pkgs.makeRustPlatform {
+          rustc = rustToolchain;
+          cargo = rustToolchain;
+        };
+        buildWorkspaceMember = dir: pkgs.callPackage ./default.nix { inherit rustPlatform dir; };
       in
       {
 
         formatter = pkgs.nixfmt-rfc-style;
+
+        checks = self.packages.${system};
+
+        packages = {
+          cli4a = buildWorkspaceMember "cli4a";
+          device-finder = buildWorkspaceMember "device-finder";
+          device-inventory = buildWorkspaceMember "device-inventory";
+          device-manager = buildWorkspaceMember "device-manager";
+          firmware-inventory = buildWorkspaceMember "firmware-inventory";
+        };
 
         devShells.default = pkgs.mkShell {
           nativeBuildInputs = with pkgs; [


### PR DESCRIPTION
To make it easier for me, and others, to add them to their nix-based development environment.

---

`.github/workflows/main.yaml`:
- Make sure the packages can be built since the existing setup evidently does not ensure this. It's not added to `make check` because I also use systems without nix and it is annoying when the workflows, notably `make fix_format`, do not work. There's some work to do here in figuring out what systems I want to support and how to make it ergonomic while ensuring CI coverage.

`crates/device-finder/Cargo.toml`:
- Add the env feature because the binary crate does not build independently without it. This is a pre-existing problem, e.g. when following the installation instructions in the readme.