### PR TITLE
fix(eap): Capture and log stderr from tar, etc

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -166,7 +166,7 @@ Cargo.lock: $(wildcard crates/*/Cargo.toml)
 	cargo metadata --format-version=1 > /dev/null
 
 init-env.sh: bin/create-venv.sh
-	@<
+	$<
 
 # The `acap-build` snapshot tests need the ACAP Native SDK. This Makefile assumes
 # it is already installed and, if it is not at the default `/opt/axis`, that

--- a/bin/create-venv.sh
+++ b/bin/create-venv.sh
@@ -23,10 +23,8 @@ INIT_ENV="$REPO_ROOT/init-env.sh"
 
 mkdir -p "$SDK_DIR"
 
-# TODO: silence platform mismatch warning
-
 for arch in armv7hf aarch64; do
-  docker run $SDK_IMAGE:$SDK_VERSION-$arch-$SDK_UBUNTU tar \
+  docker run --platform linux/amd64 $SDK_IMAGE:$SDK_VERSION-$arch-$SDK_UBUNTU tar \
     --create \
     --directory /opt/ \
     --file - \

--- a/crates/eap/src/archive/equivalent.rs
+++ b/crates/eap/src/archive/equivalent.rs
@@ -5,6 +5,8 @@
 //! Bit-exactness depends on the versions of `tar` and `gzip` that are resolved.
 use std::{path::Path, process::Command};
 
+use log::{debug, warn};
+
 use crate::{command_utils::RunWith, Mtime};
 
 /// Finds an available GNU `tar`, returning its program name, or `None` if
@@ -73,8 +75,25 @@ impl EquivalentArchiveBuilder {
         self
     }
 
-    pub fn run_with_logged_stdout(mut self) -> anyhow::Result<()> {
+    pub fn run_with_logged_output(mut self) -> anyhow::Result<()> {
         self.0.arg("--verbose");
-        self.0.run_with_logged_stdout()
+        self.0.run_with_processed_output(
+            |line| {
+                let line = line?;
+                if !line.is_empty() {
+                    debug!("Child said {line:?}.");
+                }
+                Ok(())
+            },
+            |line| {
+                let line = line?;
+                if line.starts_with("tar: Option --mtime: Treating date") {
+                    debug!("Child said {line:?}.");
+                } else if !line.is_empty() {
+                    warn!("Child said {line:?}.");
+                }
+                Ok(())
+            },
+        )
     }
 }

--- a/crates/eap/src/command_utils.rs
+++ b/crates/eap/src/command_utils.rs
@@ -4,11 +4,11 @@ use anyhow::Context;
 use log::debug;
 
 pub trait RunWith {
-    fn run_with_processed_stdout(
+    fn run_with_processed_output(
         self,
-        func: impl FnMut(std::io::Result<String>) -> anyhow::Result<()>,
+        stdout_func: impl FnMut(std::io::Result<String>) -> anyhow::Result<()>,
+        stderr_func: impl FnMut(std::io::Result<String>) -> anyhow::Result<()> + Send,
     ) -> anyhow::Result<()>;
-    fn run_with_logged_stdout(self) -> anyhow::Result<()>;
 }
 
 fn spawn(mut cmd: std::process::Command) -> anyhow::Result<std::process::Child> {
@@ -25,25 +25,47 @@ fn spawn(mut cmd: std::process::Command) -> anyhow::Result<std::process::Child> 
 }
 
 impl RunWith for std::process::Command {
-    fn run_with_processed_stdout(
+    fn run_with_processed_output(
         mut self,
-        mut func: impl FnMut(std::io::Result<String>) -> anyhow::Result<()>,
+        mut stdout_func: impl FnMut(std::io::Result<String>) -> anyhow::Result<()>,
+        mut stderr_func: impl FnMut(std::io::Result<String>) -> anyhow::Result<()> + Send,
     ) -> anyhow::Result<()> {
         self.stdout(std::process::Stdio::piped());
+        self.stderr(std::process::Stdio::piped());
         debug!("Spawning child {self:#?}...");
         let mut child = spawn(self)?;
         // PANICS:
         // `expect` will never panic because we configured `Stdio::piped()` above, so the child
-        // has a stdout handle, and this function is the only place that takes it.
+        // has the handles, and this function is the only place that takes them.
         let stdout = child
             .stdout
             .take()
             .expect("not previously taken by this function");
+        let stderr = child
+            .stderr
+            .take()
+            .expect("not previously taken by this function");
 
-        let lines = BufReader::new(stdout).lines();
-        for line in lines {
-            func(line)?;
-        }
+        let (stdout_result, stderr_result) = std::thread::scope(|scope| {
+            let stderr_thread = scope.spawn(move || -> anyhow::Result<()> {
+                for line in BufReader::new(stderr).lines() {
+                    stderr_func(line)?;
+                }
+                Ok(())
+            });
+            let stdout_result: anyhow::Result<()> = (|| {
+                for line in BufReader::new(stdout).lines() {
+                    stdout_func(line)?;
+                }
+                Ok(())
+            })();
+            let stderr_result = stderr_thread
+                .join()
+                .expect("the stderr thread does not panic");
+            (stdout_result, stderr_result)
+        });
+        let () = stdout_result?;
+        let () = stderr_result?;
 
         debug!("Waiting for child...");
         let status = child.wait()?;
@@ -51,14 +73,5 @@ impl RunWith for std::process::Command {
             anyhow::bail!("Child failed: {status}");
         }
         Ok(())
-    }
-    fn run_with_logged_stdout(self) -> anyhow::Result<()> {
-        self.run_with_processed_stdout(|line| {
-            let line = line?;
-            if !line.is_empty() {
-                debug!("Child said {line:?}.");
-            };
-            Ok(())
-        })
     }
 }

--- a/crates/eap/src/lib.rs
+++ b/crates/eap/src/lib.rs
@@ -352,7 +352,7 @@ impl<'a> AppBuilder<'a> {
             }
         }
 
-        tar.run_with_logged_stdout()?;
+        tar.run_with_logged_output()?;
 
         Ok(OsString::from(eap_file_name))
     }


### PR DESCRIPTION
It was consistently polluting our output with notices like `tar: Option --mtime: Treating date ...`.

Details
=======

`Makefile`:
- Drive by fix of broken target

`bin/create-venv.sh`:
- Drive by fix silencing warnings emitted when running on a modern Mac.

`crates/eap/src/command_utils.rs`:
- The streams are drained concurrently so that the child can never block on writing one while this process blocks on reading the other.