### PR TITLE
fix(ab): Accept `arm`, not `armv7hf`, for OECORE_TARGET_ARCH

### DIFF
--- a/crates/acap-build/src/main.rs
+++ b/crates/acap-build/src/main.rs
@@ -16,6 +16,7 @@ use tempdir::TempDir;
 #[derive(Clone, Copy, Debug, ValueEnum)]
 pub enum Architecture {
     Aarch64,
+    #[value(name = "arm")]
     Armv7hf,
 }
 

--- a/snapshots/acap-build-docs
+++ b/snapshots/acap-build-docs
@@ -14,7 +14,7 @@ Options:
       --disable-manifest-validation
           Disable validation of manifest file against manifest schema
       --oecore-target-arch <OECORE_TARGET_ARCH>
-          [env: OECORE_TARGET_ARCH=] [possible values: aarch64, armv7hf]
+          [env: OECORE_TARGET_ARCH=] [possible values: aarch64, arm]
       --acap-sdk-location <ACAP_SDK_LOCATION>
           [env: ACAP_SDK_LOCATION=] [default: /opt/axis/]
       --source-date-epoch <SOURCE_DATE_EPOCH>


### PR DESCRIPTION
The SDK's environment-setup exports OECORE_TARGET_ARCH=arm for the armv7hf target and the upstream acap-build accepts only arm, but the port accepted only armv7hf -- so sourced into a real armv7hf SDK it would fail. Match the upstream vocabulary. Surfaced by the target-architecture fuzzing.