### PR TITLE
chore: Add dev containers

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,9 @@
+ARG TAG
+FROM --platform=linux/amd64 axisecp/acap-native-sdk:${TAG}
+RUN echo '. /opt/axis/acapsdk/environment-setup-*' >> /root/.bashrc
+RUN apt-get update \
+ && apt-get install --no-install-recommends --yes gcc libc6-dev \
+ && rm -rf /var/lib/apt/lists/*
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
+  | sh -s -- -y --no-modify-path --default-toolchain 1.85.1
+ENV PATH=/root/.cargo/bin:$PATH

--- a/.devcontainer/acap-native-sdk-12-aarch64/devcontainer.json
+++ b/.devcontainer/acap-native-sdk-12-aarch64/devcontainer.json
@@ -1,0 +1,12 @@
+{
+  "name": "ACAP Native SDK 12 aarch64",
+  "build": {
+    "dockerfile": "../Dockerfile",
+    "args": {
+      // Keep the version in sync with:
+      // - nix/acap-native-sdk.nix
+      // - bin/create-venv.sh
+      "TAG": "12.1.0-aarch64-ubuntu24.04"
+    }
+  }
+}

--- a/.devcontainer/acap-native-sdk-12-armv7hf/devcontainer.json
+++ b/.devcontainer/acap-native-sdk-12-armv7hf/devcontainer.json
@@ -1,0 +1,12 @@
+{
+  "name": "ACAP Native SDK 12 armv7hf",
+  "build": {
+    "dockerfile": "../Dockerfile",
+    "args": {
+      // Keep the version in sync with:
+      // - nix/acap-native-sdk.nix
+      // - bin/create-venv.sh
+      "TAG": "12.1.0-armv7hf-ubuntu24.04"
+    }
+  }
+}

--- a/.devcontainer/acap-native-sdk-13-aarch64/devcontainer.json
+++ b/.devcontainer/acap-native-sdk-13-aarch64/devcontainer.json
@@ -1,0 +1,9 @@
+{
+  "name": "ACAP Native SDK 13 aarch64",
+  "build": {
+    "dockerfile": "../Dockerfile",
+    "args": {
+      "TAG": "13.0.0-preview-aarch64-ubuntu25.10"
+    }
+  }
+}

--- a/.devcontainer/acap-native-sdk-13-armv7hf/devcontainer.json
+++ b/.devcontainer/acap-native-sdk-13-armv7hf/devcontainer.json
@@ -1,0 +1,9 @@
+{
+  "name": "ACAP Native SDK 13 armv7hf",
+  "build": {
+    "dockerfile": "../Dockerfile",
+    "args": {
+      "TAG": "13.0.0-preview-armv7hf-ubuntu25.10"
+    }
+  }
+}

--- a/bin/create-venv.sh
+++ b/bin/create-venv.sh
@@ -6,7 +6,10 @@
 #     . init-env.sh                 # activate (run `deactivate` to undo)
 set -eu
 
-# Keep these in sync with nix/acap-native-sdk.nix.
+# Keep these in sync with:
+# - .devcontainer/acap-native-sdk-12-aarch64/devcontainer.json
+# - .devcontainer/acap-native-sdk-12-armv7hf/devcontainer.json
+# - nix/acap-native-sdk.nix.
 SDK_IMAGE="axisecp/acap-native-sdk"
 SDK_VERSION="12.1.0"
 SDK_UBUNTU="ubuntu24.04"

--- a/crates/acap-build/README.md
+++ b/crates/acap-build/README.md
@@ -17,6 +17,11 @@ There are aspects in which the observable behavior is expected to differ, notabl
 
 ### How this is tested
 
+The upstream `acap-build` can be run using the dev containers in
+`.devcontainer/`, e.g. to build the apps in `tests/data/` and compare the
+output to that of the port. There is one dev container per combination of
+SDK version and target architecture.
+
 In addition to the cargo integration tests and snapshot tests iin this repository
 the bit-exactness has been manually verified on all reproducible apps from:
 - `AxisCommunications/acap-rs@176d669ec37a5fe35764461d1f23494d3d3822b2`

--- a/nix/acap-native-sdk.nix
+++ b/nix/acap-native-sdk.nix
@@ -10,6 +10,11 @@
 # digest with `docker manifest inspect --verbose <image>:<tag>`), set the
 # corresponding `sha256` to `lib.fakeHash`, run `nix build .#acap-native-sdk`,
 # and copy the hash Nix reports back into this file.
+#
+# Keep the version in sync with:
+# - .devcontainer/acap-native-sdk-12-aarch64/devcontainer.json
+# - .devcontainer/acap-native-sdk-12-armv7hf/devcontainer.json
+# - bin/create-venv.sh
 {
   lib,
   stdenvNoCC,


### PR DESCRIPTION
To make comparing acap-build behavior to that of the reference implementation easier. Comparing to v13 is not yet in scope, but I added the containers to ensure that it works and to make starting to explore the impact of v13 easier.