### PR TITLE
chore(eap): Extract the archive logic

### DIFF
--- a/crates/eap/src/archive.rs
+++ b/crates/eap/src/archive.rs
@@ -1,0 +1,4 @@
+//! Creation of the compressed archive that constitutes an EAP.
+
+mod equivalent;
+pub use equivalent::EquivalentArchiveBuilder;

--- a/crates/eap/src/archive/equivalent.rs
+++ b/crates/eap/src/archive/equivalent.rs
@@ -1,0 +1,80 @@
+//! Archive creation that delegates to the system `tar` and `gzip`.
+//!
+//! With matching inputs the output is bit-identical to the upstream `acap-build`, at the cost of
+//! requiring a GNU-compatible `tar` (notably, macOS ships BSD `tar`) and `gzip` on the `PATH`.
+//! Bit-exactness depends on the versions of `tar` and `gzip` that are resolved.
+use std::{path::Path, process::Command};
+
+use crate::{command_utils::RunWith, Mtime};
+
+/// Finds an available GNU `tar`, returning its program name, or `None` if
+/// only a non-GNU `tar` (e.g. BSD `tar` on macOS) is installed.
+#[cfg(test)]
+fn gnu_tar() -> Option<&'static str> {
+    ["tar", "gtar"].into_iter().find(|program| {
+        Command::new(program)
+            .arg("--version")
+            .output()
+            .ok()
+            .filter(|output| output.status.success())
+            .is_some_and(|output| String::from_utf8_lossy(&output.stdout).contains("GNU tar"))
+    })
+}
+
+pub struct EquivalentArchiveBuilder(Command);
+
+impl EquivalentArchiveBuilder {
+    fn init(
+        mut self,
+        staging_dir: &Path,
+        eap_file_name: &str,
+        mtime: Mtime,
+        use_compression: bool,
+    ) -> Self {
+        self.0.current_dir(staging_dir);
+        self.0
+            .args(["--exclude", "*~"])
+            .args(["--file", eap_file_name])
+            .args(["--format", "gnu"])
+            .args(["--group", "0"])
+            .args(["--mtime", &format!("@{}", mtime.0)])
+            .args(["--owner", "0"])
+            .args(["--sort", "name"]);
+        if use_compression {
+            self.0.args(["--use-compress-program", "gzip --no-name -9"]);
+        }
+        self.0
+            .arg("--create")
+            .arg("--numeric-owner")
+            .arg("--exclude-vcs");
+        self
+    }
+    pub fn new(staging_dir: &Path, eap_file_name: &str, mtime: Mtime) -> Self {
+        Self(Command::new("tar")).init(staging_dir, eap_file_name, mtime, true)
+    }
+
+    #[expect(dead_code, reason = "Will be used in the next commit")]
+    #[cfg(test)]
+    pub fn new_portable_without_compression(
+        staging_dir: &Path,
+        eap_file_name: &str,
+        mtime: Mtime,
+    ) -> Option<Self> {
+        gnu_tar().map(|p| Self(Command::new(p)).init(staging_dir, eap_file_name, mtime, false))
+    }
+
+    pub fn file(&mut self, name: &str) -> &mut Self {
+        self.0.arg(name);
+        self
+    }
+
+    pub fn files(&mut self, files: &[&str]) -> &mut Self {
+        self.0.args(files);
+        self
+    }
+
+    pub fn run_with_logged_stdout(mut self) -> anyhow::Result<()> {
+        self.0.arg("--verbose");
+        self.0.run_with_logged_stdout()
+    }
+}

--- a/crates/eap/src/lib.rs
+++ b/crates/eap/src/lib.rs
@@ -7,12 +7,10 @@ use std::{
     io::Write,
     os::unix::fs::{symlink, PermissionsExt},
     path::{Path, PathBuf},
-    process::Command,
     str::FromStr,
 };
 
 use anyhow::{bail, ensure, Context};
-use command_utils::RunWith;
 use log::debug;
 use semver::Version;
 use serde_json::Value;
@@ -21,6 +19,7 @@ use crate::files::{
     cgi_conf::CgiConf, manifest::Manifest, package_conf::PackageConf, param_conf::ParamConf,
 };
 
+mod archive;
 mod command_utils;
 mod json_ext;
 mod schema;
@@ -28,6 +27,8 @@ mod schema;
 mod files;
 
 pub use schema::SchemaSource;
+
+use crate::archive::EquivalentArchiveBuilder;
 
 /// The location where the ACAP SDK is installed by default.
 ///
@@ -327,37 +328,24 @@ impl<'a> AppBuilder<'a> {
         fs::set_permissions(&manifest_file, permissions)?;
 
         // Create the archive
-        let mut tar = Command::new("tar");
-        tar.args(["--exclude", "*~"])
-            .args(["--file", &eap_file_name])
-            .args(["--format", "gnu"])
-            .args(["--group", "0"])
-            .args(["--mtime", &format!("@{}", self.mtime.0)])
-            .args(["--owner", "0"])
-            .args(["--sort", "name"])
-            .args(["--use-compress-program", "gzip --no-name -9"])
-            .arg("--create")
-            .arg("--numeric-owner")
-            .arg("--exclude-vcs");
+        let mut tar = EquivalentArchiveBuilder::new(staging_dir, &eap_file_name, self.mtime);
 
         for name in self.section_1_files() {
             if staging_dir.join(name).symlink_metadata().is_ok() {
-                tar.arg(name);
+                tar.file(name);
             }
         }
 
-        tar.args(self.other_files());
+        tar.files(self.other_files().as_slice());
 
         // TODO: Consider implementing support for `httpd.conf.local.*` and `mime.types.local.*`.
 
         for name in self.section_4_files() {
             if staging_dir.join(name).symlink_metadata().is_ok() {
-                tar.arg(name);
+                tar.file(name);
             }
         }
 
-        tar.arg("--verbose");
-        tar.current_dir(staging_dir);
         tar.run_with_logged_stdout()?;
 
         Ok(OsString::from(eap_file_name))


### PR DESCRIPTION
The purpose is to create space for a new archiving implementation that does not depend on external programs.