### PR TITLE
fix(eap): Add architecture to manifest from schema version 1.3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -114,6 +114,11 @@ check_tests_t3:
 		--exclude rs4a-eap
 .PHONY: check_tests_t3
 
+check_tests_mac_os: init-env.sh
+	. ./init-env.sh && \
+	export PATH="/opt/homebrew/opt/gnu-tar/libexec/gnubin:${PATH}" && \
+	cargo test -p acap-build -- --ignored
+
 ## Fixes
 ## -----
 
@@ -143,6 +148,9 @@ fix_lint:
 
 Cargo.lock: $(wildcard crates/*/Cargo.toml)
 	cargo metadata --format-version=1 > /dev/null
+
+init-env.sh: bin/create-venv.sh
+	@<
 
 # The `acap-build` snapshot tests need the ACAP Native SDK. This Makefile assumes
 # it is already installed and, if it is not at the default `/opt/axis`, that

--- a/crates/acap-build/tests/data/schema_1_3_app/LICENSE
+++ b/crates/acap-build/tests/data/schema_1_3_app/LICENSE
@@ -1,0 +1,1 @@
+Placeholder for smoke test fixture; not a real license.

--- a/crates/acap-build/tests/data/schema_1_3_app/a
+++ b/crates/acap-build/tests/data/schema_1_3_app/a
@@ -1,0 +1,2 @@
+#!/bin/sh
+exit 0

--- a/crates/acap-build/tests/data/schema_1_3_app/manifest.json
+++ b/crates/acap-build/tests/data/schema_1_3_app/manifest.json
@@ -1,0 +1,10 @@
+{
+  "schemaVersion": "1.3",
+  "acapPackageConf": {
+    "setup": {
+      "appName": "a",
+      "runMode": "never",
+      "version": "0.0.0"
+    }
+  }
+}

--- a/crates/acap-build/tests/equivalence.rs
+++ b/crates/acap-build/tests/equivalence.rs
@@ -23,21 +23,20 @@ fn copy_dir(src: &Path, dst: &Path) {
     }
 }
 
-// TODO: Add facilities for comparing with upstream automatically
-// TODO: Make `acap-build` compatible with all supported dev environments of this propject
-#[ignore = "requires a tier 2 developer environment"]
-#[test]
-fn example_app_output_matches_snapshot() {
+/// Build the app in `tests/data/<name>` and return the exit code of the build together with a
+/// checksum of the produced EAP.
+fn build_and_checksum(name: &str, extra_args: &[&str]) -> (Option<i32>, String) {
     let manifest_dir = env!("CARGO_MANIFEST_DIR");
-    let fixture = Path::new(manifest_dir).join("tests/data/example_app");
+    let fixture = Path::new(manifest_dir).join("tests/data").join(name);
 
     // Build in a scratch copy so the generated files don't pollute the fixture.
     let scratch = tempfile::tempdir().unwrap();
-    let app = scratch.path().join("example_app");
+    let app = scratch.path().join(name);
     copy_dir(&fixture, &app);
 
     let output = Command::new(env!("CARGO_BIN_EXE_acap-build"))
         .args(["--build", "no-build"])
+        .args(extra_args)
         .arg(&app)
         .env("SOURCE_DATE_EPOCH", "0")
         .env("OECORE_TARGET_ARCH", "aarch64")
@@ -48,7 +47,7 @@ fn example_app_output_matches_snapshot() {
     let eap_file_path = PathBuf::from(String::from_utf8(output.stdout).unwrap().trim());
     assert!(
         output.status.success(),
-        "acap-built existed with {}: {eap_file_path:?}",
+        "acap-build exited with {}: {eap_file_path:?}",
         output.status
     );
 
@@ -58,8 +57,14 @@ fn example_app_output_matches_snapshot() {
         .unwrap();
     let mut hasher = DefaultHasher::new();
     contents.hash(&mut hasher);
-    let checksum = format!("{:016x}", hasher.finish());
+    (output.status.code(), format!("{:016x}", hasher.finish()))
+}
 
+// TODO: Add facilities for comparing with upstream automatically
+// TODO: Make `acap-build` compatible with all supported dev environments of this propject
+#[ignore = "requires a tier 2 developer environment"]
+#[test]
+fn example_app_output_matches_snapshot() {
     // TODO: Also assert other properties of the output, such as name and location of artefacts
     expect![[r#"
         (
@@ -69,5 +74,24 @@ fn example_app_output_matches_snapshot() {
             "ee74935e2c809417",
         )
     "#]]
-    .assert_debug_eq(&(output.status.code(), checksum));
+    .assert_debug_eq(&build_and_checksum("example_app", &[]));
+}
+
+#[ignore = "requires a tier 2 developer environment"]
+#[test]
+fn schema_1_3_app_output_matches_snapshot() {
+    // Validation is disabled because that is how the example was built when it was found.
+    // TODO: Look into whether it can be enabled to stay close to the idealized model
+    expect![[r#"
+        (
+            Some(
+                0,
+            ),
+            "246baeeded73541b",
+        )
+    "#]]
+    .assert_debug_eq(&build_and_checksum(
+        "schema_1_3_app",
+        &["--disable-manifest-validation"],
+    ));
 }

--- a/crates/eap/src/files/manifest.rs
+++ b/crates/eap/src/files/manifest.rs
@@ -25,7 +25,7 @@ impl Manifest {
             schema_version.push_str(".0");
         }
         let schema_version = semver::Version::parse(&schema_version)?;
-        if schema_version > semver::Version::new(1, 3, 0) {
+        if schema_version >= semver::Version::new(1, 3, 0) {
             let setup = manifest.try_find_setup_mut()?;
             if let Some(a) = setup.get("architecture") {
                 if a != "all" && a != architecture.nickname() {
@@ -132,5 +132,56 @@ impl Manifest {
             Serializer::with_formatter(&mut data, PrettyFormatter::with_indent(b"    "));
         self.0.serialize(&mut serializer)?;
         Ok(String::from_utf8(data)?)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::*;
+
+    #[test]
+    fn architecture_is_added_from_schema_version_1_3() {
+        for schema_version in ["1.3", "1.3.0", "1.4"] {
+            let manifest = Manifest::new(
+                json!({
+                    "schemaVersion": schema_version,
+                    "acapPackageConf": {
+                        "setup": {
+                            "appName": "a",
+                            "runMode": "never",
+                            "version": "0.0.0"
+                        }
+                    }
+                }),
+                Architecture::Aarch64,
+            )
+            .unwrap();
+            assert_eq!(
+                manifest.try_find_architecture().ok(),
+                Some("aarch64"),
+                "schemaVersion {schema_version:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn architecture_is_not_added_before_schema_version_1_3() {
+        let manifest = Manifest::new(
+            json!({
+                "schemaVersion": "1.2",
+                "acapPackageConf": {
+                    "setup": {
+                        "appName": "a",
+                        "runMode": "never",
+                        "version": "0.0.0"
+                    }
+                }
+            }),
+            Architecture::Aarch64,
+        )
+        .unwrap();
+        manifest.try_find_architecture().unwrap_err();
     }
 }


### PR DESCRIPTION
Differential fuzzing against the reference acap-build (12.1.0) found that it adds the architecture field to the manifest that enters the EAP for every schema version from 1.3 onwards, whereas this implementation did so only for versions strictly greater than 1.3.0.

The shrunken input is committed as an example app covered by a snapshot test like the existing one, in addition to a unit test. The snapshot was taken after the fix, from a build that fuzzing verified to be bit-identical to the output of the reference.

Details
=======

`Makefile`:
- Add `check_tests_mac_os` to make it easier to run the tests on macOS; I keep forgetting the path to GNU tar. This recipe deviates from the pattern of relying on the environment to be set up properly, which is not a pattern that should proliferate because I have bad experiences with it. It's not given a docstring because it's not a main workflow - typically macOS developers should not need to test this.

