### PR TITLE
feat(ab): Add new package

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,24 @@
 version = 4
 
 [[package]]
+name = "acap-build"
+version = "0.0.0"
+dependencies = [
+ "anyhow",
+ "clap",
+ "dirs",
+ "env_logger",
+ "glob",
+ "log",
+ "regex",
+ "semver",
+ "serde",
+ "serde_json",
+ "tempdir",
+ "tempfile",
+]
+
+[[package]]
 name = "addr2line"
 version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -165,7 +183,7 @@ dependencies = [
  "futures-lite",
  "parking",
  "polling",
- "rustix",
+ "rustix 0.38.44",
  "slab",
  "tracing",
  "windows-sys 0.59.0",
@@ -197,7 +215,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "event-listener 5.4.0",
  "futures-lite",
- "rustix",
+ "rustix 0.38.44",
  "tracing",
 ]
 
@@ -213,7 +231,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "futures-core",
  "futures-io",
- "rustix",
+ "rustix 0.38.44",
  "signal-hook-registry",
  "slab",
  "windows-sys 0.59.0",
@@ -804,6 +822,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fuchsia-cprng"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
+
+[[package]]
 name = "futures-channel"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1354,6 +1378,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
+
+[[package]]
 name = "litemap"
 version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1530,7 +1560,7 @@ dependencies = [
  "concurrent-queue",
  "hermit-abi",
  "pin-project-lite",
- "rustix",
+ "rustix 0.38.44",
  "tracing",
  "windows-sys 0.59.0",
 ]
@@ -1701,6 +1731,19 @@ checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
 
 [[package]]
 name = "rand"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293"
+dependencies = [
+ "fuchsia-cprng",
+ "libc",
+ "rand_core 0.3.1",
+ "rdrand",
+ "winapi",
+]
+
+[[package]]
+name = "rand"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
@@ -1743,6 +1786,21 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b"
+dependencies = [
+ "rand_core 0.4.2",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
+
+[[package]]
+name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
@@ -1757,6 +1815,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
 dependencies = [
  "getrandom 0.3.2",
+]
+
+[[package]]
+name = "rdrand"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
+dependencies = [
+ "rand_core 0.3.1",
 ]
 
 [[package]]
@@ -1798,6 +1865,15 @@ name = "regex-syntax"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
+
+[[package]]
+name = "remove_dir_all"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "reqwest"
@@ -2000,7 +2076,20 @@ dependencies = [
  "bitflags",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustix"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd15f8a2c5551a84d56efdc1cd049089e409ac19a3072d5037a17fd70719ff3e"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.11.0",
  "windows-sys 0.59.0",
 ]
 
@@ -2094,6 +2183,7 @@ version = "1.0.143"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d401abef1d108fbd9cbaebc3e46611f4b1021f714a0597a71f41ee463f5f4a5a"
 dependencies = [
+ "indexmap",
  "itoa",
  "memchr",
  "ryu",
@@ -2233,6 +2323,29 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.100",
+]
+
+[[package]]
+name = "tempdir"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15f2b5fb00ccdf689e0149d1b1b3c03fead81c2b37735d812fa8bddbbf41b6d8"
+dependencies = [
+ "rand 0.4.6",
+ "remove_dir_all",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d31c77bdf42a745371d260a26ca7163f1e0924b64afa0b688e61b5a9fa02f16"
+dependencies = [
+ "fastrand",
+ "getrandom 0.3.2",
+ "once_cell",
+ "rustix 1.1.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,8 @@ reqwest = { version = "0.12.15", default-features = false }
 semver = "1.0.0"
 serde = "1.0.219"
 serde_json = "1.0.140"
+tempdir = "0.3.7"
+tempfile = "3.10.1"
 thiserror = "2.0.17"
 tokio = "1.0.0"
 url = "2.5.4"

--- a/Makefile
+++ b/Makefile
@@ -53,6 +53,7 @@ check_format_rs:
 ## _
 check_generated_files: \
 	Cargo.lock \
+	snapshots/acap-build-docs \
 	snapshots/cli4a-docs \
 	snapshots/device-finder-docs \
 	snapshots/device-inventory-docs \
@@ -74,12 +75,22 @@ check_lint:
 		-Dwarnings
 .PHONY: check_lint
 
+# I have a vague memory of cassettes being less reproducible when order is preserved because the
+# server returns JSON with inconsistent field ordering. So when I ran into ordering issues due
+# to workspace feature unification I took a shortcut and split the test execution.
+# TODO: Investigate if cassette tests can be made to run with `serde_json/preserve_order`
+
 ## _
 check_tests:
 	cargo test \
 		--all-targets \
 		--locked \
-		--workspace
+		--workspace \
+		--exclude acap-build
+	cargo test \
+		--all-targets \
+		--locked \
+		-p acap-build
 .PHONY: check_tests
 
 ## Fixes

--- a/bin/acap-build-docs.sh
+++ b/bin/acap-build-docs.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env sh
+set -eu
+set -x
+acap-build -h

--- a/crates/acap-build/Cargo.toml
+++ b/crates/acap-build/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "acap-build"
+version = "0.0.0"
+edition = "2021"
+
+[dependencies]
+anyhow = { workspace = true }
+clap = { workspace = true, features = ["derive", "env"] }
+dirs = { workspace = true }
+env_logger = { workspace = true }
+glob = { workspace = true }
+log = { workspace = true }
+semver = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true, features = ["preserve_order"] }
+tempfile = { workspace = true }
+regex = { workspace = true }
+tempdir = { workspace = true }

--- a/crates/acap-build/README.md
+++ b/crates/acap-build/README.md
@@ -1,0 +1,28 @@
+A replacement for the `acap-build` python script in the ACAP SDK.
+
+This package improves on the upstream tool by:
+1. Enabling `acap-build` to be installed without the rest of the SDK.
+2. Enabling apps to be built with the SDK in a location different from `/opt/axis/`.
+3. Enabling other development tools to use `acap-build` as a library.
+
+<!--
+These requirements are driven by the work on `cargo-acap-build` in AxisCommunications/acap-rs.
+-->
+
+To that end this package provides both:
+- A binary crate designed as a bit-exact drop-in replacement for the upstream script.
+- A library crate designed for use by other development tools.
+
+<!--
+The binary serves one more purpose;
+it pressures the library to support everything users of the upstream tool are accustomed to.
+-->
+
+The bit-exactness works on all reproducible apps tested from:
+- `AxisCommunications/acap-rs@176d669ec37a5fe35764461d1f23494d3d3822b2`
+- `AxisCommunications/acap-native-sdk-examples@36800ed4c28dd96a2b659db3cb2c8a937c61d6d0`
+
+The non-reproducible examples are:
+- curl-openssl
+- using-opencv
+- utility-libraries/openssl_curl_example: probably because `libcrypto.so` is not reproducible.

--- a/crates/acap-build/src/bin/acap-build.rs
+++ b/crates/acap-build/src/bin/acap-build.rs
@@ -1,0 +1,95 @@
+//! A drop-in replacement for the acap-build python script
+use std::{
+    env,
+    fmt::{Display, Formatter},
+    fs,
+    path::PathBuf,
+    process::Command,
+};
+
+use acap_build::{AppBuilder, Architecture};
+use anyhow::Context;
+use clap::{Parser, ValueEnum};
+use log::debug;
+use tempdir::TempDir;
+
+#[derive(Clone, Copy, Debug, Default, Eq, Hash, PartialEq, ValueEnum)]
+#[clap(rename_all = "kebab-case")]
+enum BuildOption {
+    #[default]
+    Make,
+    NoBuild,
+}
+
+impl Display for BuildOption {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Make => write!(f, "make"),
+            Self::NoBuild => write!(f, "no-build"),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Parser)]
+struct Cli {
+    path: PathBuf,
+    /// Build tool, if any, to run before packaging.
+    #[clap(default_value_t, long, short)]
+    build: BuildOption,
+    /// Location of the manifest relative to the path argument.
+    #[clap(long, short, default_value = "manifest.json")]
+    manifest: PathBuf,
+    /// Additional files to include in the package.
+    /// May be specified multiple times
+    #[clap(long, short)]
+    additional_file: Vec<PathBuf>,
+}
+
+fn main() -> anyhow::Result<()> {
+    env_logger::init();
+
+    let Cli {
+        path,
+        build,
+        manifest,
+        additional_file,
+    } = Cli::parse();
+    match build {
+        BuildOption::Make => assert!(Command::new("make")
+            .status()
+            .context("subprocess make failed")?
+            .success()),
+        BuildOption::NoBuild => {
+            debug!("no build");
+        }
+    }
+
+    let arch: Architecture = env::var("OECORE_TARGET_ARCH")?.parse()?;
+    let manifest = path.join(&manifest);
+
+    let staging_dir = TempDir::new_in(&path, "acap-build")?;
+    let mut builder = AppBuilder::new(true, staging_dir.path(), &manifest, arch)?;
+
+    for name in builder.mandatory_files() {
+        builder.add(&path.join(name))?;
+    }
+
+    for name in builder.optional_files() {
+        let file = path.join(name);
+        if file.symlink_metadata().is_ok() {
+            builder.add(&file)?;
+        }
+    }
+
+    for additional_file in additional_file {
+        builder.add(&path.join(additional_file))?;
+    }
+
+    let eap_file_name = builder.build()?;
+    fs::copy(
+        staging_dir.path().join(&eap_file_name),
+        path.join(&eap_file_name),
+    )?;
+
+    Ok(())
+}

--- a/crates/acap-build/src/command_utils.rs
+++ b/crates/acap-build/src/command_utils.rs
@@ -1,0 +1,61 @@
+use std::io::{BufRead, BufReader};
+
+use anyhow::Context;
+use log::debug;
+
+pub trait RunWith {
+    fn run_with_processed_stdout(
+        self,
+        func: impl FnMut(std::io::Result<String>) -> anyhow::Result<()>,
+    ) -> anyhow::Result<()>;
+    fn run_with_logged_stdout(self) -> anyhow::Result<()>;
+}
+
+fn spawn(mut cmd: std::process::Command) -> anyhow::Result<std::process::Child> {
+    match cmd.spawn() {
+        Ok(t) => Ok(t),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            let program = cmd.get_program().to_string_lossy().to_string();
+            Err(e).context(format!(
+                "{program} not found, perhaps it must be installed."
+            ))
+        }
+        Err(e) => Err(e.into()),
+    }
+}
+
+impl RunWith for std::process::Command {
+    fn run_with_processed_stdout(
+        mut self,
+        mut func: impl FnMut(std::io::Result<String>) -> anyhow::Result<()>,
+    ) -> anyhow::Result<()> {
+        self.stdout(std::process::Stdio::piped());
+        debug!("Spawning child {self:#?}...");
+        let mut child = spawn(self)?;
+        let stdout = child
+            .stdout
+            .take()
+            .expect("not previously taken by this function");
+
+        let lines = BufReader::new(stdout).lines();
+        for line in lines {
+            func(line)?;
+        }
+
+        debug!("Waiting for child...");
+        let status = child.wait()?;
+        if !status.success() {
+            anyhow::bail!("Child failed: {status}");
+        }
+        Ok(())
+    }
+    fn run_with_logged_stdout(self) -> anyhow::Result<()> {
+        self.run_with_processed_stdout(|line| {
+            let line = line?;
+            if !line.is_empty() {
+                debug!("Child said {line:?}.");
+            };
+            Ok(())
+        })
+    }
+}

--- a/crates/acap-build/src/files.rs
+++ b/crates/acap-build/src/files.rs
@@ -1,0 +1,5 @@
+//! Files that are parsed or created in the course of creating an EAP.
+pub(crate) mod cgi_conf;
+pub(crate) mod manifest;
+pub(crate) mod package_conf;
+pub(crate) mod param_conf;

--- a/crates/acap-build/src/files/cgi_conf.rs
+++ b/crates/acap-build/src/files/cgi_conf.rs
@@ -1,0 +1,66 @@
+//! Code for populating the `cgi.conf` file
+use std::fmt::{Display, Formatter};
+
+use log::debug;
+
+use crate::{
+    files::manifest::Manifest,
+    json_ext,
+    json_ext::{MapExt, ValueExt},
+};
+
+#[derive(Debug)]
+enum Entry {
+    Fast { access: String, name: String },
+    Other { access: String, name: String },
+}
+
+#[derive(Debug)]
+pub(crate) struct CgiConf(Vec<Entry>);
+
+impl CgiConf {
+    pub(crate) fn new(manifest: &Manifest) -> anyhow::Result<Option<Self>> {
+        let conf = match manifest.try_find_http_config() {
+            Ok(v) => v,
+            Err(json_ext::Error::KeyNotFound(_)) => return Ok(None),
+            Err(e) => return Err(e.into()),
+        };
+
+        let mut entries = Vec::new();
+        for obj in conf.iter() {
+            let obj = obj.try_to_object()?;
+
+            let kind = obj.try_get_str("type")?;
+            if kind == "directory" {
+                debug!("Skipping httpConfig of type directory");
+                continue;
+            }
+
+            let name = obj.try_get_str("name")?.trim_start_matches('/').to_string();
+
+            let access = match obj.try_get_str("access")? {
+                "admin" => "administrator",
+                access => access,
+            }
+            .to_string();
+
+            entries.push(match kind {
+                "fastCgi" => Entry::Fast { access, name },
+                _ => Entry::Other { access, name },
+            })
+        }
+        Ok(Some(Self(entries)))
+    }
+}
+
+impl Display for CgiConf {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        for cgi in &self.0 {
+            match &cgi {
+                Entry::Fast { access, name } => writeln!(f, "{access} /{name} fastCgi")?,
+                Entry::Other { access, name } => writeln!(f, "{access} /{name}")?,
+            }
+        }
+        Ok(())
+    }
+}

--- a/crates/acap-build/src/files/manifest.rs
+++ b/crates/acap-build/src/files/manifest.rs
@@ -1,0 +1,132 @@
+use anyhow::bail;
+use log::debug;
+use serde::Serialize;
+use serde_json::{ser::PrettyFormatter, Map, Serializer, Value};
+
+use crate::{
+    json_ext,
+    json_ext::{MapExt, ValueExt},
+    Architecture,
+};
+
+#[derive(Debug)]
+pub(crate) struct Manifest(Value);
+
+impl Manifest {
+    pub(crate) fn new(manifest: Value, architecture: Architecture) -> anyhow::Result<Self> {
+        let mut manifest = Self(manifest);
+        let mut schema_version = manifest
+            .as_object()?
+            .try_get_str("schemaVersion")?
+            .to_string();
+
+        // Make it valid semver
+        for _ in 0..(2 - schema_version.chars().filter(|&c| c == '.').count()) {
+            schema_version.push_str(".0");
+        }
+        let schema_version = semver::Version::parse(&schema_version)?;
+        if schema_version > semver::Version::new(1, 3, 0) {
+            let setup = manifest.try_find_setup_mut()?;
+            if let Some(a) = setup.get("architecture") {
+                if a != "all" && a != architecture.nickname() {
+                    bail!(
+                        "Architecture in manifest ({a}) is not compatible with built target ({:?})",
+                        architecture
+                    );
+                }
+            } else {
+                debug!(
+                    "Architecture not set in manifest, using {:?}",
+                    &architecture
+                );
+                setup.insert(
+                    "architecture".to_string(),
+                    Value::String(architecture.nickname().to_string()),
+                );
+            }
+        }
+        Ok(manifest)
+    }
+
+    pub(crate) fn as_object(&self) -> json_ext::Result<&Map<String, Value>> {
+        self.0.try_to_object()
+    }
+
+    pub(crate) fn as_object_mut(&mut self) -> json_ext::Result<&mut Map<String, Value>> {
+        self.0.try_to_object_mut()
+    }
+
+    // TODO: Consider generalizing this to something like `try_get_as_str(&self, path: &[&str])`
+    pub(crate) fn try_find_app_name(&self) -> json_ext::Result<&str> {
+        self.as_object()?
+            .try_get_object("acapPackageConf")?
+            .try_get_object("setup")?
+            .try_get_str("appName")
+    }
+
+    pub(crate) fn try_find_architecture(&self) -> json_ext::Result<&str> {
+        self.as_object()?
+            .try_get_object("acapPackageConf")?
+            .try_get_object("setup")?
+            .try_get_str("architecture")
+    }
+
+    pub(crate) fn try_find_friendly_name(&self) -> json_ext::Result<&str> {
+        self.as_object()?
+            .try_get_object("acapPackageConf")?
+            .try_get_object("setup")?
+            .try_get_str("friendlyName")
+    }
+
+    pub(crate) fn try_find_http_config(&self) -> json_ext::Result<&Vec<Value>> {
+        self.as_object()?
+            .try_get_object("acapPackageConf")?
+            .try_get_object("configuration")?
+            .try_get_array("httpConfig")
+    }
+
+    pub(crate) fn try_find_param_config(&self) -> json_ext::Result<&Vec<Value>> {
+        self.as_object()?
+            .try_get_object("acapPackageConf")?
+            .try_get_object("configuration")?
+            .try_get_array("paramConfig")
+    }
+
+    pub(crate) fn try_find_post_install_script(&self) -> json_ext::Result<&str> {
+        self.as_object()?
+            .try_get_object("acapPackageConf")?
+            .try_get_object("installation")?
+            .try_get_str("postInstallScript")
+    }
+
+    pub(crate) fn try_find_pre_uninstall_script(&self) -> json_ext::Result<&str> {
+        self.as_object()?
+            .try_get_object("acapPackageConf")?
+            .try_get_object("uninstallation")?
+            .try_get_str("preUninstallScript")
+    }
+
+    pub(crate) fn try_find_version(&self) -> json_ext::Result<&str> {
+        self.as_object()?
+            .try_get_object("acapPackageConf")?
+            .try_get_object("setup")?
+            .try_get_str("version")
+    }
+
+    pub(crate) fn try_find_setup_mut(&mut self) -> json_ext::Result<&mut Map<String, Value>> {
+        self.as_object_mut()?
+            .try_get_object_mut("acapPackageConf")?
+            .try_get_object_mut("setup")
+    }
+
+    pub(crate) fn try_to_string(&self) -> anyhow::Result<String> {
+        // This file is included in the EAP, so for as long as we want bit-exact output, we must
+        // take care to serialize the manifest the same way as the python implementation.
+        // let mut writer = BufWriter::new(String::new());
+        let mut data = Vec::new();
+        let mut serializer =
+            Serializer::with_formatter(&mut data, PrettyFormatter::with_indent(b"    "));
+        self.0.serialize(&mut serializer)?;
+        Ok(String::from_utf8(data)?)
+    }
+}

--- a/crates/acap-build/src/files/package_conf.rs
+++ b/crates/acap-build/src/files/package_conf.rs
@@ -1,0 +1,342 @@
+//! Code for populating the `package.conf` file
+use std::{
+    collections::HashMap,
+    fmt::{Display, Formatter},
+};
+
+use anyhow::{bail, Context};
+use log::debug;
+use regex::Regex;
+use semver::Version;
+use serde_json::{Map, Value};
+
+use crate::{files::manifest::Manifest, Architecture};
+
+#[derive(Clone, Debug)]
+pub(crate) struct PackageConf(HashMap<&'static str, String>);
+
+impl PackageConf {
+    pub(crate) fn new(
+        manifest: &Manifest,
+        other_files: &[&str],
+        default_arch: Architecture,
+    ) -> anyhow::Result<PackageConf> {
+        let mut package_conf = Self(HashMap::new());
+        package_conf.set_custom_from_manifest(manifest)?;
+        package_conf.set_custom_from_other_files(other_files)?;
+        package_conf.set_defaults(default_arch);
+        Ok(package_conf)
+    }
+
+    fn set_custom_from_manifest(&mut self, manifest: &Manifest) -> anyhow::Result<()> {
+        let parameters: HashMap<_, _> = PARAMETERS
+            .iter()
+            .flat_map(|p| p.source.map(|s| (s, p.name)))
+            .collect();
+
+        let flat_manifest = flattened(manifest.as_object()?.clone());
+        let valid_vendor_url =
+            Regex::new("(?:(?:http|https)://)?(.+)").expect("Hard-coded regex is valid");
+        for (path, value) in flat_manifest {
+            match path.as_str() {
+                "acapPackageConf.setup.version" => {
+                    let v = value
+                        .as_str()
+                        .context("acapPackageConf.setup.version is not a string")?;
+                    let v = Version::parse(v)?;
+                    self.0.insert("APPMAJORVERSION", v.major.to_string());
+                    self.0.insert("APPMINORVERSION", v.minor.to_string());
+                    self.0.insert("APPMICROVERSION", v.patch.to_string());
+                }
+                "acapPackageConf.setup.vendorUrl" => {
+                    let v = value
+                        .as_str()
+                        .context("acapPackageConf.setup.vendorUrl is not a string")?;
+                    let Some(caps) = valid_vendor_url.captures(v) else {
+                        bail!("Expected vendor url to match regex {:?}", valid_vendor_url)
+                    };
+                    let domain_name = caps
+                        .get(1)
+                        .expect("Hard coded regex as exactly one capture group")
+                        .as_str();
+
+                    self.0.insert(
+                        "VENDORHOMEPAGELINK",
+                        format!(r#"<a href="{v}" target="_blank">{domain_name}</a>"#),
+                    );
+                }
+                "acapPackageConf.configuration.httpConfig" => {
+                    let v = value
+                        .as_array()
+                        .context("acapPackageConf.configuration.httpConfig is not an array")?;
+                    if !v.is_empty() {
+                        self.0.insert("HTTPCGIPATHS", "cgi.conf".to_string());
+                    }
+                }
+                path => {
+                    if let Some(name) = parameters.get(path) {
+                        let v = value
+                            .as_str()
+                            .with_context(|| format!("{path} is not a string"))?
+                            .to_string();
+                        self.0.insert(name, v);
+                    } else {
+                        debug!("{path} skipped, no corresponding parameter in package.conf")
+                    }
+                }
+            }
+        }
+        Ok(())
+    }
+
+    fn set_custom_from_other_files(&mut self, other_files: &[&str]) -> anyhow::Result<()> {
+        if !other_files.is_empty() {
+            self.0.insert("OTHERFILES", other_files.join(" "));
+        }
+        Ok(())
+    }
+
+    fn set_defaults(&mut self, arch: Architecture) {
+        // If not set from the manifest, eap-create.sh would try to infer it.
+        self.0
+            .entry("APPTYPE")
+            .or_insert(arch.nickname().to_string());
+
+        // If not set from the manifest, eap-create.sh would try to infer it from the exe.
+        // But we know that it must be set for the manifest to be valid.
+        // TODO: Fail explicitly if app name is not set.
+        let app_name = self.0.get("APPNAME").cloned().unwrap_or_default();
+        // If not set from the manifest, eap-create.sh would fall back on the app name
+        self.0.entry("PACKAGENAME").or_insert(app_name);
+
+        for Parameter { name, default, .. } in PARAMETERS {
+            if let Some(v) = default {
+                self.0.entry(name).or_insert(v.to_string());
+            }
+        }
+    }
+}
+
+impl Display for PackageConf {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        for Parameter { name, .. } in PARAMETERS {
+            if let Some(value) = self.0.get(name) {
+                if name == "VENDORHOMEPAGELINK" {
+                    writeln!(f, r#"{name}='{value}'"#)?;
+                } else {
+                    writeln!(f, r#"{name}="{value}""#)?;
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+struct Parameter {
+    name: &'static str,
+    source: Option<&'static str>,
+    default: Option<&'static str>,
+}
+
+// TODO: Consider generating this (semi-) automatically from its sources:
+// - conversion.py
+// - package-conf-parameters.cfg
+const PARAMETERS: [Parameter; 25] = [
+    Parameter {
+        name: "PACKAGENAME",
+        source: Some("acapPackageConf.setup.friendlyName"),
+        default: Some(""),
+    },
+    // Not supported. The name of the ACAP will be taken from PACKAGENAME instead
+    Parameter {
+        name: "MENUNAME",
+        source: None,
+        default: None,
+    },
+    Parameter {
+        name: "APPTYPE",
+        source: Some("acapPackageConf.setup.architecture"),
+        default: Some(""),
+    },
+    Parameter {
+        name: "APPNAME",
+        source: Some("acapPackageConf.setup.appName"),
+        default: Some(""),
+    },
+    Parameter {
+        name: "APPID",
+        source: Some("acapPackageConf.setup.appId"),
+        default: Some(""),
+    },
+    // Not supported by manifest ACAP applications
+    Parameter {
+        name: "LICENSENAME",
+        source: None,
+        default: Some("Available"),
+    },
+    Parameter {
+        name: "LICENSEPAGE",
+        source: Some("acapPackageConf.copyProtection.method"),
+        default: Some("none"),
+    },
+    // If the application uses a custom licensing solution but still want to be able to use the
+    // standard list.cgi and WebUI to display license status.
+    // Use this option to allow the application to hook into the AXIS API.
+    Parameter {
+        name: "LICENSE_CHECK_ARGS",
+        source: Some("acapPackageConf.copyProtection.customOptions"),
+        default: None,
+    },
+    Parameter {
+        name: "VENDOR",
+        source: Some("acapPackageConf.setup.vendor"),
+        default: Some("-"),
+    },
+    Parameter {
+        name: "REQEMBDEVVERSION",
+        source: Some("acapPackageConf.setup.embeddedSdkVersion"),
+        default: Some("2.0"),
+    },
+    Parameter {
+        name: "APPMAJORVERSION",
+        source: None, // Treated specially
+        default: Some("1"),
+    },
+    Parameter {
+        name: "APPMINORVERSION",
+        source: None, // Treated specially
+        default: Some("0"),
+    },
+    Parameter {
+        name: "APPMICROVERSION",
+        source: None, // Treated specially
+        default: Some("0"),
+    },
+    Parameter {
+        name: "APPGRP",
+        source: Some("acapPackageConf.setup.user.group"),
+        default: Some("sdk"),
+    },
+    Parameter {
+        name: "APPUSR",
+        source: Some("acapPackageConf.setup.user.username"),
+        default: Some("sdk"),
+    },
+    Parameter {
+        name: "APPOPTS",
+        source: Some("acapPackageConf.setup.runOptions"),
+        default: Some(""),
+    },
+    Parameter {
+        name: "OTHERFILES",
+        source: None,
+        default: Some(""),
+    },
+    Parameter {
+        name: "SETTINGSPAGEFILE",
+        source: Some("acapPackageConf.configuration.settingPage"),
+        default: Some(""),
+    },
+    // Special name on the link to the settings page is not supported
+    Parameter {
+        name: "SETTINGSPAGETEXT",
+        source: None,
+        default: Some(""),
+    },
+    Parameter {
+        name: "VENDORHOMEPAGELINK",
+        source: None, // Treated specially
+        default: Some(""),
+    },
+    // Pre-upgrade scripts are not supported
+    Parameter {
+        name: "PREUPGRADESCRIPT",
+        source: None,
+        default: Some(""),
+    },
+    Parameter {
+        name: "POSTINSTALLSCRIPT",
+        source: Some("acapPackageConf.installation.postInstallScript"),
+        default: Some(""),
+    },
+    Parameter {
+        name: "STARTMODE",
+        source: Some("acapPackageConf.setup.runMode"),
+        default: Some("never"),
+    },
+    Parameter {
+        name: "HTTPCGIPATHS",
+        source: None, // Treated specially
+        default: Some(""),
+    },
+    // Only supported for pre-installed applications
+    Parameter {
+        name: "AUTOSTART",
+        source: None,
+        default: None,
+    },
+];
+
+fn flattened(root: Map<String, Value>) -> Vec<(String, Value)> {
+    let mut output = Vec::new();
+    let mut values = vec![(String::new(), Value::Object(root))];
+    while let Some((path, value)) = values.pop() {
+        match value {
+            Value::Null => output.push((path, Value::Null)),
+            Value::Bool(b) => output.push((path, Value::Bool(b))),
+            Value::Number(n) => output.push((path, Value::Number(n))),
+            Value::String(s) => output.push((path, Value::String(s.clone()))),
+            Value::Array(a) => output.push((path, Value::Array(a.clone()))),
+            Value::Object(o) => {
+                for (k, v) in o.into_iter().rev() {
+                    debug_assert!(!k.contains('.'));
+                    let mut p = path.clone();
+                    if !p.is_empty() {
+                        p.push('.');
+                    }
+                    p.push_str(&k.to_string());
+                    values.push((p, v));
+                }
+            }
+        }
+    }
+    output
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::{json, Value};
+
+    use super::*;
+
+    #[test]
+    fn stringify_works_on_example() {
+        let value = json!(
+            {
+                "a": 1,
+                "b": [2, 3],
+                "c": [{"i":4}],
+                "d": {"j": 5},
+                "e": {
+                    "k": 6,
+                    "l": {"x": 7},
+                    "m": 8,
+                },
+            }
+        );
+        let Value::Object(object) = value else {
+            panic!("expected object");
+        };
+        let actual = flattened(object);
+        let expected = vec![
+            ("a".to_string(), json!(1)),
+            ("b".to_string(), json!([2, 3])),
+            ("c".to_string(), json!([{"i": 4}])),
+            ("d.j".to_string(), json!(5)),
+            ("e.k".to_string(), json!(6)),
+            ("e.l.x".to_string(), json!(7)),
+            ("e.m".to_string(), json!(8)),
+        ];
+        assert_eq!(actual, expected);
+    }
+}

--- a/crates/acap-build/src/files/param_conf.rs
+++ b/crates/acap-build/src/files/param_conf.rs
@@ -1,0 +1,68 @@
+//! Code for populating the `param.conf` file
+use std::fmt::{Display, Formatter};
+
+use crate::{
+    files::manifest::Manifest,
+    json_ext,
+    json_ext::{MapExt, ValueExt},
+};
+
+#[derive(Debug)]
+enum Entry {
+    Typed {
+        name: String,
+        default: String,
+        kind: String,
+    },
+    Untyped {
+        name: String,
+        default: String,
+    },
+}
+
+#[derive(Debug)]
+pub(crate) struct ParamConf(Vec<Entry>);
+
+impl ParamConf {
+    pub(crate) fn new(manifest: &Manifest) -> anyhow::Result<Option<Self>> {
+        let param_config = match manifest.try_find_param_config() {
+            Ok(v) => v,
+            Err(json_ext::Error::KeyNotFound(_)) => return Ok(None),
+            Err(e) => return Err(e.into()),
+        };
+
+        let mut entries = Vec::new();
+        for obj in param_config.iter() {
+            let obj = obj.try_to_object()?;
+            let name = obj.try_get_str("name")?.to_string();
+            let default = obj.try_get_str("default")?.to_string();
+            let kind = obj.try_get_str("type")?.to_string();
+
+            entries.push(match kind.is_empty() {
+                false => Entry::Typed {
+                    name,
+                    default,
+                    kind,
+                },
+                true => Entry::Untyped { name, default },
+            })
+        }
+        Ok(Some(Self(entries)))
+    }
+}
+
+impl Display for ParamConf {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        for param in &self.0 {
+            match param {
+                Entry::Typed {
+                    name,
+                    default,
+                    kind,
+                } => writeln!(f, r#"{name}="{default}" type="{kind}""#)?,
+                Entry::Untyped { name, default } => writeln!(f, "{name}={default}")?,
+            }
+        }
+        Ok(())
+    }
+}

--- a/crates/acap-build/src/json_ext.rs
+++ b/crates/acap-build/src/json_ext.rs
@@ -1,0 +1,127 @@
+//! Additional methods for [`serde_json`] types.
+use std::{
+    any::type_name_of_val,
+    fmt::{Debug, Display, Formatter},
+};
+
+use serde_json::{Map, Value};
+
+#[derive(Debug)]
+pub(crate) enum Error {
+    KeyNotFound(&'static str),
+    WrongType {
+        key: &'static str,
+        expected: &'static str,
+        found: &'static str,
+    },
+}
+
+impl Display for Error {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Error::KeyNotFound(key) => {
+                write!(f, "Expected key {key}")
+            }
+            Error::WrongType {
+                key,
+                expected,
+                found,
+            } => {
+                write!(f, "Expected {key} to be {expected}, but found {found}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for Error {}
+
+pub(crate) type Result<T> = core::result::Result<T, Error>;
+pub(crate) trait MapExt {
+    fn to_object(&self) -> &Map<String, Value>;
+    fn to_object_mut(&mut self) -> &mut Map<String, Value>;
+
+    fn try_get_array(&self, key: &'static str) -> Result<&Vec<Value>> {
+        match self.to_object().get(key) {
+            Some(Value::Array(a)) => Ok(a),
+            Some(v) => Err(Error::WrongType {
+                key,
+                expected: "array",
+                found: type_name_of_val(v),
+            }),
+            None => Err(Error::KeyNotFound(key)),
+        }
+    }
+
+    fn try_get_object(&self, key: &'static str) -> Result<&Map<String, Value>> {
+        match self.to_object().get(key) {
+            Some(Value::Object(o)) => Ok(o),
+            Some(v) => Err(Error::WrongType {
+                key,
+                expected: "object",
+                found: type_name_of_val(v),
+            }),
+            None => Err(Error::KeyNotFound(key)),
+        }
+    }
+
+    fn try_get_object_mut(&mut self, key: &'static str) -> Result<&mut Map<String, Value>> {
+        match self.to_object_mut().get_mut(key) {
+            Some(Value::Object(o)) => Ok(o),
+            Some(v) => Err(Error::WrongType {
+                key,
+                expected: "object",
+                found: type_name_of_val(v),
+            }),
+            None => Err(Error::KeyNotFound(key)),
+        }
+    }
+
+    fn try_get_str(&self, key: &'static str) -> Result<&str> {
+        match self.to_object().get(key) {
+            Some(Value::String(s)) => Ok(s),
+            Some(v) => Err(Error::WrongType {
+                key,
+                expected: "string",
+                found: type_name_of_val(v),
+            }),
+            None => Err(Error::KeyNotFound(key)),
+        }
+    }
+}
+
+impl MapExt for Map<String, Value> {
+    fn to_object(&self) -> &Map<String, Value> {
+        self
+    }
+    fn to_object_mut(&mut self) -> &mut Map<String, Value> {
+        self
+    }
+}
+
+pub(crate) trait ValueExt {
+    fn try_to_object(&self) -> Result<&Map<String, Value>>;
+    fn try_to_object_mut(&mut self) -> Result<&mut Map<String, Value>>;
+}
+
+impl ValueExt for Value {
+    fn try_to_object(&self) -> Result<&Map<String, Value>> {
+        match self {
+            Value::Object(o) => Ok(o),
+            v => Err(Error::WrongType {
+                key: "?",
+                expected: "object",
+                found: type_name_of_val(v),
+            }),
+        }
+    }
+    fn try_to_object_mut(&mut self) -> Result<&mut Map<String, Value>> {
+        match self {
+            Value::Object(o) => Ok(o),
+            v => Err(Error::WrongType {
+                key: "?",
+                expected: "object",
+                found: type_name_of_val(v),
+            }),
+        }
+    }
+}

--- a/crates/acap-build/src/lib.rs
+++ b/crates/acap-build/src/lib.rs
@@ -1,0 +1,495 @@
+#![forbid(unsafe_code)]
+//! Library for creating Embedded Application Packages (EAPs).
+use std::{
+    collections::HashSet,
+    env,
+    ffi::OsString,
+    fs,
+    io::Write,
+    os::unix::fs::PermissionsExt,
+    path::{Path, PathBuf},
+    process::Command,
+    str::FromStr,
+};
+
+use anyhow::{anyhow, bail, Context};
+use command_utils::RunWith;
+use log::{debug, info};
+use semver::Version;
+use serde_json::Value;
+
+use crate::files::{
+    cgi_conf::CgiConf, manifest::Manifest, package_conf::PackageConf, param_conf::ParamConf,
+};
+
+mod command_utils;
+mod json_ext;
+
+mod files;
+
+// TODO: Find a better way to support reproducible builds
+fn copy<P: AsRef<Path>, Q: AsRef<Path>>(
+    src: P,
+    dst: Q,
+    copy_permissions: bool,
+) -> anyhow::Result<()> {
+    let src = src.as_ref();
+    let dst = dst.as_ref();
+    if dst.symlink_metadata().is_ok() {
+        bail!("Path already exists {dst:?}");
+    }
+    if src.is_symlink() {
+        // FIXME: Copy symlink in Rust
+        let mut cp = Command::new("cp");
+
+        if copy_permissions {
+            cp.arg("--preserve=mode");
+        }
+
+        cp.arg("-dn").arg(src.as_os_str()).arg(dst.as_os_str());
+
+        if !cp.status()?.success() {
+            bail!("Failed to copy symlink: {}", src.display());
+        }
+    } else if copy_permissions {
+        fs::copy(src, dst)?;
+    } else {
+        let mut src = fs::File::open(src)?;
+        let mut dst = fs::File::create(dst)?;
+        std::io::copy(&mut src, &mut dst)?;
+    }
+    Ok(())
+}
+
+fn copy_recursively(src: &Path, dst: &Path, copy_permissions: bool) -> anyhow::Result<()> {
+    if !src.is_dir() {
+        copy(src, dst, copy_permissions)?;
+        debug!("Created reg {dst:?}");
+        return Ok(());
+    }
+    match fs::create_dir(dst) {
+        Ok(()) => {
+            debug!("Created dir {dst:?}");
+            Ok(())
+        }
+        Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => Ok(()),
+        Err(e) => Err(e),
+    }?;
+    for entry in fs::read_dir(src)? {
+        let entry = entry?;
+        copy_recursively(
+            &entry.path(),
+            &dst.join(entry.file_name()),
+            copy_permissions,
+        )?;
+    }
+    Ok(())
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum AcapBuildImpl {
+    /// Delegate to the foreign (upstream) `acap-build` program.
+    Reference,
+    /// Use the native, equivalent implementation.
+    Equivalent,
+}
+
+impl Default for AcapBuildImpl {
+    fn default() -> Self {
+        Self::Equivalent
+    }
+}
+
+impl FromStr for AcapBuildImpl {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "reference" => Ok(Self::Reference),
+            "equivalent" => Ok(Self::Equivalent),
+            _ => bail!("Expected 'reference' or 'equivalent', but found {s:?}"),
+        }
+    }
+}
+
+pub struct AppBuilder<'a> {
+    preserve_permissions: bool,
+    staging_dir: &'a Path,
+    manifest: Manifest,
+    files: Vec<String>,
+    default_architecture: Architecture,
+    app_name: String,
+    acap_build_impl: AcapBuildImpl,
+}
+
+impl<'a> AppBuilder<'a> {
+    pub fn new(
+        preserve_permissions: bool,
+        staging_dir: &'a Path,
+        manifest: &Path,
+        default_architecture: Architecture,
+    ) -> anyhow::Result<Self> {
+        let manifest: Value = serde_json::from_reader(fs::File::open(manifest)?)?;
+        let manifest = Manifest::new(manifest, default_architecture)?;
+        let app_name = manifest.try_find_app_name()?.to_string();
+        Ok(Self {
+            preserve_permissions,
+            staging_dir,
+            manifest,
+            app_name,
+            files: Vec::new(),
+            default_architecture,
+            acap_build_impl: AcapBuildImpl::default(),
+        })
+    }
+
+    /// Select the implementation used to build the EAP.
+    ///
+    /// Defaults to [`AcapBuildImpl::Equivalent`].
+    pub fn implementation(&mut self, acap_build_impl: AcapBuildImpl) -> &mut Self {
+        self.acap_build_impl = acap_build_impl;
+        self
+    }
+
+    /// Add a file to the EAP.
+    pub fn add(&mut self, path: &Path) -> anyhow::Result<&mut Self> {
+        let name = path
+            .file_name()
+            .context("file has no name")?
+            .to_str()
+            .context("file name is not a string")?;
+        self.add_as(path, name)?;
+        Ok(self)
+    }
+
+    /// Add all files in a directory to the EAP.
+    pub fn add_from(&mut self, dir: &Path) -> anyhow::Result<&mut Self> {
+        let mut entries = fs::read_dir(dir)?
+            .map(|res| res.map(|e| e.path()))
+            .collect::<std::io::Result<Vec<PathBuf>>>()?;
+        entries.sort();
+        for entry in entries {
+            let name = entry
+                .file_name()
+                .context("file has no name")?
+                .to_str()
+                .context("file name is not a string")?;
+            self.add_as(&entry, name)?;
+        }
+        Ok(self)
+    }
+
+    // TODO: Remove the file system copy
+    pub fn add_as(&mut self, path: &Path, name: &str) -> anyhow::Result<PathBuf> {
+        let dst = self.staging_dir.join(name);
+        if dst.symlink_metadata().is_ok() {
+            bail!("Cannot add {path:?} because {name} already exists");
+        }
+        copy_recursively(path, &dst, self.preserve_permissions)?;
+        self.files.push(name.to_string());
+        if name == self.app_name && !self.preserve_permissions {
+            let mut permissions = fs::metadata(&dst)?.permissions();
+            let mode = permissions.mode();
+            permissions.set_mode(mode | 0o111);
+            fs::set_permissions(&dst, permissions)?;
+        }
+        debug!("Added {name} from {path:?}");
+        Ok(dst)
+    }
+
+    /// Add the **mandatory** executable to the EAP.
+    pub fn add_exe(&mut self, reg: &Path) -> anyhow::Result<&mut Self> {
+        // TODO: Consider refactoring or changing to avoid cloning.
+        let app_name = self.app_name.clone();
+        self.add_as(reg, &app_name)?;
+        Ok(self)
+    }
+
+    /// Build the EAP and return its path.
+    pub fn build(self) -> anyhow::Result<OsString> {
+        match self.acap_build_impl {
+            AcapBuildImpl::Reference => {
+                debug!("Using acap-build");
+                self.build_foreign()
+            }
+            AcapBuildImpl::Equivalent => {
+                // TODO: Implement validation.
+                info!("Bypassing acap-build, manifest will not be validated");
+                self.build_native()
+            }
+        }
+    }
+
+    fn build_foreign(self) -> anyhow::Result<OsString> {
+        let Self {
+            staging_dir,
+            default_architecture,
+            manifest,
+            ..
+        } = &self;
+
+        fs::File::create_new(staging_dir.join("manifest.json"))
+            .context("creating manifest.json")?
+            .write_all(manifest.try_to_string()?.as_bytes())?;
+
+        let mut acap_build = Command::new("acap-build");
+        acap_build.args(["--build", "no-build"]);
+        for file in self.additional_files() {
+            acap_build.args(["--additional-file", file]);
+        }
+        acap_build.arg(".");
+
+        let mut sh = Command::new("sh");
+        sh.current_dir(staging_dir);
+
+        let env_setup = match default_architecture {
+            Architecture::Aarch64 => "environment-setup-cortexa53-crypto-poky-linux",
+            Architecture::Armv7hf => "environment-setup-cortexa9hf-neon-poky-linux-gnueabi",
+        };
+        sh.args([
+            "-c",
+            &format!(". /opt/axis/acapsdk/{env_setup} && {acap_build:?}"),
+        ]);
+        sh.run_with_logged_stdout()?;
+
+        let mut apps = Vec::new();
+        for entry in fs::read_dir(staging_dir)? {
+            let entry = entry?;
+            let path = entry.path();
+            if let Some(extension) = path.extension() {
+                if extension.to_str() == Some("eap") {
+                    apps.push(path);
+                }
+            }
+        }
+        let mut apps = apps.into_iter();
+        let app = apps.next().context("Expected at least one artifact")?;
+        if let Some(second) = apps.next() {
+            bail!("Built at least one unexpected .eap file {second:?}")
+        }
+        Ok(app.file_name().context("file has no name")?.to_os_string())
+    }
+
+    fn build_native(self) -> anyhow::Result<OsString> {
+        let Self {
+            staging_dir,
+            manifest,
+
+            default_architecture,
+            app_name,
+            ..
+        } = &self;
+        let mtime = match env::var_os("SOURCE_DATE_EPOCH") {
+            Some(v) => v.into_string().map_err(|e| anyhow!("{e:?}"))?,
+            None => String::from_utf8(Command::new("date").arg("+%s").output()?.stdout)?,
+        };
+
+        // Compute file name
+        let package_name = match manifest.try_find_friendly_name() {
+            Ok(v) => v,
+            Err(json_ext::Error::KeyNotFound(_)) => app_name.as_str(),
+            Err(e) => return Err(e.into()),
+        }
+        .replace(' ', "_");
+        let Version {
+            major,
+            minor,
+            patch,
+            ..
+        } = manifest.try_find_version().context("no version")?.parse()?;
+
+        let arch = match manifest.try_find_architecture() {
+            Ok(v) => v,
+            Err(json_ext::Error::KeyNotFound(_)) => default_architecture.nickname(),
+            Err(e) => return Err(e.into()),
+        };
+        let eap_file_name = format!("{package_name}_{major}_{minor}_{patch}_{arch}.eap");
+
+        // Generate derived files
+        let package_conf =
+            PackageConf::new(manifest, &self.other_files(), *default_architecture)?.to_string();
+        fs::File::create_new(staging_dir.join("package.conf"))?
+            .write_all(package_conf.as_bytes())?;
+
+        let param_conf = match ParamConf::new(manifest)? {
+            None => {
+                // If there is no param.conf, `eap-create.sh` creates one
+                debug!("Creating empty param.conf");
+                String::new()
+            }
+            Some(v) => v.to_string(),
+        };
+        fs::File::create_new(staging_dir.join("param.conf"))?.write_all(param_conf.as_bytes())?;
+
+        match CgiConf::new(manifest)? {
+            None => {
+                debug!("Skipping cgi.conf")
+            }
+            Some(cgi_conf) => {
+                fs::File::create_new(staging_dir.join("cgi.conf"))?
+                    .write_all(cgi_conf.to_string().as_bytes())?;
+            }
+        }
+
+        // This file is included in the EAP, so for as long as we want bit-exact output, we must
+        // take care to serialize the manifest the same way as the python implementation.
+        let manifest_file = staging_dir.join("manifest.json");
+        fs::File::create_new(&manifest_file)?.write_all(manifest.try_to_string()?.as_bytes())?;
+        // Replicate the permissions that temporary files get by default.
+        let mut permissions = fs::metadata(&manifest_file)?.permissions();
+        permissions.set_mode(0o600);
+        fs::set_permissions(&manifest_file, permissions)?;
+
+        // Create the archive
+        let mut tar = Command::new("tar");
+        tar.args(["--exclude", "*~"])
+            .args(["--file", &eap_file_name])
+            .args(["--format", "gnu"])
+            .args(["--group", "0"])
+            .args(["--mtime", &format!("@{mtime}")])
+            .args(["--owner", "0"])
+            .args(["--sort", "name"])
+            .args(["--use-compress-program", "gzip --no-name -9"])
+            .arg("--create")
+            .arg("--numeric-owner")
+            .arg("--exclude-vcs");
+
+        for name in self.section_1_files() {
+            if staging_dir.join(name).symlink_metadata().is_ok() {
+                tar.arg(name);
+            }
+        }
+
+        tar.args(self.other_files());
+
+        // TODO: Consider implementing support for `httpd.conf.local.*` and `mime.types.local.*`.
+
+        for name in self.section_4_files() {
+            if staging_dir.join(name).symlink_metadata().is_ok() {
+                tar.arg(name);
+            }
+        }
+
+        tar.arg("--verbose");
+        tar.current_dir(staging_dir);
+        tar.run_with_logged_stdout()?;
+
+        Ok(OsString::from(eap_file_name))
+    }
+
+    // These sections are probably relevant only for the equivalent and reference implementations;
+    // Once unpacked on device the order of files or the reason they were included is not important
+    // (even though some files are nonetheless treated specially).
+    // The sections don't have any semantics, they are just partitions that can be composed to
+    // create meaningful or useful lists of names.
+
+    fn section_1_files(&self) -> Vec<&str> {
+        [
+            Some(self.app_name.as_str()),
+            Some("package.conf"),
+            Some("param.conf"),
+            Some("LICENSE"),
+            Some("manifest.json"),
+            self.manifest.try_find_post_install_script().ok(),
+        ]
+        .into_iter()
+        .flatten()
+        .collect()
+    }
+
+    fn section_2_files(&self) -> Vec<&str> {
+        let known_files: HashSet<_> = [
+            self.section_1_files(),
+            self.section_3_files(),
+            self.section_4_files(),
+        ]
+        .into_iter()
+        .flatten()
+        .collect();
+
+        self.files
+            .iter()
+            .map(String::as_str)
+            .filter(|f| !known_files.contains(f))
+            .collect()
+    }
+
+    fn section_3_files(&self) -> Vec<&str> {
+        [self.manifest.try_find_pre_uninstall_script().ok()]
+            .into_iter()
+            .flatten()
+            .collect()
+    }
+
+    fn section_4_files(&self) -> Vec<&str> {
+        ["html", "declarations", "lib", "cgi.conf"]
+            .into_iter()
+            .collect()
+    }
+
+    /// Additional files for the reference implementation.
+    fn additional_files(&self) -> Vec<&str> {
+        self.section_2_files()
+    }
+
+    /// Other files for the `package.conf` file.
+    fn other_files(&self) -> Vec<&str> {
+        [self.section_2_files(), self.section_3_files()].concat()
+    }
+
+    /// Return the name of files that must be added using [`Self::add`].
+    pub fn mandatory_files(&self) -> Vec<String> {
+        [
+            Some(self.app_name.as_str()),
+            Some("LICENSE"),
+            self.manifest.try_find_post_install_script().ok(),
+            self.manifest.try_find_pre_uninstall_script().ok(),
+        ]
+        .into_iter()
+        .flatten()
+        .map(str::to_string)
+        .collect()
+    }
+
+    /// Return the name of files that should be added using [`Self::add`].
+    pub fn optional_files(&self) -> Vec<String> {
+        ["html", "declarations", "lib"]
+            .into_iter()
+            .map(str::to_string)
+            .collect()
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+pub enum Architecture {
+    Aarch64,
+    Armv7hf,
+}
+
+impl Architecture {
+    pub fn triple(&self) -> &'static str {
+        match self {
+            Architecture::Aarch64 => "aarch64-unknown-linux-gnu",
+            Architecture::Armv7hf => "thumbv7neon-unknown-linux-gnueabihf",
+        }
+    }
+
+    pub fn nickname(&self) -> &'static str {
+        match self {
+            Self::Aarch64 => "aarch64",
+            Self::Armv7hf => "armv7hf",
+        }
+    }
+}
+
+impl FromStr for Architecture {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "aarch64" => Ok(Self::Aarch64),
+            "arm" => Ok(Self::Armv7hf),
+            _ => Err(anyhow::anyhow!("Unrecognized variant {s}")),
+        }
+    }
+}

--- a/docs/commit-messages.md
+++ b/docs/commit-messages.md
@@ -5,17 +5,18 @@ Commit messages ...
 - ... follow Conventional Commits [^1]
 - ... use scopes from the table below.
 
-| Scope | Explanation            | Deprecated aliases |
-|-------|------------------------|--------------------|
-| a     | rs4a-authentication    |                    |
-| c     | cli4a                  |                    |
-| di    | device-inventory       | device-inventory   |
-| dm    | device-manager         |                    |
-| dut   | rs4a-dut               |                    |
-| fi    | firmware-inventory     |                    |
-| vapix | rs4a-vapix             | v                  |
-| ct    | rs4a-cassette-testing  |                    |
-| vlt   | rs4a-vlt               |                    |
+| Scope | Explanation           | Deprecated aliases |
+|-------|-----------------------|--------------------|
+| a     | rs4a-authentication   |                    |
+| ab    | acap-build            |                    |
+| c     | cli4a                 |                    |
+| di    | device-inventory      | device-inventory   |
+| dm    | device-manager        |                    |
+| dut   | rs4a-dut              |                    |
+| fi    | firmware-inventory    |                    |
+| vapix | rs4a-vapix            | v                  |
+| ct    | rs4a-cassette-testing |                    |
+| vlt   | rs4a-vlt              |                    |
 
 
 [^1]: https://www.conventionalcommits.org/en/v1.0.0/

--- a/snapshots/acap-build-docs
+++ b/snapshots/acap-build-docs
@@ -1,0 +1,15 @@
++ acap-build -h
+Usage: acap-build [OPTIONS] <PATH>
+
+Arguments:
+  <PATH>  
+
+Options:
+  -b, --build <BUILD>
+          Build tool, if any, to run before packaging [default: make] [possible values: make, no-build]
+  -m, --manifest <MANIFEST>
+          Location of the manifest relative to the path argument [default: manifest.json]
+  -a, --additional-file <ADDITIONAL_FILE>
+          Additional files to include in the package. May be specified multiple times
+  -h, --help
+          Print help


### PR DESCRIPTION
As noted in the readme:

This package improves on the upstream tool by:
1. Enabling `acap-build` to be installed without the rest of the SDK.
2. Enabling apps to be built with the SDK in a location different from `/opt/axis/`.
3. Enabling other development tools to use `acap-build` as a library.

These requirements are driven by the work on `cargo-acap-build` in AxisCommunications/acap-rs.

To that end this package provides both:
- A binary crate designed as a bit-exact drop-in replacement for the upstream script.
- A library crate designed for use by other development tools.

The binary serves one more purpose; it pressures the library to support everything users of the upstream tool are accustomed to.

Details
=======

`bin/acap-build-docs.sh`:
- `set -x` is on a separate line to reinforce the pattern of having two phases; silent setup and then the real commands.