### PR TITLE
feat(fim): Add new crate for working with fimages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /.idea/
 /.direnv/
+/crates/fimage/tests/fimages/
 /target/
 /venv/
 /init-env.sh

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -584,6 +584,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if 1.0.0",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -866,6 +875,26 @@ name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
+name = "filetime"
+version = "0.2.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759"
+dependencies = [
+ "cfg-if 1.0.0",
+ "libc",
+]
+
+[[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "fluent-uri"
@@ -1576,6 +1605,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3be647b768db090acb35d5ec5db2b0e1f1de11133ca123b9eacf5137868f892a"
 dependencies = [
  "adler2",
+ "simd-adler32",
 ]
 
 [[package]]
@@ -2259,6 +2289,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "rs4a-fimage"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "chrono",
+ "clap",
+ "flate2",
+ "glob",
+ "libtest-mimic",
+ "rs4a-bin-utils",
+ "ruzstd",
+ "serde",
+ "serde_json",
+ "tar",
+]
+
+[[package]]
 name = "rs4a-firmware-inventory"
 version = "0.1.0"
 dependencies = [
@@ -2406,6 +2453,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eded382c5f5f786b989652c49544c4877d9f015cc22e145a5ea8ea66c2921cd2"
 
 [[package]]
+name = "ruzstd"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fad02996bfc73da3e301efe90b1837be9ed8f4a462b6ed410aa35d00381de89f"
+dependencies = [
+ "twox-hash",
+]
+
+[[package]]
 name = "ryu"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2498,6 +2554,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "simd-adler32"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+
+[[package]]
 name = "slab"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2527,6 +2589,12 @@ name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "strsim"
@@ -2592,6 +2660,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.100",
+]
+
+[[package]]
+name = "tar"
+version = "0.4.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f6221d9a6003c78398e3b239969f352578258df48c8eb051caadae0015bc840"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
 ]
 
 [[package]]
@@ -2793,6 +2872,16 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "twox-hash"
+version = "1.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
+dependencies = [
+ "cfg-if 1.0.0",
+ "static_assertions",
+]
 
 [[package]]
 name = "typenum"
@@ -3293,6 +3382,16 @@ name = "writeable"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
+
+[[package]]
+name = "xattr"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
+dependencies = [
+ "libc",
+ "rustix 1.1.2",
+]
 
 [[package]]
 name = "yoke"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ digest_auth = "0.3.1"
 dirs = "6.0.0"
 env_logger = "0.11.8"
 expect-test = "1.5.1"
+flate2 = "1.1.2"
 futures-util = "0.3.31"
 glob = "0.3.2"
 itertools = "0.14.0"
@@ -26,9 +27,11 @@ mdns = "3.0.0"
 quick-xml = "0.38.3"
 regex = "1.11.3"
 reqwest = { version = "0.12.15", default-features = false }
+ruzstd = "0.7.3"
 semver = "1.0.0"
 serde = "1.0.219"
 serde_json = "1.0.140"
+tar = "0.4.44"
 tempdir = "0.3.7"
 tempfile = "3.10.1"
 thiserror = "2.0.17"
@@ -41,6 +44,7 @@ rs4a-dut = { version = "0.1", path = "crates/dut" }
 rs4a-vapix = { path = "crates/vapix" }
 rs4a-cassette-testing = { path = "crates/cassette-testing" }
 rs4a-device-manager = { path = "crates/device-manager" }
+rs4a-fimage = { path = "crates/fimage" }
 rs4a-firmware-inventory = { path = "crates/firmware-inventory" }
 rs4a-vlt = { path = "crates/vlt" }
 

--- a/Makefile
+++ b/Makefile
@@ -74,6 +74,7 @@ check_generated_files_t3: \
 	snapshots/device-inventory-docs \
 	snapshots/device-inventory-smoke-test \
 	snapshots/device-manager-docs \
+	snapshots/fimage-docs \
 	snapshots/firmware-inventory-docs
 	git update-index -q --refresh
 	git --no-pager diff --exit-code HEAD -- $^

--- a/bin/fimage-docs.sh
+++ b/bin/fimage-docs.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env sh
+set -eux
+unset RUST_LOG
+
+# Special commands in alphabetical order
+fimage help
+# Normal commands in alphabetical order
+fimage help extract
+fimage help inspect

--- a/crates/fimage/Cargo.toml
+++ b/crates/fimage/Cargo.toml
@@ -1,0 +1,33 @@
+[package]
+name = "rs4a-fimage"
+version = "0.1.0"
+edition.workspace = true
+license = "MIT"
+description = "Utilities for inspecting firmware images"
+
+[lints]
+workspace = true
+
+[[bin]]
+name = "fimage"
+path = "src/main.rs"
+
+[[test]]
+name = "fimages"
+harness = false
+
+[dependencies]
+anyhow = { workspace = true }
+chrono = { workspace = true }
+clap = { workspace = true, features = ["derive"] }
+flate2 = { workspace = true }
+ruzstd = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true }
+tar = { workspace = true }
+
+rs4a-bin-utils = { workspace = true }
+
+[dev-dependencies]
+glob = { workspace = true }
+libtest-mimic = { workspace = true }

--- a/crates/fimage/src/archive.rs
+++ b/crates/fimage/src/archive.rs
@@ -1,0 +1,63 @@
+//! Read AXIS OS firmware image (`.bin`) archives.
+
+use std::{
+    io::{Cursor, Read},
+    path::Path,
+};
+
+use anyhow::{bail, Context};
+use flate2::read::GzDecoder;
+
+// Images for AXIS OS before 13 are compressed with gzip, images for AXIS OS 13 and later with zstd.
+const GZIP_MAGIC: [u8; 2] = [0x1f, 0x8b];
+const ZSTD_MAGIC: [u8; 4] = [0x28, 0xb5, 0x2f, 0xfd];
+const INFO_FILE_NAME: &str = "info.json";
+
+/// Wrap an image in a decompressor appropriate for its magic numbers.
+fn decompress<'a>(mut image: impl Read + 'a) -> anyhow::Result<Box<dyn Read + 'a>> {
+    let mut magic = [0u8; 4];
+    image
+        .read_exact(&mut magic)
+        .context("Failed to read the first bytes of the image")?;
+    let image = Cursor::new(magic).chain(image);
+    if magic == ZSTD_MAGIC {
+        Ok(Box::new(
+            ruzstd::StreamingDecoder::new(image)
+                .context("Failed to start decompressing the image")?,
+        ))
+    } else if magic.starts_with(&GZIP_MAGIC) {
+        Ok(Box::new(GzDecoder::new(image)))
+    } else {
+        bail!("unrecognized magic numbers: {magic:?} (expected gzip or zstd)");
+    }
+}
+
+/// Extract the content of the `info.json` member from an AXIS OS firmware image.
+///
+/// Returns as soon as the member is found; in the images seen so far it is
+/// the second member, before the large ones.
+pub fn read_info_json(image: impl Read) -> anyhow::Result<String> {
+    let mut archive = tar::Archive::new(decompress(image)?);
+    for member in archive
+        .entries()
+        .context("Failed to read the archive inside the image")?
+    {
+        let mut member = member.context("Failed to read a member of the archive")?;
+        if member.path()?.to_str() == Some(INFO_FILE_NAME) {
+            let mut text = String::new();
+            member
+                .read_to_string(&mut text)
+                .with_context(|| format!("Failed to read {INFO_FILE_NAME}"))?;
+            return Ok(text);
+        }
+    }
+    bail!("{INFO_FILE_NAME} not found in the archive");
+}
+
+/// Extract all members of an AXIS OS firmware image into a directory.
+pub fn unpack(image: impl Read, directory: &Path) -> anyhow::Result<()> {
+    let mut archive = tar::Archive::new(decompress(image)?);
+    archive
+        .unpack(directory)
+        .with_context(|| format!("Failed to extract the archive into {}", directory.display()))
+}

--- a/crates/fimage/src/commands.rs
+++ b/crates/fimage/src/commands.rs
@@ -1,0 +1,2 @@
+pub mod extract;
+pub mod inspect;

--- a/crates/fimage/src/commands/extract.rs
+++ b/crates/fimage/src/commands/extract.rs
@@ -1,0 +1,38 @@
+use std::{
+    fs::File,
+    io::BufReader,
+    path::{Path, PathBuf},
+};
+
+use anyhow::Context;
+
+use crate::archive;
+
+#[derive(Clone, Debug, clap::Args)]
+pub struct ExtractCommand {
+    /// Path to a firmware image, i.e. a `.bin` file.
+    image: PathBuf,
+    /// Directory to extract into.
+    ///
+    /// Defaults to a directory in the current working directory named after the image.
+    directory: Option<PathBuf>,
+}
+
+fn default_directory(image: &Path) -> anyhow::Result<PathBuf> {
+    let stem = image.file_stem().context("Image path has no file name")?;
+    Ok(PathBuf::from(stem))
+}
+
+impl ExtractCommand {
+    pub fn exec(self) -> anyhow::Result<String> {
+        let Self { image, directory } = self;
+        let directory = match directory {
+            Some(directory) => directory,
+            None => default_directory(&image)?,
+        };
+        let file =
+            File::open(&image).with_context(|| format!("Failed to open {}", image.display()))?;
+        archive::unpack(BufReader::new(file), &directory)?;
+        Ok(format!("{}\n", directory.display()))
+    }
+}

--- a/crates/fimage/src/commands/inspect.rs
+++ b/crates/fimage/src/commands/inspect.rs
@@ -1,0 +1,80 @@
+use std::{fmt::Write, fs::File, io::BufReader, path::PathBuf};
+
+use anyhow::Context;
+use chrono::SecondsFormat;
+
+use crate::{
+    archive::read_info_json,
+    info::{ImageInfo, Product},
+};
+
+#[derive(Clone, Debug, clap::Args)]
+pub struct InspectCommand {
+    /// Path to a firmware image, i.e. a `.bin` file.
+    image: PathBuf,
+    /// Print the metadata as JSON.
+    #[arg(long)]
+    json: bool,
+}
+
+fn render(info: &ImageInfo) -> anyhow::Result<String> {
+    let build_time = info.try_build_time()?;
+    let ImageInfo {
+        release,
+        build_nbr,
+        part_nbr,
+        build_time: _,
+        signing_domain,
+        track,
+        upgradeable_from,
+        products,
+    } = info;
+    let mut out = String::new();
+    writeln!(out, "Release: {release}")?;
+    writeln!(out, "Build number: {build_nbr}")?;
+    writeln!(out, "Part number: {part_nbr}")?;
+    writeln!(
+        out,
+        "Build time: {}",
+        build_time.to_rfc3339_opts(SecondsFormat::Secs, true)
+    )?;
+    writeln!(out, "Signing domain: {signing_domain}")?;
+    if let Some(track) = track {
+        writeln!(out, "Track: {track}")?;
+    }
+    if let Some(upgradeable_from) = upgradeable_from {
+        writeln!(out, "Upgradeable from: {}", upgradeable_from.join(", "))?;
+    }
+    for Product {
+        prod_full_name,
+        hardware_id,
+        prod_variant,
+        ..
+    } in products
+    {
+        match prod_variant {
+            Some(prod_variant) => writeln!(
+                out,
+                "Product: {prod_full_name} {prod_variant} ({hardware_id})"
+            )?,
+            None => writeln!(out, "Product: {prod_full_name} ({hardware_id})")?,
+        }
+    }
+    Ok(out)
+}
+
+impl InspectCommand {
+    pub fn exec(self) -> anyhow::Result<String> {
+        let Self { image, json } = self;
+        let file =
+            File::open(&image).with_context(|| format!("Failed to open {}", image.display()))?;
+        let info: ImageInfo = read_info_json(BufReader::new(file))?
+            .parse()
+            .context("Failed to parse the image info")?;
+        if json {
+            Ok(format!("{}\n", serde_json::to_string_pretty(&info)?))
+        } else {
+            render(&info)
+        }
+    }
+}

--- a/crates/fimage/src/info.rs
+++ b/crates/fimage/src/info.rs
@@ -1,0 +1,77 @@
+//! The specification of the `info.json` member of a firmware image.
+//!
+//! There is no published schema; the fields are inferred from inspecting images.
+
+use std::str::FromStr;
+
+use anyhow::anyhow;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+/// The content of the `info.json` member of a firmware image.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "PascalCase")]
+pub struct ImageInfo {
+    pub release: String,
+    pub build_nbr: String,
+    pub part_nbr: String,
+    /// Seconds since the Unix epoch.
+    pub build_time: i64,
+    pub signing_domain: String,
+    /// Observed only in AXIS OS 13 images, e.g. as "preview-13".
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub track: Option<String>,
+    /// Absent from images for AXIS OS before 11.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub upgradeable_from: Option<Vec<String>>,
+    pub products: Vec<Product>,
+}
+
+impl ImageInfo {
+    pub fn try_build_time(&self) -> anyhow::Result<chrono::DateTime<chrono::Utc>> {
+        chrono::DateTime::from_timestamp(self.build_time, 0).ok_or(anyhow!(
+            "Expected a UNIX timestamp, got {}",
+            self.build_time
+        ))
+    }
+}
+
+/// A product that a firmware image can be installed on.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "PascalCase")]
+pub struct Product {
+    pub brand: String,
+    pub prod_nbr: String,
+    #[serde(rename = "HardwareID")]
+    pub hardware_id: String,
+    pub prod_type: String,
+    pub prod_full_name: String,
+    pub prod_short_name: String,
+    /// Observed only in images for products that come in variants, e.g. as
+    /// "7mm" for a thermal camera lens.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub prod_variant: Option<String>,
+}
+
+/// Deserialize JSON, asserting in debug builds that no information is lost.
+fn parse_lossless<T>(text: &str) -> anyhow::Result<T>
+where
+    T: for<'de> Deserialize<'de> + Serialize,
+{
+    let data: T = serde_json::from_str(text)?;
+    if cfg!(debug_assertions) {
+        let expected: Value =
+            serde_json::from_str(text).expect("already deserialized successfully");
+        let actual: Value = serde_json::to_value(&data)?;
+        assert_eq!(actual, expected);
+    }
+    Ok(data)
+}
+
+impl FromStr for ImageInfo {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        parse_lossless(s)
+    }
+}

--- a/crates/fimage/src/lib.rs
+++ b/crates/fimage/src/lib.rs
@@ -1,0 +1,31 @@
+pub mod archive;
+pub mod commands;
+pub mod info;
+
+use clap::{Parser, Subcommand};
+
+pub use crate::commands::{extract::ExtractCommand, inspect::InspectCommand};
+
+#[derive(Parser)]
+pub struct Cli {
+    #[command(subcommand)]
+    pub command: Commands,
+}
+
+impl Cli {
+    pub fn exec(self) -> anyhow::Result<String> {
+        let Self { command } = self;
+        match command {
+            Commands::Extract(cmd) => cmd.exec(),
+            Commands::Inspect(cmd) => cmd.exec(),
+        }
+    }
+}
+
+#[derive(Subcommand)]
+pub enum Commands {
+    /// Extract a firmware image into a directory
+    Extract(ExtractCommand),
+    /// Print identifying metadata read from a firmware image on disk
+    Inspect(InspectCommand),
+}

--- a/crates/fimage/src/main.rs
+++ b/crates/fimage/src/main.rs
@@ -1,0 +1,11 @@
+use clap::Parser;
+
+fn main() -> anyhow::Result<()> {
+    let mut guard = rs4a_bin_utils::logger::init();
+    let out = rs4a_fimage::Cli::parse().exec()?;
+    if !out.is_empty() {
+        print!("{out}");
+    }
+    guard.disarm();
+    Ok(())
+}

--- a/crates/fimage/tests/fimages.rs
+++ b/crates/fimage/tests/fimages.rs
@@ -1,0 +1,50 @@
+use std::{
+    path::{Path, PathBuf},
+    process::Command,
+};
+
+use libtest_mimic::{Arguments, Failed, Trial};
+
+fn main() -> std::process::ExitCode {
+    libtest_mimic::run(&Arguments::from_args(), trials()).exit_code()
+}
+
+fn trials() -> Vec<Trial> {
+    let file = Path::new(file!());
+    let dir = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("tests")
+        .join(file.file_stem().expect("this file has a stem"));
+    let pattern = format!("{}/**/*.bin", dir.display());
+    glob::glob(&pattern)
+        .expect("the pattern is valid")
+        .map(|image| {
+            let image = image.expect("the images are readable");
+            let name = image
+                .strip_prefix(&dir)
+                .expect("the images are in the searched directory")
+                .display()
+                .to_string();
+            Trial::test(name, move || inspect(&image))
+        })
+        .collect()
+}
+
+fn inspect(image: &PathBuf) -> Result<(), Failed> {
+    let output = Command::new(env!("CARGO_BIN_EXE_fimage"))
+        .arg("inspect")
+        .arg(image)
+        .output()
+        .map_err(|e| format!("could not run fimage: {e}"))?;
+    if !output.status.success() {
+        return Err(format!(
+            "fimage inspect exited with {}; stderr:\n{}",
+            output.status,
+            String::from_utf8_lossy(&output.stderr)
+        )
+        .into());
+    }
+    if output.stdout.is_empty() {
+        return Err("expected metadata on stdout, got nothing".into());
+    }
+    Ok(())
+}

--- a/docs/commit-messages.md
+++ b/docs/commit-messages.md
@@ -14,9 +14,9 @@ Commit messages ...
 | dm    | device-manager        |                    |
 | dut   | rs4a-dut              |                    |
 | fi    | firmware-inventory    |                    |
+| fim   | fimage                |                    |
 | vapix | rs4a-vapix            | v                  |
 | ct    | rs4a-cassette-testing |                    |
 | vlt   | rs4a-vlt              |                    |
-
 
 [^1]: https://www.conventionalcommits.org/en/v1.0.0/

--- a/snapshots/fimage-docs
+++ b/snapshots/fimage-docs
@@ -1,0 +1,39 @@
++ unset RUST_LOG
++ fimage help
+Usage: fimage <COMMAND>
+
+Commands:
+  extract  Extract a firmware image into a directory
+  inspect  Print identifying metadata read from a firmware image on disk
+  help     Print this message or the help of the given subcommand(s)
+
+Options:
+  -h, --help  Print help
++ fimage help extract
+Extract a firmware image into a directory
+
+Usage: fimage extract <IMAGE> [DIRECTORY]
+
+Arguments:
+  <IMAGE>
+          Path to a firmware image, i.e. a `.bin` file
+
+  [DIRECTORY]
+          Directory to extract into.
+          
+          Defaults to a directory in the current working directory named after the image.
+
+Options:
+  -h, --help
+          Print help (see a summary with '-h')
++ fimage help inspect
+Print identifying metadata read from a firmware image on disk
+
+Usage: fimage inspect [OPTIONS] <IMAGE>
+
+Arguments:
+  <IMAGE>  Path to a firmware image, i.e. a `.bin` file
+
+Options:
+      --json  Print the metadata as JSON
+  -h, --help  Print help


### PR DESCRIPTION
Prompted by me learning that Axis announced that the compression changes with AXIS OS 13 suggesting that there exist uses for inspecting the images with some level of support which made me curious to see what information is available. The current functionality serves mainly to satisfy that curiosity and to make the information more easily available so that it can be consulted when trying to solve actual problems.

One real problem I expect this information could be useful for is firmware upgrades where it lets us start with a target fimage and work our way backwards until we find that the currently installed image is upgradable from.

Details
=======

`crates/fimage/Cargo.toml`:
- The crate is named fimage because that is what Axis calls these files (see the *_fimage_signed.bin download names), it is short, and it leaves room for sibling commands that operate on images without implying they only inspect.
- This is a crate separate from firmware-inventory because inspecting an image on disk shares nothing with downloading and caching firmware: no index, no session, not even the async runtime. This keeps firmware-inventory a porcelain over the download flow and leaves the inspection plumbing reusable as a library.

`crates/fimage/src/archive.rs`:
- read_info_json does not cap how far into the archive it searches because scanning the whole archive is more robust and a cap solved no problem in practice.

`crates/fimage/tests/fimages.rs`:
- The fixture directory is gitignored and searched recursively so it can be populated by copying from a firmware-inventory cache; when it is absent, as in CI, the suite is empty and passes.

`snapshots/device-inventory-smoke-test`:
- Added because check_generated_files regenerates it on every run and origin/main tracks it, but it was absent from this branch, leaving the check silently incomplete.