### PR TITLE
feat(vapix)!: Remove use of `non_exhaustive` attribute in API bindings

### DIFF
--- a/crates/device-inventory/src/fusion.rs
+++ b/crates/device-inventory/src/fusion.rs
@@ -28,7 +28,6 @@ fn convert_architecture(a: Architecture) -> anyhow::Result<DeviceArchitecture> {
         Architecture::Armv7hf => Ok(DeviceArchitecture::Armv7hf),
         Architecture::Armv7l => Ok(DeviceArchitecture::Armv7l),
         Architecture::Mips => Ok(DeviceArchitecture::Mips),
-        _ => Err(anyhow::anyhow!("not implemented for {a:?}")),
     }
 }
 

--- a/crates/vapix/src/apis/axis_cgi/api_discovery_1.rs
+++ b/crates/vapix/src/apis/axis_cgi/api_discovery_1.rs
@@ -24,7 +24,6 @@ impl ApiId {
     }
 }
 
-#[non_exhaustive]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ApiListData {
@@ -45,7 +44,6 @@ impl ApiListData {
     }
 }
 
-#[non_exhaustive]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Api {
@@ -84,7 +82,6 @@ impl GetApiListRequest {
     }
 }
 
-#[non_exhaustive]
 #[derive(Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct SupportedVersionsData {
@@ -133,7 +130,6 @@ impl Api {
     }
 }
 
-#[non_exhaustive]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum ApiStatus {
     Official,

--- a/crates/vapix/src/apis/axis_cgi/basic_device_info_1.rs
+++ b/crates/vapix/src/apis/axis_cgi/basic_device_info_1.rs
@@ -17,7 +17,6 @@ use crate::{
 };
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-#[non_exhaustive]
 pub enum ErrorKind {
     InvalidParameter = 1000,
     AccessForbidden = 2001,
@@ -73,7 +72,6 @@ where
     }
 }
 
-#[non_exhaustive]
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
 pub enum ProductType {
     AirQualitySensor,
@@ -119,14 +117,12 @@ impl FromStr for ProductType {
     }
 }
 
-#[non_exhaustive]
 #[derive(Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct AllUnrestrictedPropertiesData {
     pub property_list: UnrestrictedProperties,
 }
 
-#[non_exhaustive]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "PascalCase")]
 pub struct UnrestrictedProperties {
@@ -193,7 +189,6 @@ impl Default for GetAllUnrestrictedPropertiesRequest {
     }
 }
 
-#[non_exhaustive]
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Deserialize, Serialize)]
 #[serde(rename_all = "lowercase")]
 pub enum Architecture {
@@ -306,7 +301,6 @@ impl<'de> Deserialize<'de> for SocSerialNumber {
     }
 }
 
-#[non_exhaustive]
 #[derive(Debug, Deserialize, Serialize)]
 #[serde(rename_all = "PascalCase")]
 pub struct RestrictedProperties {
@@ -339,7 +333,6 @@ pub struct AllProperties {
     pub restricted: RestrictedProperties,
 }
 
-#[non_exhaustive]
 #[derive(Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct AllPropertiesData {

--- a/crates/vapix/src/apis/axis_cgi/firmware_management_1.rs
+++ b/crates/vapix/src/apis/axis_cgi/firmware_management_1.rs
@@ -14,7 +14,6 @@ use crate::{
 };
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-#[non_exhaustive]
 pub enum ErrorKind {
     BadRequest = 400,
     NoPreviousFirmware = 404,

--- a/crates/vapix/src/apis/axis_cgi/network_settings_1.rs
+++ b/crates/vapix/src/apis/axis_cgi/network_settings_1.rs
@@ -85,7 +85,6 @@ impl SetGlobalProxyConfigurationRequest {
     }
 }
 
-#[non_exhaustive]
 #[derive(Debug, Deserialize, Serialize)]
 pub struct SetGlobalProxyConfigurationData {}
 
@@ -122,7 +121,6 @@ impl GetNetworkInfoRequest {
     }
 }
 
-#[non_exhaustive]
 #[derive(Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct NetworkInfoData {
@@ -130,7 +128,6 @@ pub struct NetworkInfoData {
     pub devices: Vec<DeviceInfo>,
 }
 
-#[non_exhaustive]
 #[derive(Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct SystemInfo {
@@ -145,7 +142,6 @@ pub struct SystemInfo {
     pub global_proxies: Option<GlobalProxies>,
 }
 
-#[non_exhaustive]
 #[derive(Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct DeviceSwitching {
@@ -155,7 +151,6 @@ pub struct DeviceSwitching {
     pub active_devices: Vec<String>,
 }
 
-#[non_exhaustive]
 #[derive(Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Hostname {
@@ -164,7 +159,6 @@ pub struct Hostname {
     pub static_hostname: String,
 }
 
-#[non_exhaustive]
 #[derive(Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Resolver {
@@ -179,7 +173,6 @@ pub struct Resolver {
     pub static_domain_name: String,
 }
 
-#[non_exhaustive]
 #[derive(Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct GlobalProxies {
@@ -188,7 +181,6 @@ pub struct GlobalProxies {
     pub no_proxy: String,
 }
 
-#[non_exhaustive]
 #[derive(Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct DeviceInfo {
@@ -209,7 +201,6 @@ pub struct DeviceInfo {
     pub ipv6: Ipv6Info,
 }
 
-#[non_exhaustive]
 #[derive(Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct WiredInfo {
@@ -222,7 +213,6 @@ pub struct WiredInfo {
     pub dot1x: Dot1xInfo,
 }
 
-#[non_exhaustive]
 #[derive(Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Dot1xInfo {
@@ -235,7 +225,6 @@ pub struct Dot1xInfo {
     pub macsec_secured: Option<bool>,
 }
 
-#[non_exhaustive]
 #[derive(Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Dot1xConfiguration {
@@ -243,7 +232,6 @@ pub struct Dot1xConfiguration {
     pub params: Dot1xParams,
 }
 
-#[non_exhaustive]
 #[derive(Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Dot1xParams {
@@ -267,7 +255,6 @@ pub struct Dot1xParams {
     pub mka_ckn: Option<String>,
 }
 
-#[non_exhaustive]
 #[derive(Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Ipv4Info {
@@ -292,7 +279,6 @@ pub struct Ipv4Info {
     pub use_dhcp_static_routes: Option<bool>,
 }
 
-#[non_exhaustive]
 #[derive(Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Ipv4Address {
@@ -304,7 +290,6 @@ pub struct Ipv4Address {
     pub broadcast: Option<String>,
 }
 
-#[non_exhaustive]
 #[derive(Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct StaticAddressConfiguration {
@@ -313,7 +298,6 @@ pub struct StaticAddressConfiguration {
     pub broadcast: String,
 }
 
-#[non_exhaustive]
 #[derive(Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Ipv6Info {
@@ -321,7 +305,6 @@ pub struct Ipv6Info {
     pub addresses: Vec<Ipv6Address>,
 }
 
-#[non_exhaustive]
 #[derive(Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Ipv6Address {

--- a/crates/vapix/src/apis/axis_cgi/system_ready_1.rs
+++ b/crates/vapix/src/apis/axis_cgi/system_ready_1.rs
@@ -34,7 +34,6 @@ where
 }
 
 // TODO: Consider parsing `bootid` as a UUID
-#[non_exhaustive]
 #[derive(Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct SystemreadyData {


### PR DESCRIPTION
Prompted by me wanting to make sure I handle every recorded product type in my application code.

Part of the value of the API bindings is exactly enabling applications to exhaustively match on known variants of a value in order to convert runtime errors to compile time errors. If the bindings ever reach a state where it's feasible to consider a stable API then the stability could be toggled with a feature flag, e.g. like:

```
#[cfg_attr(not(feature = "unstable"), non_exhaustive)]
```

Note that `non_exhaustive` attributes outside the API bindings are left because there a stable API is more important and easier to achieve because the API isn't forced to adapt to an underlying API.