### PR TITLE
fix(vlt): Add missing loanable fields and use correct port

### DIFF
--- a/crates/device-inventory/src/fusion.rs
+++ b/crates/device-inventory/src/fusion.rs
@@ -557,7 +557,11 @@ pub fn loan_fingerprint(d: &Loan) -> String {
 }
 
 pub fn other_fingerprint(d: &rs4a_vlt::responses::Device) -> String {
-    format!("{}:{}", d.host(), d.external_ip.http_port())
+    // Fingerprints calculated with this method will not match fingerprints calculated with another
+    // method for the same device, so the device would show up twice if present among VLT devices
+    // and some other inventory.
+    // TODO: Removal VLT devices that are not borrowed from device-inventory
+    format!("{}:{}", d.host(), d.external_ip.to_bits())
 }
 
 pub fn mdns_fingerprint(d: &mdns_source::Device) -> String {

--- a/crates/vlt/src/responses.rs
+++ b/crates/vlt/src/responses.rs
@@ -3,9 +3,10 @@ use std::{
     fmt::{Display, Formatter},
     net::Ipv4Addr,
     path::PathBuf,
+    str::FromStr,
 };
 
-use anyhow::Context;
+use anyhow::{anyhow, Context};
 use chrono::{DateTime, SecondsFormat, Utc};
 use serde::{ser::SerializeSeq, Deserialize, Deserializer, Serialize, Serializer};
 use serde_json::Value;
@@ -203,25 +204,72 @@ where
 pub struct ExternalIp(Ipv4Addr);
 
 impl ExternalIp {
-    fn port_suffix(&self) -> u16 {
-        let external = self.0;
-        let [_, _, o2, o3] = external.octets();
-        1_000 * o2 as u16 + o3 as u16
+    pub fn to_bits(&self) -> u32 {
+        self.0.to_bits()
+    }
+}
+
+#[derive(Clone, Debug, Deserialize)]
+#[serde(try_from = "String")]
+pub struct InternalIp {
+    host: Ipv4Addr,
+    base_port: u16,
+}
+
+impl InternalIp {
+    fn forwarded_port(&self, protocol_index: u8) -> u16 {
+        // Replace the first digit of `self.base_port` with `protocol_index`
+        let scale = 10u16.pow(self.base_port.checked_ilog10().unwrap_or(0));
+        let suffix = self.base_port % scale;
+        protocol_index as u16 * scale + suffix
     }
 
     /// Returns the port forwarded to port 80.
     pub fn http_port(&self) -> u16 {
-        10_000 + self.port_suffix()
+        self.forwarded_port(1)
     }
 
     /// Returns the port forwarded to port 443.
     pub fn https_port(&self) -> u16 {
-        40_000 + self.port_suffix()
+        self.forwarded_port(4)
     }
 
     /// Returns the port forwarded to port 22.
     pub fn ssh_port(&self) -> u16 {
-        20_000 + self.port_suffix()
+        self.forwarded_port(2)
+    }
+
+    /// Returns the port forwarded to port 554.
+    pub fn rtsp_port(&self) -> u16 {
+        self.forwarded_port(3)
+    }
+}
+
+impl Display for InternalIp {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}:{}", self.host, self.base_port)
+    }
+}
+
+impl Serialize for InternalIp {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.collect_str(self) // uses your Display impl
+    }
+}
+
+impl TryFrom<String> for InternalIp {
+    type Error = anyhow::Error;
+
+    fn try_from(s: String) -> Result<Self, Self::Error> {
+        let (host, port) = s
+            .rsplit_once(':')
+            .ok_or_else(|| anyhow!("Internal IP `{s}` has no port"))?;
+        let base_port = port
+            .parse()
+            .context("Internal IP `{s}` has an invalide port")?;
+        let host =
+            Ipv4Addr::from_str(host).context("Internal IP `{s}` has an invalid IP address")?;
+        Ok(Self { host, base_port })
     }
 }
 
@@ -247,8 +295,7 @@ pub struct Device {
     #[serde(serialize_with = "serialize_datetime_array")]
     pub booked: Vec<DateTime<Utc>>,
     /// Despite it's name, the device is not accessible from the internet at this IP.
-    /// But it can be used to infer connect options such as ports.
-    /// However, it is best to refrain from connecting to these devices since they may be in use.
+    /// It only serves as a stable per-device identifier.
     pub external_ip: ExternalIp,
     pub firmware_version: FirmwareVersion,
     pub id: LoanableId,
@@ -274,7 +321,7 @@ impl Device {
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct NewLoanable {
     pub id: LoanableId,
-    pub internal_ip: String,
+    pub internal_ip: InternalIp,
     pub model: String,
 }
 
@@ -322,31 +369,19 @@ impl Loan {
         Host::Ipv4(Ipv4Addr::from([195, 60, 68, 14]))
     }
 
-    fn base_port(&self) -> anyhow::Result<u16> {
-        let (_, port) = self
-            .loanable
-            .internal_ip
-            .split_once(':')
-            .context("Internal IP has no port")?;
-        let port: u16 = port
-            .parse()
-            .context("Internal IP port is not a valid port number")?;
-        Ok(port)
-    }
-
     /// Returns the port forwarded to port 80.
     pub fn http_port(&self) -> u16 {
-        self.base_port().unwrap()
+        self.loanable.internal_ip.http_port()
     }
 
     /// Returns the port forwarded to port 443.
     pub fn https_port(&self) -> u16 {
-        self.base_port().unwrap() + 30_000
+        self.loanable.internal_ip.https_port()
     }
 
     /// Returns the port forwarded to port 22.
     pub fn ssh_port(&self) -> u16 {
-        self.base_port().unwrap() + 10_000
+        self.loanable.internal_ip.ssh_port()
     }
 }
 
@@ -369,7 +404,7 @@ pub struct Loanable {
     pub external_ip: ExternalIp,
     pub id: LoanableId,
     pub image_url: PathBuf,
-    pub internal_ip: String,
+    pub internal_ip: InternalIp,
     pub model: String,
     portcast_device: Option<PortcastDevice>,
     pub r#type: String,
@@ -387,5 +422,29 @@ impl LoanableId {
 impl Display for LoanableId {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         self.0.fmt(f)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn internal_ip(s: &str) -> InternalIp {
+        InternalIp::try_from(s.to_string()).unwrap()
+    }
+
+    #[test]
+    fn ports_are_computed_correctly_on_example() {
+        let ip = internal_ip("10.20.41.10:11060");
+        assert_eq!(ip.http_port(), 11060);
+        assert_eq!(ip.ssh_port(), 21060);
+        assert_eq!(ip.rtsp_port(), 31060);
+        assert_eq!(ip.https_port(), 41060);
+    }
+
+    #[test]
+    fn parsing_rejects_strings_without_a_valid_port() {
+        let () = assert!(InternalIp::try_from("10.20.41.10".to_string()).is_err());
+        let () = assert!(InternalIp::try_from("10.20.41.10:bogus".to_string()).is_err());
     }
 }

--- a/crates/vlt/src/responses.rs
+++ b/crates/vlt/src/responses.rs
@@ -336,22 +336,17 @@ impl Loan {
 
     /// Returns the port forwarded to port 80.
     pub fn http_port(&self) -> u16 {
-        let from_suffix = self.loanable.external_ip.http_port();
-        if cfg!(debug_assertions) {
-            let from_base_port = self.base_port().unwrap();
-            debug_assert_eq!(from_base_port, from_suffix);
-        }
-        from_suffix
+        self.base_port().unwrap()
     }
 
     /// Returns the port forwarded to port 443.
     pub fn https_port(&self) -> u16 {
-        self.loanable.external_ip.https_port()
+        self.base_port().unwrap() + 30_000
     }
 
     /// Returns the port forwarded to port 22.
     pub fn ssh_port(&self) -> u16 {
-        self.loanable.external_ip.ssh_port()
+        self.base_port().unwrap() + 10_000
     }
 }
 
@@ -367,12 +362,17 @@ impl Display for LoanId {
 #[non_exhaustive]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Loanable {
+    pub device_map_id: u32,
+    pub display_name: String,
     /// Despite it's name, the device is not accessible from the internet at this IP.
     /// Consider using [`Loan::host`] instead.
     pub external_ip: ExternalIp,
-    pub internal_ip: String,
     pub id: LoanableId,
+    pub image_url: PathBuf,
+    pub internal_ip: String,
     pub model: String,
+    portcast_device: Option<PortcastDevice>,
+    pub r#type: String,
 }
 
 #[derive(Clone, Copy, Debug, Deserialize, Serialize)]

--- a/crates/vlt/src/responses.rs
+++ b/crates/vlt/src/responses.rs
@@ -253,7 +253,7 @@ impl Display for InternalIp {
 
 impl Serialize for InternalIp {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        serializer.collect_str(self) // uses your Display impl
+        serializer.collect_str(self)
     }
 }
 
@@ -295,7 +295,6 @@ pub struct Device {
     #[serde(serialize_with = "serialize_datetime_array")]
     pub booked: Vec<DateTime<Utc>>,
     /// Despite it's name, the device is not accessible from the internet at this IP.
-    /// It only serves as a stable per-device identifier.
     pub external_ip: ExternalIp,
     pub firmware_version: FirmwareVersion,
     pub id: LoanableId,

--- a/crates/vlt/tests/responses/get_loans_non_empty.json
+++ b/crates/vlt/tests/responses/get_loans_non_empty.json
@@ -12,10 +12,15 @@
       "selected_firmware": "11.11.169",
       "started_at": "2025-10-04T10:42:30.000Z",
       "loanable": {
-        "model": "AXIS P8815-2",
-        "internal_ip": "10.20.41.10:11060",
-        "external_ip": "192.168.1.60",
-        "id": 184
+        "device_map_id": 90,
+        "model": "AXIS Q8752-E",
+        "display_name": "",
+        "internal_ip": "10.20.41.10:13108",
+        "external_ip": "192.168.2.43",
+        "image_url": "images/devices/AXIS_Q8752-E.png",
+        "type": "Bispectral Zoom PTZ Camera",
+        "id": 1234,
+        "portcast_device": null
       },
       "meta": []
     }

--- a/crates/vlt/tests/responses/get_loans_radar.json
+++ b/crates/vlt/tests/responses/get_loans_radar.json
@@ -12,10 +12,15 @@
       "selected_firmware": "12.7.53",
       "started_at": "2025-11-15T12:20:41.000Z",
       "loanable": {
+        "device_map_id": 90,
         "model": "AXIS D2210-VE",
+        "display_name": "",
         "internal_ip": "10.20.41.10:12095",
         "external_ip": "192.168.2.95",
-        "id": 851
+        "image_url": "images/devices/AXIS_Q8752-E.png",
+        "type": "Radar",
+        "id": 851,
+        "portcast_device": null
       },
       "meta": [
         "Since the radar is mounted indoors, we will provide you with a pre-recorded data file for testing.",


### PR DESCRIPTION
The ports set by `device-inventory sync` did not work and did not match those displayed in the web app, but it seems the other method of calculating ports does work so we switch to that.

Details
=======

`crates/vlt/tests/responses/get_loans_radar.json`:
- This was failing and because gathering real data is laborious I just guessed some reasonable data; this crate needs something like the cassette tests that is easy to update, but it is also more difficult because the operations are costly, which we can observe in the form of severe rate limits.