### PR TITLE
chore: Add SDK 13 to the equivalence test matrices

### DIFF
--- a/.github/workflows/fuzz.yaml
+++ b/.github/workflows/fuzz.yaml
@@ -24,9 +24,10 @@ jobs:
           # - .github/workflows/main.yaml
           # - bin/create-venv.sh
           # - nix/acap-native-sdk.nix
-          # TODO: Add the SDK 13 environments when acap-build is compatible with them
           - 12.11.0-aarch64-ubuntu24.04
           - 12.11.0-armv7hf-ubuntu24.04
+          - 13.0.0-preview-aarch64-ubuntu25.10
+          - 13.0.0-preview-armv7hf-ubuntu25.10
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -16,6 +16,7 @@ jobs:
         with:
           filters: |
             acap-build:
+              - '.github/**'
               - 'crates/acap-build/**'
               - 'crates/acap-build-tester/**'
   checks:
@@ -65,9 +66,10 @@ jobs:
           # - .github/workflows/fuzz.yaml
           # - bin/create-venv.sh
           # - nix/acap-native-sdk.nix
-          # TODO: Add the SDK 13 environments when acap-build is compatible with them
           - 12.11.0-aarch64-ubuntu24.04
           - 12.11.0-armv7hf-ubuntu24.04
+          - 13.0.0-preview-aarch64-ubuntu25.10
+          - 13.0.0-preview-armv7hf-ubuntu25.10
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
Run the equivalence tests and fuzz campaign against the SDK 13 preview alongside 12.11, on both target architectures. The dev container definitions already existed; this wires them into the job matrices.

The tests pass, but that's because nothing exercises v2 manifests so both implementations fail the same way on v1 manifest input. Future commits will add test coverage for this.

Details
=======

`.github/workflows/main.yaml`:
 - The equivalence job is gated by a paths filter that only watched the acap-build crates, so edits to the workflows themselves (e.g. adding an SDK to the matrix) would not exercise it. Include `.github/**` so changes to CI re-run the equivalence job.