### PR TITLE
chore: Skip check flake pre-merge

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -21,6 +21,7 @@ jobs:
       - name: Run checks
         run: nix develop --ignore-env --command make check
       - name: Check flake
+        if: github.event_name == 'push'
         run: nix flake check
   checks-macos:
     needs: checks


### PR DESCRIPTION
This typically takes about 2/3 of the total time is unlikely to fail if the other jobs pass.