### PR TITLE
fix(eap): Omit cgi.conf when httpConfig is present but empty

### DIFF
--- a/crates/acap-build/tests/data/directory_http_config_app/LICENSE
+++ b/crates/acap-build/tests/data/directory_http_config_app/LICENSE
@@ -1,0 +1,1 @@
+Placeholder for smoke test fixture; not a real license.

--- a/crates/acap-build/tests/data/directory_http_config_app/a
+++ b/crates/acap-build/tests/data/directory_http_config_app/a
@@ -1,0 +1,2 @@
+#!/bin/sh
+exit 0

--- a/crates/acap-build/tests/data/directory_http_config_app/manifest.json
+++ b/crates/acap-build/tests/data/directory_http_config_app/manifest.json
@@ -1,0 +1,19 @@
+{
+  "schemaVersion": "1.3",
+  "acapPackageConf": {
+    "setup": {
+      "appName": "a",
+      "runMode": "never",
+      "version": "0.0.0"
+    },
+    "configuration": {
+      "httpConfig": [
+        {
+          "type": "directory",
+          "name": "html",
+          "access": "viewer"
+        }
+      ]
+    }
+  }
+}

--- a/crates/acap-build/tests/data/empty_http_config_app/LICENSE
+++ b/crates/acap-build/tests/data/empty_http_config_app/LICENSE
@@ -1,0 +1,1 @@
+Placeholder for smoke test fixture; not a real license.

--- a/crates/acap-build/tests/data/empty_http_config_app/a
+++ b/crates/acap-build/tests/data/empty_http_config_app/a
@@ -1,0 +1,2 @@
+#!/bin/sh
+exit 0

--- a/crates/acap-build/tests/data/empty_http_config_app/manifest.json
+++ b/crates/acap-build/tests/data/empty_http_config_app/manifest.json
@@ -1,0 +1,13 @@
+{
+  "schemaVersion": "1.3",
+  "acapPackageConf": {
+    "setup": {
+      "appName": "a",
+      "runMode": "never",
+      "version": "0.0.0"
+    },
+    "configuration": {
+      "httpConfig": []
+    }
+  }
+}

--- a/crates/acap-build/tests/equivalence.rs
+++ b/crates/acap-build/tests/equivalence.rs
@@ -114,3 +114,41 @@ fn non_ascii_app_output_matches_snapshot() {
         &["--disable-manifest-validation"],
     ));
 }
+
+#[ignore = "requires a tier 2 developer environment"]
+#[test]
+fn empty_http_config_app_output_matches_snapshot() {
+    // Validation is disabled because that is how the example was built when it was found.
+    // TODO: Look into whether it can be enabled to stay close to the idealized model
+    expect![[r#"
+        (
+            Some(
+                0,
+            ),
+            "7080805ecf289485",
+        )
+    "#]]
+    .assert_debug_eq(&build_and_checksum(
+        "empty_http_config_app",
+        &["--disable-manifest-validation"],
+    ));
+}
+
+#[ignore = "requires a tier 2 developer environment"]
+#[test]
+fn directory_http_config_app_output_matches_snapshot() {
+    // Validation is disabled because that is how the example was built when it was found.
+    // TODO: Look into whether it can be enabled to stay close to the idealized model
+    expect![[r#"
+        (
+            Some(
+                0,
+            ),
+            "e8d8187330c90010",
+        )
+    "#]]
+    .assert_debug_eq(&build_and_checksum(
+        "directory_http_config_app",
+        &["--disable-manifest-validation"],
+    ));
+}

--- a/crates/eap/src/files/cgi_conf.rs
+++ b/crates/eap/src/files/cgi_conf.rs
@@ -26,6 +26,13 @@ impl CgiConf {
             Err(e) => return Err(e.into()),
         };
 
+        // note that a non-empty httpConfig with only directory entries still
+        // produces a file, albeit an empty one.
+        if conf.is_empty() {
+            debug!("Skipping cgi.conf, httpConfig is empty");
+            return Ok(None);
+        }
+
         let mut entries = Vec::new();
         for obj in conf.iter() {
             let obj = obj.try_to_object()?;
@@ -62,5 +69,50 @@ impl Display for CgiConf {
             }
         }
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::{json, Value};
+
+    use super::*;
+    use crate::Architecture;
+
+    fn manifest_with_http_config(http_config: Value) -> Manifest {
+        Manifest::new(
+            json!({
+                "schemaVersion": "1.3",
+                "acapPackageConf": {
+                    "setup": {
+                        "appName": "a",
+                        "runMode": "never",
+                        "version": "0.0.0"
+                    },
+                    "configuration": {
+                        "httpConfig": http_config
+                    }
+                }
+            }),
+            Architecture::Aarch64,
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn cgi_conf_is_omitted_when_http_config_is_empty() {
+        let manifest = manifest_with_http_config(json!([]));
+        assert!(CgiConf::new(&manifest).unwrap().is_none());
+    }
+
+    #[test]
+    fn cgi_conf_is_empty_but_present_when_http_config_has_only_directory_entries() {
+        // Unlike an empty httpConfig, one containing only directory entries still produces a
+        // file, albeit an empty one, in both implementations.
+        let manifest = manifest_with_http_config(json!([
+            {"type": "directory", "name": "html", "access": "viewer"}
+        ]));
+        let conf = CgiConf::new(&manifest).unwrap().unwrap();
+        assert_eq!(conf.to_string(), "");
     }
 }


### PR DESCRIPTION
Differential fuzzing against the reference acap-build (12.1.0) found that it skips creating cgi.conf when httpConfig is empty, same as when it is absent, whereas this implementation packaged an empty cgi.conf. Note that a non-empty httpConfig containing only directory entries still produces an empty cgi.conf in both implementations.