### PR TITLE
feat(eap): Add "compatible" implementation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2332,6 +2332,7 @@ name = "rs4a-eap"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "flate2",
  "jsonschema",
  "log",
  "regex",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2332,6 +2332,7 @@ name = "rs4a-eap"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "clap",
  "flate2",
  "jsonschema",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ digest_auth = "0.3.1"
 dirs = "6.0.0"
 env_logger = "0.11.8"
 expect-test = "1.5.1"
-flate2 = "1.1.2"
+flate2 = { version = "1.1.2", default-features = false, features = ["rust_backend"] }
 futures-util = "0.3.31"
 glob = "0.3.2"
 itertools = "0.14.0"

--- a/bin/acap-build-docs.sh
+++ b/bin/acap-build-docs.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env sh
 set -eu
 
+unset ACAP_BUILD_IMPL
 unset ACAP_SDK_LOCATION
 unset SOURCE_DATE_EPOCH
 

--- a/crates/acap-build-tester/src/commands/replay.rs
+++ b/crates/acap-build-tester/src/commands/replay.rs
@@ -6,7 +6,7 @@ use std::{
 use acap_build::{Architecture, BuildOption, Cli};
 use anyhow::{bail, ensure, Context};
 use libtest_mimic::{Arguments, Failed, Trial};
-use rs4a_eap::{Mtime, DEFAULT_ACAP_SDK_LOCATION};
+use rs4a_eap::{AcapBuildImpl, Mtime, DEFAULT_ACAP_SDK_LOCATION};
 
 use crate::invocation::{build_with_candidate, build_with_reference};
 
@@ -51,6 +51,7 @@ fn check(app_dir: PathBuf, oecore_target_arch: Architecture) -> anyhow::Result<(
         oecore_target_arch,
         acap_sdk_location: PathBuf::from(DEFAULT_ACAP_SDK_LOCATION),
         source_date_epoch: Some(Mtime::default()),
+        acap_build_impl: AcapBuildImpl::Equivalent,
     };
     let candidate = build_with_candidate(cli.clone()).context("building with the candidate")?;
     let reference = build_with_reference(Cli {

--- a/crates/acap-build-tester/src/input.rs
+++ b/crates/acap-build-tester/src/input.rs
@@ -8,7 +8,7 @@ use proptest::{
     prelude::{BoxedStrategy, Just, Strategy},
     prop_oneof,
 };
-use rs4a_eap::{Mtime, DEFAULT_ACAP_SDK_LOCATION};
+use rs4a_eap::{AcapBuildImpl, Mtime, DEFAULT_ACAP_SDK_LOCATION};
 
 use crate::source::Source;
 
@@ -50,6 +50,7 @@ pub fn arbitrary_input(oecore_target_arch: Architecture) -> BoxedStrategy<Input>
                 source_date_epoch: Some(
                     Mtime::try_from(epoch).expect("generated values fit in the tar headers"),
                 ),
+                acap_build_impl: AcapBuildImpl::Equivalent,
             },
             source,
         })

--- a/crates/acap-build-tester/src/invocation.rs
+++ b/crates/acap-build-tester/src/invocation.rs
@@ -27,6 +27,7 @@ pub fn build_with_reference(cli: Cli) -> anyhow::Result<Output> {
         oecore_target_arch,
         acap_sdk_location: _,
         source_date_epoch,
+        acap_build_impl: _,
     } = cli;
 
     let mut command = Command::new("acap-build");

--- a/crates/acap-build/Cargo.toml
+++ b/crates/acap-build/Cargo.toml
@@ -15,7 +15,7 @@ log = { workspace = true }
 tempfile = { workspace = true }
 tempdir = { workspace = true }
 
-rs4a-eap.workspace = true
+rs4a-eap = { workspace = true, features = ["clap"] }
 
 [dev-dependencies]
 expect-test.workspace = true

--- a/crates/acap-build/src/lib.rs
+++ b/crates/acap-build/src/lib.rs
@@ -56,6 +56,10 @@ pub struct Cli {
     pub manifest: PathBuf,
     /// Additional files to include in the package.
     /// May be specified multiple times
+    ///
+    /// If it matches the archiver's exclude patterns (`*~` and VCS names like `.git`),
+    /// then it's silently omitted from the archive but still listed in `package.conf`.
+    // TODO: Consider pushing this quirk out of the library and into this binary
     #[clap(long, short)]
     pub additional_file: Vec<PathBuf>,
     /// Disable validation of manifest file against manifest schema.

--- a/crates/acap-build/src/lib.rs
+++ b/crates/acap-build/src/lib.rs
@@ -9,7 +9,7 @@ use std::{
 use anyhow::Context;
 use clap::{Parser, ValueEnum};
 use log::debug;
-use rs4a_eap::{AppBuilder, Mtime, SchemaSource};
+use rs4a_eap::{AcapBuildImpl, AppBuilder, Mtime, SchemaSource};
 use tempdir::TempDir;
 
 #[derive(Clone, Copy, Debug, ValueEnum)]
@@ -78,6 +78,9 @@ pub struct Cli {
     /// Defaults to the current time.
     #[clap(long, env = "SOURCE_DATE_EPOCH", value_parser = parse_mtime)]
     pub source_date_epoch: Option<Mtime>,
+    /// Implementation used to package the EAP.
+    #[clap(long = "impl", env = "ACAP_BUILD_IMPL", default_value_t = AcapBuildImpl::Equivalent)]
+    pub acap_build_impl: AcapBuildImpl,
 }
 
 fn parse_mtime(s: &str) -> anyhow::Result<Mtime> {
@@ -95,6 +98,7 @@ impl Cli {
             oecore_target_arch,
             acap_sdk_location,
             source_date_epoch,
+            acap_build_impl,
         } = self;
 
         let schema = if disable_manifest_validation {
@@ -137,6 +141,7 @@ impl Cli {
 
         builder.schema(schema);
         builder.mtime(mtime);
+        builder.implementation(acap_build_impl);
 
         for name in builder.mandatory_files() {
             builder.add(&path.join(name))?;

--- a/crates/eap/Cargo.toml
+++ b/crates/eap/Cargo.toml
@@ -7,8 +7,13 @@ license = "MIT"
 description = "Utilities for creating Embedded Application Packages (EAPs)"
 homepage = "https://github.com/apljungquist/rs4acap"
 
+[features]
+## Implement clap traits for some types to make them easier to expose on a CLI
+clap = ["dep:clap"]
+
 [dependencies]
 anyhow = { workspace = true }
+clap = { workspace = true, features = ["derive"], optional = true }
 flate2 = { workspace = true }
 jsonschema = { workspace = true }
 log = { workspace = true }

--- a/crates/eap/Cargo.toml
+++ b/crates/eap/Cargo.toml
@@ -9,6 +9,7 @@ homepage = "https://github.com/apljungquist/rs4acap"
 
 [dependencies]
 anyhow = { workspace = true }
+flate2 = { workspace = true }
 jsonschema = { workspace = true }
 log = { workspace = true }
 semver = { workspace = true }

--- a/crates/eap/src/archive.rs
+++ b/crates/eap/src/archive.rs
@@ -1,4 +1,7 @@
 //! Creation of the compressed archive that constitutes an EAP.
 
+mod compatible;
 mod equivalent;
+
+pub use compatible::CompatibleArchiveBuilder;
 pub use equivalent::EquivalentArchiveBuilder;

--- a/crates/eap/src/archive/compatible.rs
+++ b/crates/eap/src/archive/compatible.rs
@@ -1,0 +1,435 @@
+use std::{
+    ffi::OsStr,
+    fs,
+    io::{self, Write},
+    os::unix::{ffi::OsStrExt, fs::PermissionsExt},
+    path::{Path, PathBuf},
+};
+
+use flate2::{Compression, GzBuilder};
+
+use crate::Mtime;
+
+const BLOCK_SIZE: usize = 512;
+/// GNU tar's default blocking factor is 20 blocks;
+/// archives are padded to a whole record of this size.
+const RECORD_SIZE: usize = 20 * BLOCK_SIZE;
+/// The largest file size this writer accepts: the 12-byte size header field holds 11 octal digits,
+/// and the GNU base-256 extension for larger values is not implemented.
+///
+/// This limit coincides with [`Mtime::MAX`] because the two fields have the same width,
+/// but it is enforced only here:
+/// in equivalent mode GNU tar silently encodes larger sizes in base-256.
+// TODO: Consider adding support for larger files
+const MAX_SIZE: u64 = (1 << 33) - 1;
+
+/// The files and directories excluded by `--exclude-vcs` in GNU tar 1.35.
+// TODO: Consider exposing this concern on the library interface or even pushing it into callers
+const VCS_NAMES: &[&str] = &[
+    ".arch-ids",
+    ".bzr",
+    ".bzrignore",
+    ".bzrtags",
+    "CVS",
+    ".cvsignore",
+    "_darcs",
+    ".git",
+    ".gitattributes",
+    ".gitignore",
+    ".gitmodules",
+    ".hg",
+    ".hgignore",
+    ".hgtags",
+    "RCS",
+    "SCCS",
+    ".svn",
+    "{arch}",
+    "=RELEASE-ID",
+    "=meta-update",
+    "=update",
+];
+
+fn is_excluded(name: &OsStr) -> bool {
+    // `--exclude '*~'`: any name ending in a tilde.
+    if name.as_bytes().ends_with(b"~") {
+        return true;
+    }
+    // `--exclude-vcs`.
+    VCS_NAMES.iter().any(|vcs| OsStr::new(vcs) == name)
+}
+
+/// Writes `value` as left-zero-padded octal followed by a NUL into `field`.
+fn put_octal(field: &mut [u8], value: u64) {
+    let last = field.len() - 1;
+    // The field holds `last` octal digits (the final byte is the NUL terminator); a larger value
+    // would silently lose its high-order digits, producing a structurally valid but wrong header.
+    // The GNU base-256 extension that lifts this limit is not implemented, so refuse instead.
+    // The fields fed by external input are bounded: the mtime by the [`Mtime`] type and sizes
+    // against [`MAX_SIZE`] by [`Tar::add`]; the remaining call sites are structurally
+    // bounded, so tripping this assert is a bug.
+    assert!(
+        last >= 22 || value < 1 << (3 * last),
+        "value {value} does not fit in {last} octal digits"
+    );
+    let mut remaining = value;
+    #[expect(
+        clippy::indexing_slicing,
+        reason = "`last` is `field.len() - 1`, so the end of the range is in bounds"
+    )]
+    for slot in field[..last].iter_mut().rev() {
+        *slot = b'0' + (remaining & 7) as u8;
+        remaining >>= 3;
+    }
+    #[expect(
+        clippy::indexing_slicing,
+        reason = "`last` is `field.len() - 1`, so the index is in bounds"
+    )]
+    {
+        field[last] = 0;
+    }
+}
+
+/// Builds a single 512-byte GNU header block.
+///
+/// # Panics
+///
+/// Panics if either `name` and `linkname` don't fit in their 100-byte fields.
+fn header(
+    name: &[u8],
+    mode: u32,
+    size: u64,
+    mtime: u64,
+    typeflag: u8,
+    linkname: &[u8],
+) -> [u8; BLOCK_SIZE] {
+    // Violations would not fail cleanly: a name of 101..=512 bytes would silently overwrite the
+    // fields after the name field, producing a structurally plausible but wrong header.
+    debug_assert!(
+        name.len() <= 100,
+        "caller must emit a LongLink record first"
+    );
+    debug_assert!(
+        linkname.len() <= 100,
+        "caller must emit a LongLink record first"
+    );
+    let mut h = [0u8; BLOCK_SIZE];
+    #[expect(
+        clippy::indexing_slicing,
+        reason = "`name` fits in its 100-byte field per this function's contract, \
+                    and the name field starts at offset 0 of the 512-byte block"
+    )]
+    h[..name.len()].copy_from_slice(name);
+    put_octal(&mut h[100..108], u64::from(mode & 0o7777));
+    put_octal(&mut h[108..116], 0); // uid (--owner 0)
+    put_octal(&mut h[116..124], 0); // gid (--group 0)
+    put_octal(&mut h[124..136], size);
+    put_octal(&mut h[136..148], mtime);
+    // The checksum is computed over the header with the checksum field itself
+    // filled with spaces.
+    h[148..156].fill(b' ');
+    h[156] = typeflag;
+    #[expect(
+        clippy::indexing_slicing,
+        reason = "`linkname` fits in its 100-byte field per this function's contract, \
+                    so the range ends at most at offset 257 of the 512-byte block"
+    )]
+    h[157..157 + linkname.len()].copy_from_slice(linkname);
+    // GNU magic and version: the eight bytes "ustar  \0".
+    // uname, gname and the device fields are left zeroed (--numeric-owner).
+    h[257..263].copy_from_slice(b"ustar ");
+    h[263] = b' ';
+    let checksum: u32 = h.iter().map(|&byte| u32::from(byte)).sum();
+    // GNU writes the checksum as six octal digits, a NUL, then a space.
+    put_octal(&mut h[148..155], u64::from(checksum));
+    h[155] = b' ';
+    h
+}
+
+/// GNU long-name marker entry type.
+const GNUTYPE_LONGNAME: u8 = b'L';
+/// GNU long-link-target marker entry type.
+const GNUTYPE_LONGLINK: u8 = b'K';
+
+struct Tar {
+    out: Vec<u8>,
+    mtime: u64,
+}
+
+impl Tar {
+    fn push_block(&mut self, block: &[u8; BLOCK_SIZE]) {
+        self.out.extend_from_slice(block);
+    }
+
+    /// Zero-pads the output up to the next multiple of `boundary`.
+    fn pad_to(&mut self, boundary: usize) {
+        self.out
+            .resize(self.out.len().next_multiple_of(boundary), 0);
+    }
+
+    /// Appends `data` and zero-pads up to the next block boundary.
+    fn push_data(&mut self, data: &[u8]) {
+        self.out.extend_from_slice(data);
+        self.pad_to(BLOCK_SIZE);
+    }
+
+    /// Emits a `././@LongLink` record carrying an over-long name or link target.
+    fn push_long_name(&mut self, typeflag: u8, value: &[u8]) {
+        // GNU stores mode 0644 and mtime 0 in the LongLink header, and the size
+        // includes the trailing NUL that terminates the payload.
+        let block = header(
+            b"././@LongLink",
+            0o644,
+            (value.len() + 1) as u64,
+            0,
+            typeflag,
+            b"",
+        );
+        self.push_block(&block);
+        self.out.extend_from_slice(value);
+        self.out.push(0);
+        self.pad_to(BLOCK_SIZE);
+    }
+
+    fn append(
+        &mut self,
+        name: &[u8],
+        mode: u32,
+        size: u64,
+        typeflag: u8,
+        linkname: &[u8],
+        data: Option<&[u8]>,
+    ) {
+        if linkname.len() > 100 {
+            self.push_long_name(GNUTYPE_LONGLINK, linkname);
+        }
+        if name.len() > 100 {
+            self.push_long_name(GNUTYPE_LONGNAME, name);
+        }
+        #[expect(
+            clippy::indexing_slicing,
+            reason = "the end of the range is clamped to `name.len()`"
+        )]
+        let name = &name[..name.len().min(100)];
+        #[expect(
+            clippy::indexing_slicing,
+            reason = "the end of the range is clamped to `linkname.len()`"
+        )]
+        let linkname = &linkname[..linkname.len().min(100)];
+        let block = header(name, mode, size, self.mtime, typeflag, linkname);
+        self.push_block(&block);
+        if let Some(data) = data {
+            self.push_data(data);
+        }
+    }
+
+    fn add(&mut self, root: &Path, rel: &Path) -> io::Result<()> {
+        // GNU tar applies the exclude patterns to operands too, skipping matches silently (exit
+        // status 0, no warning). Its unanchored patterns match a trailing run of path components,
+        // and every pattern here is slash-free, so testing the last component is equivalent.
+        if rel.file_name().is_some_and(is_excluded) {
+            return Ok(());
+        }
+        let abs = root.join(rel);
+        let metadata = abs.symlink_metadata()?;
+        let file_type = metadata.file_type();
+        let mode = metadata.permissions().mode();
+        if file_type.is_symlink() {
+            let target = fs::read_link(&abs)?;
+            self.append(
+                &tar_name(rel, false),
+                mode,
+                0,
+                b'2',
+                target.as_os_str().as_bytes(),
+                None,
+            );
+        } else if file_type.is_dir() {
+            self.append(&tar_name(rel, true), mode, 0, b'5', b"", None);
+            // `--sort name`: children are archived in byte order, which is how
+            // `OsString` compares on Unix.
+            let mut names = fs::read_dir(&abs)?
+                .map(|entry| entry.map(|entry| entry.file_name()))
+                .collect::<io::Result<Vec<_>>>()?;
+            names.sort();
+            for name in names {
+                self.add(root, &rel.join(name))?;
+            }
+        } else {
+            let data = fs::read(&abs)?;
+            if data.len() as u64 > MAX_SIZE {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    format!(
+                        "{abs:?} is {} bytes, but the size field holds at most {MAX_SIZE}",
+                        data.len()
+                    ),
+                ));
+            }
+            self.append(
+                &tar_name(rel, false),
+                mode,
+                data.len() as u64,
+                b'0',
+                b"",
+                Some(&data),
+            );
+        }
+        Ok(())
+    }
+
+    fn finish(mut self) -> Vec<u8> {
+        // End-of-archive marker: two zero blocks, then pad to a whole record.
+        self.out.resize(self.out.len() + 2 * BLOCK_SIZE, 0);
+        self.pad_to(RECORD_SIZE);
+        self.out
+    }
+}
+
+fn tar_name(rel: &Path, is_dir: bool) -> Vec<u8> {
+    let mut name = rel.as_os_str().as_bytes().to_vec();
+    if is_dir {
+        name.push(b'/');
+    }
+    name
+}
+
+/// Creates a GNU-format tar archive of `operands` (resolved relative to `root`).
+///
+/// `operands` are archived in the given order;
+/// directories are recursed into with their entries sorted by name.
+fn create_gnu_tar(root: &Path, operands: &[String], mtime: Mtime) -> io::Result<Vec<u8>> {
+    let mut tar = Tar {
+        out: Vec::new(),
+        mtime: mtime.0,
+    };
+    for operand in operands {
+        tar.add(root, Path::new(operand))?;
+    }
+    Ok(tar.finish())
+}
+
+/// Compresses `data` as gzip, deterministically and without any external process.
+///
+/// The pure-Rust `miniz_oxide` backend, a fixed mtime of 0, an empty file name and a pinned OS byte
+/// make the output depend only on `data` and the compressor  version.
+/// It is therefore reproducible across platforms,
+/// but it is *not* bit-identical to GNU `gzip` (and hence to the upstream `acap-build`).
+fn gzip(data: &[u8]) -> io::Result<Vec<u8>> {
+    let mut encoder = GzBuilder::new()
+        .operating_system(255)
+        .write(Vec::new(), Compression::best());
+    encoder.write_all(data)?;
+    encoder.finish()
+}
+
+/// Builds the EAP entirely in process
+///
+/// The archive records the staged files' actual modes, so the output depends on the umask
+/// in effect when the files were staged and on platform-specific symlink modes (0755 on
+/// macOS, 0777 on Linux). Normalizing would remove this dependence, but mapping modes to
+/// fixed values risks breaking apps that rely on special bits (e.g. setuid), so it needs
+/// verification before it is enabled.
+// TODO: Consider normalizing permission bits.
+pub struct CompatibleArchiveBuilder {
+    staging_dir: PathBuf,
+    eap_file_name: String,
+    mtime: Mtime,
+    operands: Vec<String>,
+}
+
+impl CompatibleArchiveBuilder {
+    pub fn new(staging_dir: &Path, eap_file_name: &str, mtime: Mtime) -> Self {
+        Self {
+            staging_dir: staging_dir.to_path_buf(),
+            eap_file_name: eap_file_name.to_string(),
+            mtime,
+            operands: Vec::new(),
+        }
+    }
+
+    pub fn files(&mut self, files: &[&str]) -> &mut Self {
+        self.operands.extend(files.iter().map(|f| f.to_string()));
+        self
+    }
+
+    /// Creates `eap_file_name` in `staging_dir` from the added files.
+    pub fn finish(self) -> anyhow::Result<()> {
+        let tar = create_gnu_tar(&self.staging_dir, &self.operands, self.mtime)?;
+        let eap = gzip(&tar)?;
+        fs::write(self.staging_dir.join(&self.eap_file_name), eap)?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::os::unix::fs::symlink;
+
+    use tempfile::tempdir;
+
+    use super::{super::EquivalentArchiveBuilder, *};
+
+    const MTIME: Mtime = Mtime(1234567890);
+
+    /// Returns the bytes a reference GNU `tar` produces for `operands`
+    fn reference(root: &Path, operands: &[&str]) -> Vec<u8> {
+        let mut tar = EquivalentArchiveBuilder::new_portable_without_compression(
+            root,
+            "__reference.tar",
+            MTIME,
+        )
+        .unwrap();
+        tar.files(operands);
+        tar.run_with_logged_output().unwrap();
+        fs::read(root.join("__reference.tar")).unwrap()
+    }
+
+    #[ignore = "requires a tier 2 developer environment"]
+    #[test]
+    fn matches_gnu_tar_byte_for_byte() {
+        let dir = tempdir().unwrap();
+        let root = dir.path();
+        // A regular file, an executable, and operands deliberately out of order
+        // to confirm the command-line order is preserved.
+        fs::write(root.join("zzz.conf"), b"conf\n").unwrap();
+        let exe = root.join("myapp");
+        fs::write(&exe, b"binary\n").unwrap();
+        fs::set_permissions(&exe, fs::Permissions::from_mode(0o755)).unwrap();
+        // A directory exercising sorted recursion, a symlink, and the excludes.
+        let lib = root.join("lib");
+        fs::create_dir(&lib).unwrap();
+        fs::write(lib.join("zebra.txt"), b"z\n").unwrap();
+        fs::write(lib.join("alpha.txt"), b"a\n").unwrap();
+        symlink("alpha.txt", lib.join("link.txt")).unwrap();
+        fs::write(lib.join("backup~"), b"drop\n").unwrap();
+        fs::create_dir(lib.join(".git")).unwrap();
+        fs::write(lib.join(".git").join("config"), b"drop\n").unwrap();
+        // A name long enough to require a `././@LongLink` record.
+        let long_name = "a".repeat(150);
+        fs::write(lib.join(&long_name), b"long\n").unwrap();
+
+        let operands = ["zzz.conf", "myapp", "lib"];
+        let expected = reference(root, &operands);
+        let actual = create_gnu_tar(root, &operands.map(str::to_string), MTIME).unwrap();
+
+        assert_eq!(actual.len(), expected.len(), "archive lengths differ");
+        assert_eq!(actual, expected, "archive bytes differ");
+    }
+
+    #[test]
+    fn excluded_operands_match_gnu_tar() {
+        let dir = tempdir().unwrap();
+        let root = dir.path();
+        fs::write(root.join("myapp"), b"binary\n").unwrap();
+        fs::write(root.join("notes~"), b"drop\n").unwrap();
+        fs::create_dir(root.join(".git")).unwrap();
+        fs::write(root.join(".git").join("config"), b"drop\n").unwrap();
+
+        // GNU tar archives only `myapp`, dropping the excluded file and directory operands.
+        let operands = ["myapp", "notes~", ".git"];
+        let expected = reference(root, &operands);
+        let actual = create_gnu_tar(root, &operands.map(str::to_string), MTIME).unwrap();
+
+        assert_eq!(actual, expected, "archive bytes differ");
+    }
+}

--- a/crates/eap/src/archive/compatible.rs
+++ b/crates/eap/src/archive/compatible.rs
@@ -311,7 +311,7 @@ fn create_gnu_tar(root: &Path, operands: &[String], mtime: Mtime) -> io::Result<
 /// Compresses `data` as gzip, deterministically and without any external process.
 ///
 /// The pure-Rust `miniz_oxide` backend, a fixed mtime of 0, an empty file name and a pinned OS byte
-/// make the output depend only on `data` and the compressor  version.
+/// make the output depend only on `data` and the compressor version.
 /// It is therefore reproducible across platforms,
 /// but it is *not* bit-identical to GNU `gzip` (and hence to the upstream `acap-build`).
 fn gzip(data: &[u8]) -> io::Result<Vec<u8>> {
@@ -416,6 +416,7 @@ mod tests {
         assert_eq!(actual, expected, "archive bytes differ");
     }
 
+    #[ignore = "requires a tier 2 developer environment"]
     #[test]
     fn excluded_operands_match_gnu_tar() {
         let dir = tempdir().unwrap();

--- a/crates/eap/src/archive/equivalent.rs
+++ b/crates/eap/src/archive/equivalent.rs
@@ -55,7 +55,6 @@ impl EquivalentArchiveBuilder {
         Self(Command::new("tar")).init(staging_dir, eap_file_name, mtime, true)
     }
 
-    #[expect(dead_code, reason = "Will be used in the next commit")]
     #[cfg(test)]
     pub fn new_portable_without_compression(
         staging_dir: &Path,
@@ -63,11 +62,6 @@ impl EquivalentArchiveBuilder {
         mtime: Mtime,
     ) -> Option<Self> {
         gnu_tar().map(|p| Self(Command::new(p)).init(staging_dir, eap_file_name, mtime, false))
-    }
-
-    pub fn file(&mut self, name: &str) -> &mut Self {
-        self.0.arg(name);
-        self
     }
 
     pub fn files(&mut self, files: &[&str]) -> &mut Self {

--- a/crates/eap/src/lib.rs
+++ b/crates/eap/src/lib.rs
@@ -28,7 +28,7 @@ mod files;
 
 pub use schema::SchemaSource;
 
-use crate::archive::EquivalentArchiveBuilder;
+use crate::archive::{CompatibleArchiveBuilder, EquivalentArchiveBuilder};
 
 /// The location where the ACAP SDK is installed by default.
 ///
@@ -38,14 +38,14 @@ pub const DEFAULT_ACAP_SDK_LOCATION: &str = "/opt/axis/";
 /// A modification time, in seconds after the Unix epoch, that the tar headers in the EAP can
 /// represent.
 ///
-/// The 12-byte numeric header fields hold 11 octal digits; GNU tar silently encodes larger
+/// The 12-byte mtime header field holds 11 octal digits; GNU tar silently encodes larger
 /// values with its base-256 extension, which not every unpacker understands, so conversion
 /// fails for values above [`Self::MAX`].
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct Mtime(u64);
 
 impl Mtime {
-    /// The largest value that the tar headers can portably represent.
+    /// The largest value that the mtime header field can portably represent.
     pub const MAX: Self = Self((1 << 33) - 1);
 }
 
@@ -122,10 +122,20 @@ fn copy_recursively(src: &Path, dst: &Path, copy_permissions: bool) -> anyhow::R
     Ok(())
 }
 
+/// The implementation used to package the EAP.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum AcapBuildImpl {
-    /// Use the native, equivalent implementation.
+    /// Produces artifacts bit-identical to those produced by the reference implementation.
+    ///
+    /// Requires a GNU-compatible `tar` and `gzip` on the `PATH`.
+    ///
+    /// Bit-exactness depends on the versions of `tar` and `gzip` that are resolved, so the
+    /// artifacts are not identical across platforms.
     Equivalent,
+    /// Produces artifacts that may not be bit-identical but nonetheless work.
+    ///
+    /// Requires no external programs.
+    Compatible,
 }
 
 impl FromStr for AcapBuildImpl {
@@ -134,7 +144,8 @@ impl FromStr for AcapBuildImpl {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
             "equivalent" => Ok(Self::Equivalent),
-            _ => bail!("Expected 'equivalent', but found {s:?}"),
+            "compatible" => Ok(Self::Compatible),
+            _ => bail!("Expected 'equivalent' or 'compatible', but found {s:?}"),
         }
     }
 }
@@ -256,15 +267,29 @@ impl<'a> AppBuilder<'a> {
 
     /// Build the EAP and return its path.
     pub fn build(self) -> anyhow::Result<OsString> {
+        debug!(
+            "Building EAP using the {:?} implementation",
+            self.acap_build_impl
+        );
+        let (eap_file_name, operands) = self.stage()?;
         match self.acap_build_impl {
             AcapBuildImpl::Equivalent => {
-                debug!("Bypassing acap-build");
-                self.build_native()
+                let mut tar =
+                    EquivalentArchiveBuilder::new(self.staging_dir, &eap_file_name, self.mtime);
+                tar.files(&operands);
+                tar.run_with_logged_output()?;
+            }
+            AcapBuildImpl::Compatible => {
+                let mut tar =
+                    CompatibleArchiveBuilder::new(self.staging_dir, &eap_file_name, self.mtime);
+                tar.files(&operands);
+                tar.finish()?;
             }
         }
+        Ok(OsString::from(eap_file_name))
     }
 
-    fn build_native(self) -> anyhow::Result<OsString> {
+    fn stage(&self) -> anyhow::Result<(String, Vec<&str>)> {
         schema::validate(self.manifest.as_value(), &self.schema)
             .context("validating manifest against schema")?;
 
@@ -333,28 +358,17 @@ impl<'a> AppBuilder<'a> {
         permissions.set_mode(0o600);
         fs::set_permissions(&manifest_file, permissions)?;
 
-        // Create the archive
-        let mut tar = EquivalentArchiveBuilder::new(staging_dir, &eap_file_name, self.mtime);
-
-        for name in self.section_1_files() {
-            if staging_dir.join(name).symlink_metadata().is_ok() {
-                tar.file(name);
-            }
-        }
-
-        tar.files(self.other_files().as_slice());
-
         // TODO: Consider implementing support for `httpd.conf.local.*` and `mime.types.local.*`.
+        let exists = |name: &&str| staging_dir.join(name).symlink_metadata().is_ok();
+        let operands = self
+            .section_1_files()
+            .into_iter()
+            .filter(exists)
+            .chain(self.other_files())
+            .chain(self.section_4_files().into_iter().filter(exists))
+            .collect();
 
-        for name in self.section_4_files() {
-            if staging_dir.join(name).symlink_metadata().is_ok() {
-                tar.file(name);
-            }
-        }
-
-        tar.run_with_logged_output()?;
-
-        Ok(OsString::from(eap_file_name))
+        Ok((eap_file_name, operands))
     }
 
     // These sections are probably relevant only for the equivalent implementation;

--- a/crates/eap/src/lib.rs
+++ b/crates/eap/src/lib.rs
@@ -3,6 +3,7 @@
 use std::{
     collections::HashSet,
     ffi::OsString,
+    fmt::Display,
     fs,
     io::Write,
     os::unix::fs::{symlink, PermissionsExt},
@@ -124,6 +125,7 @@ fn copy_recursively(src: &Path, dst: &Path, copy_permissions: bool) -> anyhow::R
 
 /// The implementation used to package the EAP.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "clap", derive(clap::ValueEnum))]
 pub enum AcapBuildImpl {
     /// Produces artifacts bit-identical to those produced by the reference implementation.
     ///
@@ -136,6 +138,15 @@ pub enum AcapBuildImpl {
     ///
     /// Requires no external programs.
     Compatible,
+}
+
+impl Display for AcapBuildImpl {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            AcapBuildImpl::Equivalent => write!(f, "equivalent"),
+            AcapBuildImpl::Compatible => write!(f, "compatible"),
+        }
+    }
 }
 
 impl FromStr for AcapBuildImpl {
@@ -489,6 +500,19 @@ mod tests {
     fn mtime_can_be_constructed_only_from_values_that_fit_in_the_headers() {
         let Mtime(_) = Mtime::try_from(Mtime::MAX.0).unwrap();
         assert!(Mtime::try_from(Mtime::MAX.0 + 1).is_err());
+    }
+
+    #[test]
+    fn acap_build_impl_round_trips_through_string() {
+        for variant in [AcapBuildImpl::Equivalent, AcapBuildImpl::Compatible] {
+            assert_eq!(
+                variant.to_string().parse::<AcapBuildImpl>().unwrap(),
+                variant
+            );
+        }
+        for s in ["equivalent", "compatible"] {
+            assert_eq!(s.parse::<AcapBuildImpl>().unwrap().to_string(), s);
+        }
     }
 
     #[test]

--- a/snapshots/acap-build-docs
+++ b/snapshots/acap-build-docs
@@ -19,5 +19,7 @@ Options:
           [env: ACAP_SDK_LOCATION=] [default: /opt/axis/]
       --source-date-epoch <SOURCE_DATE_EPOCH>
           Time to stamp on every archive member, in seconds after the Unix epoch [env: SOURCE_DATE_EPOCH=]
+      --impl <ACAP_BUILD_IMPL>
+          Implementation used to package the EAP [env: ACAP_BUILD_IMPL=] [default: equivalent] [possible values: equivalent, compatible]
   -h, --help
           Print help (see more with '--help')


### PR DESCRIPTION
The immediate benefit is that dependent binaries can be self-contained and do not depend on the user having a compatible version of `tar` on their `PATH`. Allowing carefully chosen deviations from the reference implementation also opens up for other improvements, such as cross-platform reproducibility through normalized file modes. The only deviation from the reference implementation is the compression, which should be safe because it's unlikely that that AXIS OS would unpack these differently than those produced with `gzip`, as long as it can decompress them.

Details
=======

`crates/acap-build-tester/src/invocation.rs`:
- Ignore `acap_build_impl` because the reference implementation has no equivalent flag; it is what `Equivalent` mirrors.

`crates/acap-build-tester/src/commands/replay.rs`,
`crates/acap-build-tester/src/input.rs`:
- Always use `AcapBuildImpl::Equivalent` because it is the only implementation expected to produce bit-identical artifacts.

`crates/eap/src/archive/compatible.rs`:
- Use a real `assert!` (not `debug_assert!`) when a value does not fit its octal header field, so that release builds refuse to build an archive rather than silently produce a wrong one. This can only trigger for files of 8 GiB or more, which are unsupported.

`crates/eap/src/lib.rs`:
- Do not normalize permission bits: mapping modes to fixed values risks breaking apps that rely on special bits (e.g. setuid) and has not been verified against real apps. Until then the output depends on the modes of the staged files, and thereby on the umask and on platform-specific symlink modes; the docs qualify the reproducibility claim accordingly and a TODO marks the intent to revisit.

`Cargo.toml`:
- Pin flate2 to the rust_backend so the output does not depend on which backend feature unification happens to pick. The resolved versions of flate2/miniz_oxide still affect the output; this is recorded as a known issue rather than pinned with `=` requirements, which would be viral for library consumers.