### PR TITLE
chore: Enable acap-native-sdk.nix for all platforms

### DIFF
--- a/nix/acap-native-sdk.nix
+++ b/nix/acap-native-sdk.nix
@@ -105,6 +105,6 @@ stdenvNoCC.mkDerivation {
   meta = {
     description = "ACAP Native SDK, extracted from the official Docker images";
     homepage = "https://github.com/AxisCommunications/acap-native-sdk";
-    platforms = lib.platforms.linux;
+    platforms = lib.platforms.all;
   };
 }


### PR DESCRIPTION
It would previously fail with an error like "is not available on the requested hostPlatform" on "aarch64-darwin". Extracted programs are unlikely to work on anything other than x64_64-linux, but so far we primarily care about the manifest schemas and those should work on any platform.