### PR TITLE
fix(eap): Escape non-ASCII in manifest like the reference

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,6 +55,7 @@ edition = "2021"
 [workspace.lints.clippy]
 indexing_slicing = "warn"
 allow_attributes_without_reason = "warn"
+non_ascii_literal = "warn"
 
 [workspace.lints.rust]
 unsafe_code = "forbid"

--- a/Makefile
+++ b/Makefile
@@ -102,7 +102,8 @@ check_tests: check_tests_t3
 		--all-targets \
 		--locked \
 		-p acap-build \
-		-p rs4a-eap
+		-p rs4a-eap \
+		-- --ignored
 .PHONY: check_tests
 
 check_tests_t3:

--- a/crates/acap-build/tests/data/non_ascii_app/LICENSE
+++ b/crates/acap-build/tests/data/non_ascii_app/LICENSE
@@ -1,0 +1,1 @@
+Placeholder for smoke test fixture; not a real license.

--- a/crates/acap-build/tests/data/non_ascii_app/a
+++ b/crates/acap-build/tests/data/non_ascii_app/a
@@ -1,0 +1,2 @@
+#!/bin/sh
+exit 0

--- a/crates/acap-build/tests/data/non_ascii_app/manifest.json
+++ b/crates/acap-build/tests/data/non_ascii_app/manifest.json
@@ -1,0 +1,11 @@
+{
+  "schemaVersion": "1.3",
+  "acapPackageConf": {
+    "setup": {
+      "appName": "a",
+      "friendlyName": "Åpp Ω",
+      "runMode": "never",
+      "version": "0.0.0"
+    }
+  }
+}

--- a/crates/acap-build/tests/equivalence.rs
+++ b/crates/acap-build/tests/equivalence.rs
@@ -95,3 +95,22 @@ fn schema_1_3_app_output_matches_snapshot() {
         &["--disable-manifest-validation"],
     ));
 }
+
+#[ignore = "requires a tier 2 developer environment"]
+#[test]
+fn non_ascii_app_output_matches_snapshot() {
+    // Validation is disabled because that is how the example was built when it was found.
+    // TODO: Look into whether it can be enabled to stay close to the idealized model
+    expect![[r#"
+        (
+            Some(
+                0,
+            ),
+            "2306cff73c24e010",
+        )
+    "#]]
+    .assert_debug_eq(&build_and_checksum(
+        "non_ascii_app",
+        &["--disable-manifest-validation"],
+    ));
+}

--- a/crates/eap/src/files/manifest.rs
+++ b/crates/eap/src/files/manifest.rs
@@ -131,8 +131,28 @@ impl Manifest {
         let mut serializer =
             Serializer::with_formatter(&mut data, PrettyFormatter::with_indent(b"    "));
         self.0.serialize(&mut serializer)?;
-        Ok(String::from_utf8(data)?)
+        Ok(ensure_ascii(&String::from_utf8(data)?))
     }
+}
+
+/// Escape non-ASCII characters the way Python's `json.dump` does with its default
+/// `ensure_ascii=True`: as `\uXXXX` sequences of UTF-16 code units, lowercase hex.
+///
+/// In serialized JSON non-ASCII characters can only occur inside string literals, so escaping
+/// them anywhere in the document is equivalent to escaping them during serialization.
+fn ensure_ascii(json: &str) -> String {
+    let mut escaped = String::with_capacity(json.len());
+    let mut buf = [0u16; 2];
+    for c in json.chars() {
+        if c.is_ascii() {
+            escaped.push(c);
+        } else {
+            for unit in c.encode_utf16(&mut buf) {
+                escaped.push_str(&format!("\\u{unit:04x}"));
+            }
+        }
+    }
+    escaped
 }
 
 #[cfg(test)]
@@ -140,6 +160,16 @@ mod tests {
     use serde_json::json;
 
     use super::*;
+
+    #[test]
+    fn ensure_ascii_escapes_like_python_json_dump() {
+        // Matches `json.dumps("Åπ🦀")`.
+        assert_eq!(
+            ensure_ascii("\"\u{c5}\u{3c0}\u{1f980}\""),
+            "\"\\u00c5\\u03c0\\ud83e\\udd80\""
+        );
+        assert_eq!(ensure_ascii("\"ascii\""), "\"ascii\"");
+    }
 
     #[test]
     fn architecture_is_added_from_schema_version_1_3() {
@@ -183,5 +213,39 @@ mod tests {
         )
         .unwrap();
         manifest.try_find_architecture().unwrap_err();
+    }
+
+    #[test]
+    fn try_to_string_escapes_non_ascii() {
+        let manifest = Manifest::new(
+            json!({
+                "schemaVersion": "1.3",
+                "acapPackageConf": {
+                    "setup": {
+                        "appName": "a",
+                        "friendlyName": "\u{c5}pp \u{3a9}",
+                        "runMode": "never",
+                        "version": "0.0.0"
+                    }
+                }
+            }),
+            Architecture::Aarch64,
+        )
+        .unwrap();
+        assert_eq!(
+            manifest.try_to_string().unwrap(),
+            r#"{
+    "schemaVersion": "1.3",
+    "acapPackageConf": {
+        "setup": {
+            "appName": "a",
+            "friendlyName": "\u00c5pp \u03a9",
+            "runMode": "never",
+            "version": "0.0.0",
+            "architecture": "aarch64"
+        }
+    }
+}"#
+        );
     }
 }


### PR DESCRIPTION
Differential fuzzing against the reference acap-build (12.1.0) found that a non-ASCII friendly name produces a different manifest.json inside the EAP: Python's json.dump escapes non-ASCII characters as \uXXXX sequences of UTF-16 code units (ensure_ascii=True), whereas serde_json emits raw UTF-8. Escape the serialized manifest the same way.

Details
=======

`Cargo.toml`:
- Warn on `clippy::non_ascii_literal` because unicode characters can be difficult to tell apart from each other and from normal ASCII which can cause surprising issues that are annoying to troubleshoot because the cause is not visible in the IDE.

`Makefile`:
- Include ignored tests in t2 to make sure the equivalence integration tests run in CI; I'm not I like using `ignored` to encode in what developer environments a test can run and I want to review this once `rs4a-eap` is stable.