### PR TITLE
feat(vapix): Add bindings for removing action configurations and rules

### DIFF
--- a/crates/vapix/src/apis/services/action1.rs
+++ b/crates/vapix/src/apis/services/action1.rs
@@ -6,9 +6,9 @@ mod action_rules;
 
 pub use action_configurations::{
     AddActionConfigurationRequest, AddActionConfigurationResponse, GetActionConfigurationsRequest,
-    GetActionConfigurationsResponse,
+    GetActionConfigurationsResponse, RemoveActionConfigurationRequest,
 };
 pub use action_rules::{
     AddActionRuleRequest, AddActionRuleResponse, Condition, GetActionRulesRequest,
-    GetActionRulesResponse,
+    GetActionRulesResponse, RemoveActionRuleRequest,
 };

--- a/crates/vapix/src/apis/services/action1/action_configurations.rs
+++ b/crates/vapix/src/apis/services/action1/action_configurations.rs
@@ -1,10 +1,11 @@
 use std::convert::Infallible;
 
-use serde::{Deserialize, Serialize};
+use anyhow::Context;
+use serde::{de::IgnoredAny, Deserialize, Serialize};
 
 use crate::{
     http::{HttpClient, Request},
-    protocol_helpers::{http::Error, soap, soap_http},
+    protocol_helpers::{http::Error, soap, soap_http, soap_http::SoapResponse},
 };
 
 const PATH: &str = "vapix/services";
@@ -85,6 +86,55 @@ impl AddActionConfigurationRequest {
         let envelope = self.try_into_envelope().map_err(Error::Request)?;
         let request = Request::new(reqwest::Method::POST, PATH.to_string()).soap(envelope);
         soap_http::send_request(client, request).await
+    }
+}
+
+pub struct RemoveActionConfigurationRequest {
+    configuration_id: u16,
+}
+
+impl RemoveActionConfigurationRequest {
+    pub fn new(configuration_id: u16) -> Self {
+        Self { configuration_id }
+    }
+
+    pub fn into_envelope(self) -> String {
+        let mut params = String::new();
+        params.push_str(r#"<ConfigurationID>"#);
+        params.push_str(&self.configuration_id.to_string());
+        params.push_str(r#"</ConfigurationID>"#);
+        soap::envelope(NAMESPACE, "RemoveActionConfiguration", Some(&params))
+    }
+
+    pub async fn send(self, client: &(impl HttpClient + Sync)) -> Result<(), Error<Infallible>> {
+        let request =
+            Request::new(reqwest::Method::POST, PATH.to_string()).soap(self.into_envelope());
+        let RemoveActionConfigurationResponse = soap_http::send_request(client, request).await?;
+        Ok(())
+    }
+}
+
+struct RemoveActionConfigurationResponse;
+
+// TODO: Consider making the `aa:RemoveActionConfigurationResponse` tag available to deserialization
+impl SoapResponse for RemoveActionConfigurationResponse {
+    fn from_envelope(s: &str) -> anyhow::Result<Self> {
+        // The body is empty, but the wrapper element must still be present and must be
+        // `RemoveActionConfigurationResponse` — anything else (e.g. a `SOAP-ENV:Fault`) should fail.
+        #[derive(Deserialize)]
+        #[serde(rename_all = "PascalCase")]
+        struct Envelope {
+            #[allow(dead_code, reason = "Required for shape validation")]
+            body: Body,
+        }
+        #[derive(Deserialize)]
+        struct Body {
+            #[serde(rename = "RemoveActionConfigurationResponse")]
+            _inner: IgnoredAny,
+        }
+        let Envelope { .. } = quick_xml::de::from_str(s)
+            .with_context(|| format!("Could not parse text; text: {s}"))?;
+        Ok(Self)
     }
 }
 

--- a/crates/vapix/src/apis/services/action1/action_rules.rs
+++ b/crates/vapix/src/apis/services/action1/action_rules.rs
@@ -1,10 +1,11 @@
 use std::convert::Infallible;
 
-use serde::Deserialize;
+use anyhow::Context;
+use serde::{de::IgnoredAny, Deserialize};
 
 use crate::{
     http::{HttpClient, Request},
-    protocol_helpers::{http::Error, soap, soap_http},
+    protocol_helpers::{http::Error, soap, soap_http, soap_http::SoapResponse},
 };
 
 const PATH: &str = "vapix/services";
@@ -93,6 +94,55 @@ impl AddActionRuleRequest {
 pub struct AddActionRuleResponse {
     #[serde(rename = "RuleID")]
     pub id: u16,
+}
+
+pub struct RemoveActionRuleRequest {
+    rule_id: u16,
+}
+
+impl RemoveActionRuleRequest {
+    pub fn new(rule_id: u16) -> Self {
+        Self { rule_id }
+    }
+
+    pub fn into_envelope(self) -> String {
+        let mut params = String::new();
+        params.push_str(r#"<RuleID>"#);
+        params.push_str(&self.rule_id.to_string());
+        params.push_str(r#"</RuleID>"#);
+        soap::envelope(NAMESPACE, "RemoveActionRule", Some(&params))
+    }
+
+    pub async fn send(self, client: &(impl HttpClient + Sync)) -> Result<(), Error<Infallible>> {
+        let request =
+            Request::new(reqwest::Method::POST, PATH.to_string()).soap(self.into_envelope());
+        let RemoveActionRuleResponse = soap_http::send_request(client, request).await?;
+        Ok(())
+    }
+}
+
+struct RemoveActionRuleResponse;
+
+// TODO: Consider making the `aa:RemoveActionRuleResponse` tag available to deserialization
+impl SoapResponse for RemoveActionRuleResponse {
+    fn from_envelope(s: &str) -> anyhow::Result<Self> {
+        // The body is empty, but the wrapper element must still be present and must be
+        // `RemoveActionRuleResponse` — anything else (e.g. a `SOAP-ENV:Fault`) should fail.
+        #[derive(Deserialize)]
+        #[serde(rename_all = "PascalCase")]
+        struct Envelope {
+            #[allow(dead_code, reason = "Required for shape validation")]
+            body: Body,
+        }
+        #[derive(Deserialize)]
+        struct Body {
+            #[serde(rename = "RemoveActionRuleResponse")]
+            _inner: IgnoredAny,
+        }
+        let Envelope { .. } = quick_xml::de::from_str(s)
+            .with_context(|| format!("Could not parse text; text: {s}"))?;
+        Ok(Self)
+    }
 }
 
 #[derive(Debug, Deserialize)]

--- a/crates/vapix/tests/cassette_tests.rs
+++ b/crates/vapix/tests/cassette_tests.rs
@@ -6,7 +6,11 @@ use log::{warn, LevelFilter};
 use rs4a_cassette_testing::{Cassette, CassetteClient, DeviceInfo, Library};
 use rs4a_vapix::{
     apis::{
-        action1::{GetActionConfigurationsRequest, GetActionRulesRequest},
+        action1::{
+            AddActionConfigurationRequest, AddActionRuleRequest, Condition,
+            GetActionConfigurationsRequest, GetActionRulesRequest,
+            RemoveActionConfigurationRequest, RemoveActionRuleRequest,
+        },
         api_discovery_1::{Api, ApiListData, GetApiListRequest},
         basic_device_info_1::{
             GetAllPropertiesRequest, GetAllUnrestrictedPropertiesRequest, ProductType,
@@ -125,8 +129,13 @@ macro_rules! cassette_tests {
 }
 
 cassette_tests! {
+    action1_action_rule_crud,
+    action1_add_action_rule_invalid_condition,
+    action1_add_action_rule_unknown_configuration,
     action1_get_action_configurations,
     action1_get_action_rules,
+    action1_remove_action_configuration_unknown,
+    action1_remove_action_rule_unknown,
     api_discovery_1_get_api_list,
     api_discovery_1_get_supported_versions,
     network_settings_1_get_network_info => [
@@ -360,6 +369,164 @@ async fn action1_get_action_configurations(client: &CassetteClient, _prelude: Op
 
 async fn action1_get_action_rules(client: &CassetteClient, _prelude: Option<Prelude>) {
     GetActionRulesRequest.send(client).await.unwrap();
+}
+
+async fn add_status_led_configuration(client: &CassetteClient) -> u16 {
+    AddActionConfigurationRequest::new("com.axis.action.fixed.ledcontrol")
+        .param("led", "statusled")
+        .param("color", "green,none")
+        .param("duration", "1")
+        .param("interval", "250")
+        .send(client)
+        .await
+        .unwrap()
+        .configuration_id
+}
+
+// The instability of `GetActionRulesResponse.action_rules` hides when devices are equivalent.
+// Furthermore, that different devices likely have different action rules hides when create and
+// remove have equivalent behavior.
+// TODO: Consider finding a way around these shortcomings
+async fn action1_action_rule_crud(client: &CassetteClient, _prelude: Option<Prelude>) {
+    let configuration_id = add_status_led_configuration(client).await;
+
+    let rule_id = AddActionRuleRequest::new("cassette test rule".to_string(), configuration_id)
+        .condition(Condition {
+            topic_expression: "tns1:Device/tnsaxis:Status/SystemReady".to_string(),
+            message_content: r#"boolean(//SimpleItem[@Name="ready" and @Value="1"])"#.to_string(),
+        })
+        .send(client)
+        .await
+        .unwrap()
+        .id;
+
+    let rules = GetActionRulesRequest::new()
+        .send(client)
+        .await
+        .unwrap()
+        .action_rules
+        .action_rule;
+    assert!(rules.iter().any(|r| r.rule_id == rule_id));
+
+    RemoveActionRuleRequest::new(rule_id)
+        .send(client)
+        .await
+        .unwrap();
+
+    let rules = GetActionRulesRequest::new()
+        .send(client)
+        .await
+        .unwrap()
+        .action_rules
+        .action_rule;
+    assert!(!rules.iter().any(|r| r.rule_id == rule_id));
+
+    RemoveActionConfigurationRequest::new(configuration_id)
+        .send(client)
+        .await
+        .unwrap();
+}
+
+async fn action1_add_action_rule_invalid_condition(
+    client: &CassetteClient,
+    _prelude: Option<Prelude>,
+) {
+    let configuration_id = add_status_led_configuration(client).await;
+
+    // ObjectAnalytics topics are only declared once the ACAP app is running, so on a
+    // device where it has not yet started this condition cannot be matched.
+    let error = AddActionRuleRequest::new("cassette test rule".to_string(), configuration_id)
+        .condition(Condition {
+            topic_expression:
+                "tnsaxis:CameraApplicationPlatform/ObjectAnalytics/Device1ScenarioANY".to_string(),
+            message_content: r#"boolean(//SimpleItem[@Name="active" and @Value="1"])"#.to_string(),
+        })
+        .send(client)
+        .await
+        .unwrap_err();
+
+    // SOAP faults currently surface as decode errors because the helper does not parse
+    // `SOAP-ENV:Fault` distinctly from the success response shape.
+    // TODO: Propagate the correct, structured error
+    let http::Error::Decode(error) = error else {
+        panic!("Expected Decode error but got {error:?}");
+    };
+    assert!(
+        format!("{error:?}").contains("could not match any property events"),
+        "Unexpected error: {error:?}"
+    );
+
+    RemoveActionConfigurationRequest::new(configuration_id)
+        .send(client)
+        .await
+        .unwrap();
+}
+
+async fn action1_add_action_rule_unknown_configuration(
+    client: &CassetteClient,
+    _prelude: Option<Prelude>,
+) {
+    // No configuration is created — on a freshly initialised device any positive ID is unknown.
+    let error = AddActionRuleRequest::new("cassette test rule".to_string(), 9999)
+        .condition(Condition {
+            topic_expression: "tns1:Device/tnsaxis:Status/SystemReady".to_string(),
+            message_content: r#"boolean(//SimpleItem[@Name="ready" and @Value="1"])"#.to_string(),
+        })
+        .send(client)
+        .await
+        .unwrap_err();
+
+    // SOAP faults currently surface as decode errors because the helper does not parse
+    // `SOAP-ENV:Fault` distinctly from the success response shape.
+    // TODO: Propagate the correct, structured error
+    let http::Error::Decode(error) = error else {
+        panic!("Expected Decode error but got {error:?}");
+    };
+    assert!(
+        format!("{error:?}").contains("action configuration"),
+        "Unexpected error: {error:?}"
+    );
+}
+
+async fn action1_remove_action_configuration_unknown(
+    client: &CassetteClient,
+    _prelude: Option<Prelude>,
+) {
+    let error = RemoveActionConfigurationRequest::new(9999)
+        .send(client)
+        .await
+        .unwrap_err();
+
+    // SOAP faults currently surface as decode errors because the helper does not parse
+    // `SOAP-ENV:Fault` distinctly from the success response shape. The `<SOAP-ENV:Reason>`
+    // text is empty for this fault, so match on the WSDL-declared detail element name.
+    // TODO: Propagate the correct, structured error
+    let http::Error::Decode(error) = error else {
+        panic!("Expected Decode error but got {error:?}");
+    };
+    assert!(
+        format!("{error:?}").contains("ActionConfigurationNotFoundFault"),
+        "Unexpected error: {error:?}"
+    );
+}
+
+async fn action1_remove_action_rule_unknown(client: &CassetteClient, _prelude: Option<Prelude>) {
+    let error = RemoveActionRuleRequest::new(9999)
+        .send(client)
+        .await
+        .unwrap_err();
+
+    // SOAP faults currently surface as decode errors because the helper does not parse
+    // `SOAP-ENV:Fault` distinctly from the success response shape. Matching on the
+    // WSDL-declared detail element name is more reliable than the human-readable reason.
+    // TODO: Propagate the correct, structured error
+    let http::Error::Decode(error) = error else {
+        panic!("Expected Decode error but got {error:?}");
+    };
+    assert!(
+        format!("{error:?}").contains("ActionRuleNotFoundFault"),
+        "Unexpected error: {error:?}"
+    );
 }
 
 async fn api_discovery_1_get_api_list(client: &CassetteClient, _: Option<Prelude>) {


### PR DESCRIPTION
The main reason for this change is to enable me to add a CRUD test for this API in preparation of rewriting the bindings.

`crates/vapix/src/apis/services/action1/action_configurations.rs`,
`crates/vapix/src/apis/services/action1/action_rules.rs`:
- `SoapResponse` is implemented manually instead or relying on deserialize because the response has no content and the name of the tag is not passed to the deserializer, so deserialization would always succeed - even for error responses.