### PR TITLE
chore(ab,eap): Opt into the workspace lints

### DIFF
--- a/crates/acap-build/Cargo.toml
+++ b/crates/acap-build/Cargo.toml
@@ -19,3 +19,6 @@ rs4a-eap.workspace = true
 
 [dev-dependencies]
 expect-test.workspace = true
+
+[lints]
+workspace = true

--- a/crates/eap/Cargo.toml
+++ b/crates/eap/Cargo.toml
@@ -15,3 +15,6 @@ semver = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true, features = ["preserve_order"] }
 regex = { workspace = true }
+
+[lints]
+workspace = true


### PR DESCRIPTION
These were the only two packages not using them and omitting them was a mistake.