### PR TITLE
chore: warn on clippy::index_slicing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,5 +44,9 @@ rs4a-vlt = { path = "crates/vlt" }
 [workspace.package]
 edition = "2021"
 
+[workspace.lints.clippy]
+indexing_slicing = "warn"
+allow_attributes_without_reason = "warn"
+
 [workspace.lints.rust]
 unsafe_code = "forbid"

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,1 @@
+allow-indexing-slicing-in-tests = true

--- a/crates/cassette-testing/src/cassette.rs
+++ b/crates/cassette-testing/src/cassette.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::indexing_slicing, reason = "TODO: Improve this")]
+
 use std::{
     hash::{DefaultHasher, Hash, Hasher},
     sync::Mutex,

--- a/crates/cassette-testing/src/library.rs
+++ b/crates/cassette-testing/src/library.rs
@@ -178,7 +178,7 @@ impl Library {
                     continue;
                 }
                 let is_referenced =
-                    referenced_hashes.map_or(false, |hashes| hashes.contains(name_str.as_ref()));
+                    referenced_hashes.is_some_and(|hashes| hashes.contains(name_str.as_ref()));
                 if !is_referenced {
                     log::info!("Removing unreferenced cassette: {sub_path:?}");
                     fs::remove_dir_all(&sub_path)?;
@@ -298,8 +298,9 @@ impl Manifest {
         if let Some(label) = matched {
             return label.to_string();
         }
-        if devices.len() == 1 {
-            return devices[0].clone();
+        // TODO: Reconsider the correct behavior when there are 0 or more than 1 devices.
+        if let [d] = devices {
+            return d.clone();
         }
         fallback
     }

--- a/crates/device-inventory/src/commands/list.rs
+++ b/crates/device-inventory/src/commands/list.rs
@@ -112,7 +112,7 @@ impl Table {
     }
 }
 
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, reason = "TODO: Improve this")]
 async fn probe_device(
     offline: bool,
     fingerprint: String,

--- a/crates/firmware-inventory/src/commands/get.rs
+++ b/crates/firmware-inventory/src/commands/get.rs
@@ -39,17 +39,19 @@ impl GetCommand {
         let index = db.read_index()?;
         let matching: Vec<_> = index.keys().filter(|p| product.matches(p)).collect();
 
-        match matching.len() {
-            0 => bail!(
-                "No indexed products matched {product:?}. Run update-index first.",
+        let product = match matching.as_slice() {
+            [] => bail!("No indexed products matched {product:?}. Run update-index first.",),
+            [p] => *p,
+            pss => bail!(
+                "Product glob {product} matched {} products: {pss:?}. Use a more specific pattern.",
+                pss.len()
             ),
-            1 => {}
-            n => bail!(
-                "Product glob {product} matched {n} products: {matching:?}. Use a more specific pattern."
-            ),
-        }
+        };
 
-        let product = matching[0];
+        #[expect(
+            clippy::indexing_slicing,
+            reason = "product is one of the keys in the index"
+        )]
         let versions = &index[product];
 
         let best = versions

--- a/crates/firmware-inventory/src/commands/list.rs
+++ b/crates/firmware-inventory/src/commands/list.rs
@@ -32,7 +32,7 @@ impl ListCommand {
         let index = db.read_index()?;
         let matching: Vec<_> = index
             .keys()
-            .filter(|p| product.as_ref().map_or(true, |pat| pat.matches(p)))
+            .filter(|p| product.as_ref().is_none_or(|pat| pat.matches(p)))
             .collect();
 
         if matching.is_empty() {
@@ -41,6 +41,10 @@ impl ListCommand {
 
         let mut out = String::new();
         for product in &matching {
+            #[expect(
+                clippy::indexing_slicing,
+                reason = "product is one of the keys in the index"
+            )]
             let versions = &index[product.as_str()];
             let mut entries: Vec<_> = versions
                 .iter()

--- a/crates/vapix/src/apis/axis_cgi/jpg_3.rs
+++ b/crates/vapix/src/apis/axis_cgi/jpg_3.rs
@@ -69,7 +69,9 @@ impl GetImageRequest {
 
         let magic = b"\xFF\xD8\xFF";
         if !bytes.starts_with(magic) {
-            bail!("Expected magic bytes {magic:?}, but got {:?}", &bytes[..3])
+            #[expect(clippy::indexing_slicing, reason = "range is clipped to array length")]
+            let prefix = &bytes[..bytes.len().min(3)];
+            bail!("Expected magic bytes {magic:?}, but got {prefix:?}");
         }
 
         Ok(bytes)

--- a/crates/vapix/src/apis/axis_cgi/system_ready_1.rs
+++ b/crates/vapix/src/apis/axis_cgi/system_ready_1.rs
@@ -72,11 +72,7 @@ impl SystemreadyData {
     pub fn parse_preview_mode(&self) -> Result<Option<Duration>, std::num::ParseIntError> {
         self.previewmode
             .as_deref()
-            .map(|s| {
-                s.parse::<u64>()
-                    .map(Duration::from_secs)
-                    .map_err(Into::into)
-            })
+            .map(|s| s.parse::<u64>().map(Duration::from_secs))
             .transpose()
     }
 }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.82.0"
+channel = "1.85.1"
 components = ["cargo", "clippy", "rustc", "rust-docs", "rustfmt", "rust-src", "rust-std"]


### PR DESCRIPTION
Inspired by two articles that I read today. The first [^1] made the case for enabling more lints and more importantly reminded me of `allow_attributes_without_reason`. The second [^2] reviewed CVEs in `uutils` and how they could have been avoided. I'm curious about all the lints suggested, but starting with `index_slicing` because I thought it would require the least code changes.

Details
=======

`crates/cassette-testing/src/cassette.rs`:
- Deferring the cleanup of this file is OK because the cassette tests are only used for tests that either run supervised or have no side effects.

`crates/firmware-inventory/src/commands/get.rs`:
- Replace the first slice with a pattern that makes the panic provably impossible. I learned about this pattern recently from an article and I'm happy I finally found a reason to apply it. Unfortunately I don't remember which article.

`crates/firmware-inventory/src/commands/list.rs`,
`crates/cassette-testing/src/library.rs`:
- Replace `map_or` to silence `clippy::unnecessary_map_or`, which appeared after upgrading rust.

`crates/vapix/src/apis/axis_cgi/system_ready_1.rs`:
- Remove `map_err` to silence `clippy::useless_conversion`, which appeared after upgrading rust.

`rust-toolchain.toml`:
- Upgrade rust to 1.85 to get access to `allow-indexing-slicing-in-tests`
- Don't upgrade rust past 1.85 to avoid needlessly raising the MSRV.

Footers
=======

[^1]: https://emschwartz.me/your-clippy-config-should-be-stricter/
[^2]: https://corrode.dev/blog/bugs-rust-wont-catch/#rule-turn-bad-input-into-errors-not-panics