### PR TITLE
feat(ab): Add OECORE_TARGET_ARCH to CLI

### DIFF
--- a/crates/acap-build/src/bin/acap-build.rs
+++ b/crates/acap-build/src/bin/acap-build.rs
@@ -1,17 +1,31 @@
 //! A drop-in replacement for the acap-build python script
 use std::{
-    env,
     fmt::{Display, Formatter},
     fs,
     path::PathBuf,
     process::Command,
 };
 
-use acap_build::{AppBuilder, Architecture};
+use acap_build::AppBuilder;
 use anyhow::Context;
 use clap::{Parser, ValueEnum};
 use log::debug;
 use tempdir::TempDir;
+
+#[derive(Clone, Copy, Debug, ValueEnum)]
+pub enum Architecture {
+    Aarch64,
+    Armv7hf,
+}
+
+impl From<Architecture> for acap_build::Architecture {
+    fn from(value: Architecture) -> Self {
+        match value {
+            Architecture::Aarch64 => Self::Aarch64,
+            Architecture::Armv7hf => Self::Armv7hf,
+        }
+    }
+}
 
 #[derive(Clone, Copy, Debug, Default, Eq, Hash, PartialEq, ValueEnum)]
 #[clap(rename_all = "kebab-case")]
@@ -43,6 +57,8 @@ struct Cli {
     /// May be specified multiple times
     #[clap(long, short)]
     additional_file: Vec<PathBuf>,
+    #[clap(long, env = "OECORE_TARGET_ARCH")]
+    oecore_target_arch: Architecture,
 }
 
 fn main() -> anyhow::Result<()> {
@@ -53,6 +69,7 @@ fn main() -> anyhow::Result<()> {
         build,
         manifest,
         additional_file,
+        oecore_target_arch,
     } = Cli::parse();
     match build {
         BuildOption::Make => assert!(Command::new("make")
@@ -64,11 +81,15 @@ fn main() -> anyhow::Result<()> {
         }
     }
 
-    let arch: Architecture = env::var("OECORE_TARGET_ARCH")?.parse()?;
     let manifest = path.join(&manifest);
 
     let staging_dir = TempDir::new_in(&path, "acap-build")?;
-    let mut builder = AppBuilder::new(true, staging_dir.path(), &manifest, arch)?;
+    let mut builder = AppBuilder::new(
+        true,
+        staging_dir.path(),
+        &manifest,
+        oecore_target_arch.into(),
+    )?;
 
     for name in builder.mandatory_files() {
         builder.add(&path.join(name))?;

--- a/crates/acap-build/src/lib.rs
+++ b/crates/acap-build/src/lib.rs
@@ -279,6 +279,7 @@ impl<'a> AppBuilder<'a> {
             app_name,
             ..
         } = &self;
+        // TODO: Consider pushing environment variable fetching to dependant
         let mtime = match env::var_os("SOURCE_DATE_EPOCH") {
             Some(v) => v.into_string().map_err(|e| anyhow!("{e:?}"))?,
             None => String::from_utf8(Command::new("date").arg("+%s").output()?.stdout)?,

--- a/snapshots/acap-build-docs
+++ b/snapshots/acap-build-docs
@@ -1,5 +1,5 @@
 + acap-build -h
-Usage: acap-build [OPTIONS] <PATH>
+Usage: acap-build [OPTIONS] --oecore-target-arch <OECORE_TARGET_ARCH> <PATH>
 
 Arguments:
   <PATH>  
@@ -11,5 +11,7 @@ Options:
           Location of the manifest relative to the path argument [default: manifest.json]
   -a, --additional-file <ADDITIONAL_FILE>
           Additional files to include in the package. May be specified multiple times
+      --oecore-target-arch <OECORE_TARGET_ARCH>
+          [env: OECORE_TARGET_ARCH=] [possible values: aarch64, armv7hf]
   -h, --help
           Print help


### PR DESCRIPTION
Upstream does not have this flag, but I think that's OK because users of the upstream tool already expect that they have to set OECORE_TARGET_ARCH and when they do they don't have to provide the flag, so our binary still works as a drop in replacement. Prompted by me being confused by this not-so-helpful output when I forgot to set OECORE_TARGET_ARCH:

```
Error: environment variable not found
```