### PR TITLE
chore(abt): Add fuzz testing

### DIFF
--- a/.devcontainer/acap-native-sdk-12-aarch64/devcontainer.json
+++ b/.devcontainer/acap-native-sdk-12-aarch64/devcontainer.json
@@ -4,6 +4,7 @@
     "dockerfile": "../Dockerfile",
     "args": {
       // Keep the version in sync with:
+      // - .github/workflows/fuzz.yaml
       // - .github/workflows/main.yaml
       // - nix/acap-native-sdk.nix
       // - bin/create-venv.sh

--- a/.devcontainer/acap-native-sdk-12-armv7hf/devcontainer.json
+++ b/.devcontainer/acap-native-sdk-12-armv7hf/devcontainer.json
@@ -4,6 +4,7 @@
     "dockerfile": "../Dockerfile",
     "args": {
       // Keep the version in sync with:
+      // - .github/workflows/fuzz.yaml
       // - .github/workflows/main.yaml
       // - nix/acap-native-sdk.nix
       // - bin/create-venv.sh

--- a/.github/workflows/fuzz.yaml
+++ b/.github/workflows/fuzz.yaml
@@ -1,0 +1,47 @@
+name: "Fuzz"
+on:
+  workflow_dispatch:
+    inputs:
+      cases:
+        description: "Number of random inputs to try"
+        default: "100"
+        required: false
+      seed:
+        description: "Random number generator seed"
+        default: "0"
+        required: false
+jobs:
+  fuzz:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        tag:
+          # Keep the versions in sync with:
+          # - .devcontainer/acap-native-sdk-12-aarch64/devcontainer.json
+          # - .devcontainer/acap-native-sdk-12-armv7hf/devcontainer.json
+          # - .github/workflows/main.yaml
+          # - bin/create-venv.sh
+          # - nix/acap-native-sdk.nix
+          # TODO: Add the SDK 13 environments when acap-build is compatible with them
+          - 12.1.0-aarch64-ubuntu24.04
+          - 12.1.0-armv7hf-ubuntu24.04
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+      - name: Build the dev container image
+        run: |
+          docker build \
+            --build-arg TAG=${{ matrix.tag }} \
+            --file .devcontainer/Dockerfile \
+            --tag devcontainer \
+            .devcontainer
+      - name: Fuzz
+        run: |
+          docker run --rm --volume "$PWD:/work" --workdir /work \
+            --env ACAP_BUILD_FUZZ_CASES='${{ inputs.cases }}' \
+            --env ACAP_BUILD_FUZZ_SEED='${{ inputs.seed }}' \
+            devcontainer \
+            bash -c '. /opt/axis/acapsdk/environment-setup-* && make fuzz_equivalence'

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -62,6 +62,7 @@ jobs:
           # Keep the versions in sync with:
           # - .devcontainer/acap-native-sdk-12-aarch64/devcontainer.json
           # - .devcontainer/acap-native-sdk-12-armv7hf/devcontainer.json
+          # - .github/workflows/fuzz.yaml
           # - bin/create-venv.sh
           # - nix/acap-native-sdk.nix
           # TODO: Add the SDK 13 environments when acap-build is compatible with them
@@ -81,4 +82,4 @@ jobs:
       - name: Run checks (tier 1)
         run: |
           docker run --rm --volume "$PWD:/work" --workdir /work devcontainer \
-            bash -c '. /opt/axis/acapsdk/environment-setup-* && make replay_equivalence_examples'
+            bash -c '. /opt/axis/acapsdk/environment-setup-* && make replay_equivalence_examples fuzz_equivalence'

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -358,9 +358,9 @@ checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bitflags"
-version = "2.9.0"
+version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
+checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 
 [[package]]
 name = "block-buffer"
@@ -1875,6 +1875,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "proptest"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
+dependencies = [
+ "bit-set",
+ "bit-vec",
+ "bitflags",
+ "num-traits",
+ "rand 0.9.0",
+ "rand_chacha 0.9.0",
+ "rand_xorshift",
+ "regex-syntax",
+ "rusty-fork",
+ "tempfile",
+ "unarray",
+]
+
+[[package]]
 name = "psl-types"
 version = "2.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2064,6 +2083,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_xorshift"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
+dependencies = [
+ "rand_core 0.9.3",
+]
+
+[[package]]
 name = "rdrand"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2234,7 +2262,9 @@ dependencies = [
  "clap",
  "env_logger",
  "libtest-mimic",
+ "proptest",
  "rs4a-eap",
+ "serde_json",
  "tempfile",
 ]
 
@@ -2474,6 +2504,18 @@ name = "rustversion"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eded382c5f5f786b989652c49544c4877d9f015cc22e145a5ea8ea66c2921cd2"
+
+[[package]]
+name = "rusty-fork"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc6bf79ff24e648f6da1f8d1f011e9cac26491b619e6b9280f2b47f1774e6ee2"
+dependencies = [
+ "fnv",
+ "quick-error",
+ "tempfile",
+ "wait-timeout",
+]
 
 [[package]]
 name = "ruzstd"
@@ -2913,6 +2955,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
 
 [[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2998,6 +3046,15 @@ name = "vsimd"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "want"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ libtest-mimic = "0.8.1"
 log = "0.4.27"
 macaddr = "1.0.1"
 mdns = "3.0.0"
+proptest = "1.6.0"
 quick-xml = "0.38.3"
 regex = "1.11.3"
 reqwest = { version = "0.12.15", default-features = false }

--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,12 @@ replay_equivalence_examples:
 		crates/acap-build/tests/data
 .PHONY: replay_equivalence_examples
 
+## Compare the output from building generated apps
+fuzz_equivalence:
+	cargo run --locked -p rs4a-acap-build-tester -- \
+		fuzz
+.PHONY: fuzz_equivalence
+
 ## Checks
 ## ------
 

--- a/bin/create-venv.sh
+++ b/bin/create-venv.sh
@@ -9,6 +9,7 @@ set -eu
 # Keep these in sync with:
 # - .devcontainer/acap-native-sdk-12-aarch64/devcontainer.json
 # - .devcontainer/acap-native-sdk-12-armv7hf/devcontainer.json
+# - .github/workflows/fuzz.yaml
 # - .github/workflows/main.yaml
 # - nix/acap-native-sdk.nix.
 SDK_IMAGE="axisecp/acap-native-sdk"

--- a/crates/acap-build-tester/Cargo.toml
+++ b/crates/acap-build-tester/Cargo.toml
@@ -9,6 +9,8 @@ anyhow = { workspace = true }
 clap = { workspace = true, features = ["derive", "env"] }
 env_logger = { workspace = true }
 libtest-mimic = { workspace = true }
+proptest = { workspace = true }
+serde_json = { workspace = true }
 tempfile = { workspace = true }
 
 acap-build = { workspace = true }

--- a/crates/acap-build-tester/src/commands.rs
+++ b/crates/acap-build-tester/src/commands.rs
@@ -1,1 +1,2 @@
+pub mod fuzz;
 pub mod replay;

--- a/crates/acap-build-tester/src/commands/fuzz.rs
+++ b/crates/acap-build-tester/src/commands/fuzz.rs
@@ -1,0 +1,86 @@
+use acap_build::{Architecture, Cli};
+use anyhow::{bail, Context};
+use proptest::test_runner::{Config, RngAlgorithm, TestCaseError, TestError, TestRng, TestRunner};
+
+use crate::{
+    input::{arbitrary_input, Input},
+    invocation::{build_with_candidate, build_with_reference},
+};
+
+fn check(input: &Input) -> anyhow::Result<()> {
+    let candidate_dir = tempfile::tempdir()?;
+    input.source.materialize_in(candidate_dir.path())?;
+    let candidate = build_with_candidate(Cli {
+        path: candidate_dir.path().to_path_buf(),
+        ..input.invocation.clone()
+    })
+    .context("building with the candidate")?;
+
+    let reference_dir = tempfile::tempdir()?;
+    input.source.materialize_in(reference_dir.path())?;
+    let reference = build_with_reference(Cli {
+        path: reference_dir.path().to_path_buf(),
+        ..input.invocation.clone()
+    })
+    .context("building with the reference")?;
+
+    if candidate.essence() != reference.essence() {
+        bail!("the candidate does not match the reference:\n{candidate:#?}\n{reference:#?}");
+    }
+    Ok(())
+}
+
+fn fuzz(
+    oecore_target_arch: Architecture,
+    cases: u32,
+    seed: u64,
+) -> Result<(), Box<TestError<Input>>> {
+    let mut rng_seed = [0u8; 32];
+    for (dst, src) in rng_seed.iter_mut().zip(seed.to_le_bytes()) {
+        *dst = src;
+    }
+
+    let config = Config {
+        cases,
+        failure_persistence: None,
+        ..Config::default()
+    };
+    let rng = TestRng::from_seed(RngAlgorithm::ChaCha, &rng_seed);
+
+    TestRunner::new_with_rng(config, rng)
+        .run(&arbitrary_input(oecore_target_arch), |input| {
+            check(&input).map_err(|e| TestCaseError::fail(format!("{e:#}")))
+        })
+        .map_err(Box::new)
+}
+
+#[derive(clap::Parser)]
+pub struct FuzzCommand {
+    /// The architecture to build for.
+    #[clap(long, env = "OECORE_TARGET_ARCH")]
+    oecore_target_arch: Architecture,
+    /// Number of random inputs to try.
+    #[clap(long, env = "ACAP_BUILD_FUZZ_CASES", default_value_t = 1)]
+    cases: u32,
+    /// Seed for the random number generator.
+    #[clap(long, env = "ACAP_BUILD_FUZZ_SEED", default_value_t = 0)]
+    seed: u64,
+}
+
+impl FuzzCommand {
+    pub fn exec(self) -> anyhow::Result<()> {
+        let Self {
+            oecore_target_arch,
+            cases,
+            seed,
+        } = self;
+
+        match fuzz(oecore_target_arch, cases, seed).map_err(|e| *e) {
+            Ok(()) => Ok(()),
+            Err(TestError::Fail(reason, input)) => {
+                bail!("Property violated by {input:#?}:\n{reason}")
+            }
+            Err(e @ TestError::Abort(_)) => bail!("Fuzzing aborted: {e}"),
+        }
+    }
+}

--- a/crates/acap-build-tester/src/input.rs
+++ b/crates/acap-build-tester/src/input.rs
@@ -1,0 +1,57 @@
+//! The input that affects the execution of an `acap-build` implementation.
+
+use std::path::PathBuf;
+
+use acap_build::{Architecture, BuildOption, Cli};
+use proptest::{
+    arbitrary::any,
+    prelude::{BoxedStrategy, Just, Strategy},
+    prop_oneof,
+};
+use rs4a_eap::{Mtime, DEFAULT_ACAP_SDK_LOCATION};
+
+use crate::source::Source;
+
+/// The complete, known input to an `acap-build` implementation.
+#[derive(Clone, Debug)]
+pub struct Input {
+    pub source: Source,
+    pub invocation: Cli,
+}
+
+pub fn arbitrary_input(oecore_target_arch: Architecture) -> BoxedStrategy<Input> {
+    (
+        any::<Source>(),
+        any::<bool>(),
+        // Nonzero to catch implementations that ignore the variable and use the (zero-ish)
+        // default of their tar library; small enough to fit every timestamp encoding.
+        prop_oneof![Just(0u64), Just(1234567890)],
+    )
+        .prop_map(move |(source, disable_manifest_validation, epoch)| Input {
+            invocation: Cli {
+                // A placeholder; each implementation builds in a scratch directory of its own.
+                // Easy to forget to overwriting, so avoiding this would be one advantage of moving
+                // away from the `Cli` as input model
+                path: PathBuf::new(),
+                build: BuildOption::NoBuild,
+                manifest: PathBuf::from(&source.manifest_name),
+                additional_file: source.additional_files.iter().map(PathBuf::from).collect(),
+                disable_manifest_validation,
+                // Taken from the environment rather than generated for now to efficiently generate
+                // interesting inputs given a realistic environment.
+                // TODO: Consider varying this, including leaving it unset.
+                oecore_target_arch,
+                // Only the default is generated: the reference does not read it, so any other
+                // location would make only the candidate use different schema which is an
+                // unnecessary potential source of divergence.
+                acap_sdk_location: PathBuf::from(DEFAULT_ACAP_SDK_LOCATION),
+                // Always set: `None` falls back to the current time, which the two
+                // implementations would sample at different moments.
+                source_date_epoch: Some(
+                    Mtime::try_from(epoch).expect("generated values fit in the tar headers"),
+                ),
+            },
+            source,
+        })
+        .boxed()
+}

--- a/crates/acap-build-tester/src/main.rs
+++ b/crates/acap-build-tester/src/main.rs
@@ -1,12 +1,14 @@
 //! Facilities for testing `acap-build` implementations.
 
 mod commands;
+mod input;
 mod invocation;
 mod output;
+mod source;
 
 use clap::{Parser, Subcommand};
 
-use crate::commands::replay::ReplayCommand;
+use crate::commands::{fuzz::FuzzCommand, replay::ReplayCommand};
 
 #[derive(Parser)]
 struct Cli {
@@ -18,6 +20,7 @@ impl Cli {
     fn exec(self) -> anyhow::Result<()> {
         let Self { command } = self;
         match command {
+            Commands::Fuzz(cmd) => cmd.exec()?,
             Commands::Replay(cmd) => cmd.exec()?,
         }
         Ok(())
@@ -26,8 +29,11 @@ impl Cli {
 
 #[derive(Subcommand)]
 enum Commands {
+    /// Verify that this workspace's `acap-build` builds generated apps like the reference
+    /// `acap-build` on the `PATH` on generated examples.
+    Fuzz(FuzzCommand),
     /// Verify that this workspace's `acap-build` builds the given apps like the reference
-    /// `acap-build` on the `PATH`
+    /// `acap-build` on the `PATH` on recorded examples.
     Replay(ReplayCommand),
 }
 

--- a/crates/acap-build-tester/src/source.rs
+++ b/crates/acap-build-tester/src/source.rs
@@ -1,0 +1,160 @@
+//! A model of the source code of an application.
+//!
+//! The model is not the source code itself but a description of it, structured so that every
+//! source tree it can describe is one that `acap-build` implementations should be able to
+//! package: strategies explore the space of interesting applications instead of wasting cases
+//! on trees that are rejected before any packaging logic runs.
+//!
+//! The model currently captures
+//! - the manifest, including where on disk it is located;
+//! - the mandatory files: the license and the executable named by the manifest;
+//! - the optional `html` directory, which implementations pick up without being told;
+//! - additional files, which are packaged only when named by `--additional-file`.
+
+use std::{collections::BTreeSet, fs, os::unix::fs::PermissionsExt, path::Path};
+
+use proptest::{
+    arbitrary::{any, Arbitrary},
+    prelude::{prop, BoxedStrategy, Just, Strategy},
+    prop_oneof,
+};
+use serde_json::{json, Map, Value};
+
+/// The name that implementations use when no manifest is named explicitly.
+pub const DEFAULT_MANIFEST_NAME: &str = "manifest.json";
+
+/// Directory names that implementations treat specially and that would shadow other files if
+/// used as file names.
+const RESERVED_NAMES: [&str; 3] = ["lib", "html", "declarations"];
+
+fn write_file(dir: &Path, rel_path: &str, content: &[u8], executable: bool) -> anyhow::Result<()> {
+    let path = dir.join(rel_path);
+    fs::write(&path, content)?;
+    let mode = if executable { 0o755 } else { 0o644 };
+    fs::set_permissions(&path, fs::Permissions::from_mode(mode))?;
+    Ok(())
+}
+
+fn file_name() -> impl Strategy<Value = String> {
+    "[a-z][a-z0-9_]{0,8}".prop_filter(
+        "file name must not shadow a reserved directory name",
+        |name| !RESERVED_NAMES.contains(&name.as_str()),
+    )
+}
+
+/// The part of the manifest content that the model can vary.
+#[derive(Clone, Debug)]
+pub struct Manifest {
+    pub schema_version: &'static str,
+    pub app_name: String,
+    pub version: String,
+    pub friendly_name: Option<String>,
+}
+
+impl Manifest {
+    fn json(&self) -> Value {
+        let mut setup = Map::new();
+        setup.insert("appName".into(), json!(self.app_name));
+        if let Some(v) = &self.friendly_name {
+            setup.insert("friendlyName".into(), json!(v));
+        }
+        setup.insert("runMode".into(), json!("never"));
+        setup.insert("version".into(), json!(self.version));
+
+        json!({
+            "schemaVersion": self.schema_version,
+            "acapPackageConf": { "setup": Value::Object(setup) },
+        })
+    }
+}
+
+impl Arbitrary for Manifest {
+    type Parameters = ();
+    type Strategy = BoxedStrategy<Self>;
+
+    fn arbitrary_with((): ()) -> Self::Strategy {
+        (
+            // 1.3 and 1.3.0 sit on the boundary at which the architecture field starts being added;
+            // 1.7.0 is a control that both implementations handle identically.
+            // TODO: Consider sampling from all known versions and maybe some novel strings
+            prop_oneof![Just("1.3"), Just("1.3.0"), Just("1.7.0")],
+            file_name(),
+            (0u8..20, 0u8..20, 0u8..100).prop_map(|(a, b, c)| format!("{a}.{b}.{c}")),
+            prop::option::of(prop_oneof![
+                "[A-Za-z][A-Za-z0-9 ]{0,10}",
+                Just("\u{c5}pp \u{3a9}".to_string()),
+            ]),
+        )
+            .prop_map(
+                |(schema_version, app_name, version, friendly_name)| Manifest {
+                    schema_version,
+                    app_name,
+                    version,
+                    friendly_name,
+                },
+            )
+            .boxed()
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct Source {
+    pub manifest: Manifest,
+    /// The name of the file that the manifest is written to.
+    ///
+    /// When this is not [`DEFAULT_MANIFEST_NAME`] the invocation must name it with `--manifest`.
+    pub manifest_name: String,
+    /// Plain files that are packaged only when named by `--additional-file`.
+    pub additional_files: BTreeSet<String>,
+    /// Whether an `html` directory exists; implementations pick it up without being told.
+    pub html: bool,
+}
+
+impl Source {
+    pub fn materialize_in(&self, dir: &Path) -> anyhow::Result<()> {
+        fs::create_dir_all(dir)?;
+        fs::write(
+            dir.join(&self.manifest_name),
+            serde_json::to_string_pretty(&self.manifest.json())?,
+        )?;
+        fs::write(dir.join("LICENSE"), "All rights reserved.\n")?;
+        write_file(dir, &self.manifest.app_name, b"#!/bin/sh\nexit 0\n", true)?;
+        for name in &self.additional_files {
+            write_file(dir, name, b"An additional file.\n", false)?;
+        }
+        if self.html {
+            fs::create_dir(dir.join("html"))?;
+            fs::write(dir.join("html").join("index.html"), "<!DOCTYPE html>\n")?;
+        }
+        Ok(())
+    }
+}
+
+impl Arbitrary for Source {
+    type Parameters = ();
+    type Strategy = BoxedStrategy<Self>;
+
+    fn arbitrary_with((): ()) -> Self::Strategy {
+        (
+            any::<Manifest>(),
+            prop_oneof![
+                3 => Just(DEFAULT_MANIFEST_NAME.to_string()),
+                1 => Just("unconventional-manifest.json".to_string()),
+            ],
+            prop::collection::btree_set(file_name(), 0..3),
+            any::<bool>(),
+        )
+            .prop_map(|(manifest, manifest_name, mut additional_files, html)| {
+                // The executable is written last so a collision would corrupt the app; the
+                // space of colliding names is not interesting enough to explore.
+                additional_files.remove(&manifest.app_name);
+                Source {
+                    manifest,
+                    manifest_name,
+                    additional_files,
+                    html,
+                }
+            })
+            .boxed()
+    }
+}

--- a/nix/acap-native-sdk.nix
+++ b/nix/acap-native-sdk.nix
@@ -14,6 +14,7 @@
 # Keep the version in sync with:
 # - .devcontainer/acap-native-sdk-12-aarch64/devcontainer.json
 # - .devcontainer/acap-native-sdk-12-armv7hf/devcontainer.json
+# - .github/workflows/fuzz.yaml
 # - .github/workflows/main.yaml
 # - bin/create-venv.sh
 {


### PR DESCRIPTION
The implementation of the fuzzing is kept somewhat simple to make it easier to land; future changes will vary more inputs, compare more outputs, and facilitate creating golden examples from the fuzzing results.

Details
=======

`.github/workflows/fuzz.yaml`:
- Added to make it facilitate running fuzzing campaigns in a reproducible way across multiple environments and creating a publicly available record of the campaigns.