### PR TITLE
feat(ab,eap)!: Move mtime control from the library to the binary

### DIFF
--- a/bin/acap-build-docs.sh
+++ b/bin/acap-build-docs.sh
@@ -2,6 +2,7 @@
 set -eu
 
 unset ACAP_SDK_LOCATION
+unset SOURCE_DATE_EPOCH
 
 set -x
 

--- a/crates/acap-build/src/main.rs
+++ b/crates/acap-build/src/main.rs
@@ -4,12 +4,13 @@ use std::{
     fs,
     path::PathBuf,
     process::Command,
+    time::{SystemTime, UNIX_EPOCH},
 };
 
 use anyhow::Context;
 use clap::{Parser, ValueEnum};
 use log::debug;
-use rs4a_eap::{AppBuilder, SchemaSource};
+use rs4a_eap::{AppBuilder, Mtime, SchemaSource};
 use tempdir::TempDir;
 
 #[derive(Clone, Copy, Debug, ValueEnum)]
@@ -68,6 +69,15 @@ struct Cli {
         default_value = rs4a_eap::DEFAULT_ACAP_SDK_LOCATION
     )]
     acap_sdk_location: PathBuf,
+    /// Time to stamp on every archive member, in seconds after the Unix epoch.
+    ///
+    /// Defaults to the current time.
+    #[clap(long, env = "SOURCE_DATE_EPOCH", value_parser = parse_mtime)]
+    source_date_epoch: Option<Mtime>,
+}
+
+fn parse_mtime(s: &str) -> anyhow::Result<Mtime> {
+    s.trim().parse::<u64>()?.try_into()
 }
 
 fn main() -> anyhow::Result<()> {
@@ -81,12 +91,26 @@ fn main() -> anyhow::Result<()> {
         disable_manifest_validation,
         oecore_target_arch,
         acap_sdk_location,
+        source_date_epoch,
     } = Cli::parse();
 
     let schema = if disable_manifest_validation {
         SchemaSource::None
     } else {
         SchemaSource::Resolve(acap_sdk_location)
+    };
+
+    // Reading the clock here, and the environment via clap, keeps the library deterministic
+    // given its inputs. Falling back to the current time matches the upstream tool.
+    let mtime = match source_date_epoch {
+        Some(value) => value,
+        None => Mtime::try_from(
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .context("reading current time")?
+                .as_secs(),
+        )
+        .context("converting current time")?,
     };
     match build {
         BuildOption::Make => assert!(Command::new("make")
@@ -109,6 +133,7 @@ fn main() -> anyhow::Result<()> {
     )?;
 
     builder.schema(schema);
+    builder.mtime(mtime);
 
     for name in builder.mandatory_files() {
         builder.add(&path.join(name))?;

--- a/crates/eap/src/lib.rs
+++ b/crates/eap/src/lib.rs
@@ -2,7 +2,6 @@
 //! Library for creating Embedded Application Packages (EAPs).
 use std::{
     collections::HashSet,
-    env,
     ffi::OsString,
     fs,
     io::Write,
@@ -12,7 +11,7 @@ use std::{
     str::FromStr,
 };
 
-use anyhow::{anyhow, bail, Context};
+use anyhow::{bail, ensure, Context};
 use command_utils::RunWith;
 use log::debug;
 use semver::Version;
@@ -34,6 +33,36 @@ pub use schema::SchemaSource;
 ///
 /// Used as the default location for resolving manifest schemas; see [`SchemaSource::Resolve`].
 pub const DEFAULT_ACAP_SDK_LOCATION: &str = "/opt/axis/";
+
+/// A modification time, in seconds after the Unix epoch, that the tar headers in the EAP can
+/// represent.
+///
+/// The 12-byte numeric header fields hold 11 octal digits; GNU tar silently encodes larger
+/// values with its base-256 extension, which not every unpacker understands, so conversion
+/// fails for values above [`Self::MAX`].
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub struct Mtime(u64);
+
+impl Mtime {
+    /// The largest value that the tar headers can portably represent.
+    pub const MAX: Self = Self((1 << 33) - 1);
+}
+
+impl TryFrom<u64> for Mtime {
+    type Error = anyhow::Error;
+
+    fn try_from(value: u64) -> Result<Self, Self::Error> {
+        // A larger value is almost always a millisecond timestamp; catching it here gives a
+        // targeted error where GNU tar would silently encode it in base-256.
+        ensure!(
+            value <= Self::MAX.0,
+            "{value} does not fit in the tar headers' 11 octal digits (max {}); if it is in \
+             milliseconds, convert it to seconds",
+            Self::MAX.0
+        );
+        Ok(Self(value))
+    }
+}
 
 // TODO: Find a better way to support reproducible builds
 fn copy<P: AsRef<Path>, Q: AsRef<Path>>(
@@ -112,6 +141,7 @@ pub struct AppBuilder<'a> {
     app_name: String,
     acap_build_impl: AcapBuildImpl,
     schema: SchemaSource,
+    mtime: Mtime,
 }
 
 impl<'a> AppBuilder<'a> {
@@ -133,6 +163,7 @@ impl<'a> AppBuilder<'a> {
             default_architecture,
             acap_build_impl: AcapBuildImpl::Equivalent,
             schema: Default::default(),
+            mtime: Mtime::default(),
         })
     }
 
@@ -149,6 +180,16 @@ impl<'a> AppBuilder<'a> {
     /// Defaults to [`SchemaSource::None`]
     pub fn schema(&mut self, schema: SchemaSource) -> &mut Self {
         self.schema = schema;
+        self
+    }
+
+    /// Set the modification time stamped on every archive member.
+    ///
+    /// Defaults to the Unix epoch. Reading this from the environment (e.g. from
+    /// `SOURCE_DATE_EPOCH`) or the clock is left to the caller so that the library stays
+    /// deterministic given its inputs.
+    pub fn mtime(&mut self, mtime: Mtime) -> &mut Self {
+        self.mtime = mtime;
         self
     }
 
@@ -228,11 +269,6 @@ impl<'a> AppBuilder<'a> {
             app_name,
             ..
         } = &self;
-        // TODO: Consider pushing environment variable fetching to dependant
-        let mtime = match env::var_os("SOURCE_DATE_EPOCH") {
-            Some(v) => v.into_string().map_err(|e| anyhow!("{e:?}"))?,
-            None => String::from_utf8(Command::new("date").arg("+%s").output()?.stdout)?,
-        };
 
         // Compute file name
         let package_name = match manifest.try_find_friendly_name() {
@@ -296,7 +332,7 @@ impl<'a> AppBuilder<'a> {
             .args(["--file", &eap_file_name])
             .args(["--format", "gnu"])
             .args(["--group", "0"])
-            .args(["--mtime", &format!("@{mtime}")])
+            .args(["--mtime", &format!("@{}", self.mtime.0)])
             .args(["--owner", "0"])
             .args(["--sort", "name"])
             .args(["--use-compress-program", "gzip --no-name -9"])
@@ -440,6 +476,12 @@ impl FromStr for Architecture {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn mtime_can_be_constructed_only_from_values_that_fit_in_the_headers() {
+        let Mtime(_) = Mtime::try_from(Mtime::MAX.0).unwrap();
+        assert!(Mtime::try_from(Mtime::MAX.0 + 1).is_err());
+    }
 
     #[test]
     fn copy_recreates_symlinks() {

--- a/snapshots/acap-build-docs
+++ b/snapshots/acap-build-docs
@@ -17,5 +17,7 @@ Options:
           [env: OECORE_TARGET_ARCH=] [possible values: aarch64, armv7hf]
       --acap-sdk-location <ACAP_SDK_LOCATION>
           [env: ACAP_SDK_LOCATION=] [default: /opt/axis/]
+      --source-date-epoch <SOURCE_DATE_EPOCH>
+          Time to stamp on every archive member, in seconds after the Unix epoch [env: SOURCE_DATE_EPOCH=]
   -h, --help
-          Print help
+          Print help (see more with '--help')


### PR DESCRIPTION
Replace the library's `SOURCE_DATE_EPOCH` and `date` subprocess reading with an AppBuilder::mtime setter (default: the Unix epoch), so that the library is deterministic given its inputs. This resolves the TODO about pushing environment variable fetching to the dependant, and removes another external binary: the `date` fallback, whose trailing newline was passed to tar as part of the timestamp.

The binary preserves the upstream semantics (`SOURCE_DATE_EPOCH` if set, the current time otherwise) with deliberate deviations:
- An unparseable value (including empty, which upstream treats as unset) is an error instead of producing a build with a nonsense timestamp.
- A value that does not fit in the headers' 11 octal digits is an error with a hint about millisecond timestamps, where GNU tar would silently encode it in base-256.
- A non-unicode value is an error, as it was in the library, where upstream would produce the nonsense-timestamp build described above;

Details
=======

`bin/acap-build-docs.sh`:
- Unset `SOURCE_DATE_EPOCH` because it appears GitHub actions sets it to `315532800` (1 Jan 1980) which shows up in the help output, breaking the snapshot tests.

`crates/eap/src/lib.rs`:
- Notes that not every unpacker understands base-256 is supported by because POSIX requires the ustar numeric fields to be "leading zero-filled octal numbers" and permits no binary alternative, so a strictly conforming implementation cannot read base-256 [^1], libarchive's tar(5) describes base-256 as an extension recognized by "GNU tar, star, and other newer tar implementations" [^2], and the GNU tar manual lists base-256 among GNU's extensions to the standard format [^3].
 
[^1]: https://pubs.opengroup.org/onlinepubs/9699919799/utilities/pax.html
[^2]: https://man.freebsd.org/cgi/man.cgi?query=tar&sektion=5
[^3]: https://www.gnu.org/software/tar/manual/html_node/Extensions.html