### PR TITLE
chore: run checks on macOS in CI

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -22,5 +22,14 @@ jobs:
         run: nix develop --ignore-env --command make check
       - name: Check flake
         run: nix flake check
-      - name: Run extra checks (do not work in every supported contributor dev env)
-        run: nix develop --ignore-env --command cargo test --test equivalence -- --ignored
+  checks-macos:
+    needs: checks
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+      - name: Install Rust toolchain
+        run: rustup show active-toolchain || rustup toolchain install
+      - name: Run checks (portable)
+        run: make check_t3

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,12 @@ help:
 ## Checks
 ## ------
 
-check: check_build check_docs check_format check_generated_files check_lint check_tests
+## _
+check: check_t3 check_format_nix check_generated_files check_tests
+.PHONY: check
+
+check_t3: check_build check_docs check_format_rs check_generated_files_t3 check_lint check_tests_t3
+.PHONY: check_t3
 
 ## _
 check_build:
@@ -54,10 +59,16 @@ check_format_rs:
 
 ## _
 check_generated_files: \
+	check_generated_files_t3 \
+	snapshots/acap-build-disallowed-property \
+	snapshots/acap-build-too-long-string
+	git update-index -q --refresh
+	git --no-pager diff --exit-code HEAD -- $^
+.PHONY: check_generated_files
+
+check_generated_files_t3: \
 	Cargo.lock \
 	snapshots/acap-build-docs \
-	snapshots/acap-build-disallowed-property \
-	snapshots/acap-build-too-long-string \
 	snapshots/cli4a-docs \
 	snapshots/device-finder-docs \
 	snapshots/device-inventory-docs \
@@ -66,7 +77,7 @@ check_generated_files: \
 	snapshots/firmware-inventory-docs
 	git update-index -q --refresh
 	git --no-pager diff --exit-code HEAD -- $^
-.PHONY: check_generated_files
+.PHONY: check_generated_files_t3
 
 ## _
 check_lint:
@@ -85,17 +96,20 @@ check_lint:
 # TODO: Investigate if cassette tests can be made to run with `serde_json/preserve_order`
 
 ## _
-check_tests:
-	cargo test \
-		--all-targets \
-		--locked \
-		--workspace \
-		--exclude acap-build
+check_tests: check_tests_t3
 	cargo test \
 		--all-targets \
 		--locked \
 		-p acap-build
 .PHONY: check_tests
+
+check_tests_t3:
+	cargo test \
+		--all-targets \
+		--locked \
+		--workspace \
+		--exclude acap-build
+.PHONY: check_tests_t3
 
 ## Fixes
 ## -----

--- a/crates/acap-build/tests/equivalence.rs
+++ b/crates/acap-build/tests/equivalence.rs
@@ -25,7 +25,7 @@ fn copy_dir(src: &Path, dst: &Path) {
 
 // TODO: Add facilities for comparing with upstream automatically
 // TODO: Make `acap-build` compatible with all supported dev environments of this propject
-#[ignore = "does not work on macOS"]
+#[ignore = "requires a tier 2 developer environment"]
 #[test]
 fn example_app_output_matches_snapshot() {
     let manifest_dir = env!("CARGO_MANIFEST_DIR");


### PR DESCRIPTION
This will:
- Ensure that a macOS + brew setup can reproduce a development environment
- Document what is and, unfortunately, isn't supported in that environment
- Document one way to set up that environment

Details
=======

`.github/workflows/main.yaml`:
- The macOS job is added last and runs sequentially because I expect failures to be rare given that the ubuntu checks have already passed and I want to not waste CI minutes in cases where the ubuntu checks would fail anyway.