### PR TITLE
chore: Upgrade targeted ACAP Native SDK version

### DIFF
--- a/.devcontainer/acap-native-sdk-12-aarch64/devcontainer.json
+++ b/.devcontainer/acap-native-sdk-12-aarch64/devcontainer.json
@@ -8,7 +8,7 @@
       // - .github/workflows/main.yaml
       // - nix/acap-native-sdk.nix
       // - bin/create-venv.sh
-      "TAG": "12.1.0-aarch64-ubuntu24.04"
+      "TAG": "12.11.0-aarch64-ubuntu24.04"
     }
   }
 }

--- a/.devcontainer/acap-native-sdk-12-armv7hf/devcontainer.json
+++ b/.devcontainer/acap-native-sdk-12-armv7hf/devcontainer.json
@@ -8,7 +8,7 @@
       // - .github/workflows/main.yaml
       // - nix/acap-native-sdk.nix
       // - bin/create-venv.sh
-      "TAG": "12.1.0-armv7hf-ubuntu24.04"
+      "TAG": "12.11.0-armv7hf-ubuntu24.04"
     }
   }
 }

--- a/.github/workflows/fuzz.yaml
+++ b/.github/workflows/fuzz.yaml
@@ -25,8 +25,8 @@ jobs:
           # - bin/create-venv.sh
           # - nix/acap-native-sdk.nix
           # TODO: Add the SDK 13 environments when acap-build is compatible with them
-          - 12.1.0-aarch64-ubuntu24.04
-          - 12.1.0-armv7hf-ubuntu24.04
+          - 12.11.0-aarch64-ubuntu24.04
+          - 12.11.0-armv7hf-ubuntu24.04
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -66,8 +66,8 @@ jobs:
           # - bin/create-venv.sh
           # - nix/acap-native-sdk.nix
           # TODO: Add the SDK 13 environments when acap-build is compatible with them
-          - 12.1.0-aarch64-ubuntu24.04
-          - 12.1.0-armv7hf-ubuntu24.04
+          - 12.11.0-aarch64-ubuntu24.04
+          - 12.11.0-armv7hf-ubuntu24.04
     steps:
       - uses: actions/checkout@v4
         with:

--- a/bin/create-venv.sh
+++ b/bin/create-venv.sh
@@ -13,7 +13,7 @@ set -eu
 # - .github/workflows/main.yaml
 # - nix/acap-native-sdk.nix.
 SDK_IMAGE="axisecp/acap-native-sdk"
-SDK_VERSION="12.1.0"
+SDK_VERSION="12.11.0"
 SDK_UBUNTU="ubuntu24.04"
 
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"

--- a/nix/acap-native-sdk.nix
+++ b/nix/acap-native-sdk.nix
@@ -24,7 +24,7 @@
   jq,
 }:
 let
-  version = "12.1.0";
+  version = "12.11.0";
   ubuntuTag = "ubuntu24.04";
 
   # The SDK images are published for amd64 hosts only; the `armv7hf`/`aarch64`
@@ -47,13 +47,13 @@ let
   images = [
     (pullSdk {
       targetArch = "armv7hf";
-      imageDigest = "sha256:b39c18c81bb7cb5cca04833a1f2e29f559b75171d79cd296a416a3b44899539f";
-      sha256 = "sha256-P6sERcnCiiraNGd+i3jb5LQR9asksYnN7e8uxtGC9Aw=";
+      imageDigest = "sha256:355a328268d0184bc7085646fee5c9bdab7e2dd0fe8952029828a68392fc3b61";
+      sha256 = "sha256-MDclOr/sJIJ1GFgo5fT9dfVII6fMvH+OMWGjReeemF4=";
     })
     (pullSdk {
       targetArch = "aarch64";
-      imageDigest = "sha256:59fbff8af293c253db76b7d3d5703af6eef34c9c32c7210f5f4a1fababfaa516";
-      sha256 = "sha256-i+3DnKVbPZNxUUjPUvCAa64V8PGWTC/GeRCsX6DI9tU=";
+      imageDigest = "sha256:44c54f65c5a1475020274520582b7a22d88505c61902c369c97bd81db98725db";
+      sha256 = "sha256-21bt/SixxmOVzfpGp2ooyDKfa7+Lxz72ZFfwclEhyOc=";
     })
   ];
 in


### PR DESCRIPTION
The goal is to support the most recent release within each major version and 12.11 is currently the most recent 12.x release.