### PR TITLE
fix(vapix): Skip serializing comment when none in ssh 1

### DIFF
--- a/crates/vapix/src/apis/config/ssh_1.rs
+++ b/crates/vapix/src/apis/config/ssh_1.rs
@@ -15,6 +15,7 @@ use crate::{
 
 #[derive(Serialize)]
 pub struct AddUserRequest {
+    #[serde(skip_serializing_if = "Option::is_none")]
     comment: Option<String>,
     password: String,
     username: String,

--- a/crates/vapix/tests/cassette_tests.rs
+++ b/crates/vapix/tests/cassette_tests.rs
@@ -223,6 +223,7 @@ cassette_tests! {
     pwdgrp_remove_user_does_not_exist,
     remote_object_storage_1_beta_crud,
     siren_and_light_2_alpha_maintenance_mode_not_supported,
+    ssh_1_add_user_without_comment,
     ssh_1_crud,
     ssh_1_set_user_does_not_exist,
     ssh_1_set_user_validation_error,
@@ -835,6 +836,25 @@ async fn siren_and_light_2_alpha_maintenance_mode_not_supported(
     };
 
     assert_eq!(error.kind(), Some(ErrorKind::InternalError));
+}
+
+async fn ssh_1_add_user_without_comment(client: &CassetteClient, prelude: Option<Prelude>) {
+    use rs4a_vapix::apis::ssh_1::{AddUserRequest, DeleteUserRequest};
+
+    if let Some(prelude) = &prelude {
+        if !prelude.supports_device_config() {
+            return;
+        }
+    }
+
+    let username = "nocomment";
+
+    AddUserRequest::new(username, "Good morning")
+        .send(client)
+        .await
+        .unwrap();
+
+    DeleteUserRequest::new(username).send(client).await.unwrap();
 }
 
 async fn ssh_1_crud(client: &CassetteClient, prelude: Option<Prelude>) {


### PR DESCRIPTION
Because this would fail with an error like:

```
Error: Failed to add SSH user

Caused by:
    (5) Validation error: Trying to add to 'users' with invalid data: null is not of type "string" (path: /comment)
```