### PR TITLE
chore(ab,eap)!: Clarify architecture concepts

### DIFF
--- a/crates/acap-build-tester/src/commands/fuzz.rs
+++ b/crates/acap-build-tester/src/commands/fuzz.rs
@@ -1,4 +1,4 @@
-use acap_build::{Architecture, Cli};
+use acap_build::{Cli, OpenEmbeddedTargetArchitecture};
 use anyhow::{bail, Context};
 use proptest::test_runner::{Config, RngAlgorithm, TestCaseError, TestError, TestRng, TestRunner};
 
@@ -31,7 +31,7 @@ fn check(input: &Input) -> anyhow::Result<()> {
 }
 
 fn fuzz(
-    oecore_target_arch: Architecture,
+    oecore_target_arch: OpenEmbeddedTargetArchitecture,
     cases: u32,
     seed: u64,
 ) -> Result<(), Box<TestError<Input>>> {
@@ -58,7 +58,7 @@ fn fuzz(
 pub struct FuzzCommand {
     /// The architecture to build for.
     #[clap(long, env = "OECORE_TARGET_ARCH")]
-    oecore_target_arch: Architecture,
+    oecore_target_arch: OpenEmbeddedTargetArchitecture,
     /// Number of random inputs to try.
     #[clap(long, env = "ACAP_BUILD_FUZZ_CASES", default_value_t = 1)]
     cases: u32,

--- a/crates/acap-build-tester/src/commands/replay.rs
+++ b/crates/acap-build-tester/src/commands/replay.rs
@@ -3,7 +3,7 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use acap_build::{Architecture, BuildOption, Cli};
+use acap_build::{BuildOption, Cli, OpenEmbeddedTargetArchitecture};
 use anyhow::{bail, ensure, Context};
 use libtest_mimic::{Arguments, Failed, Trial};
 use rs4a_eap::{AcapBuildImpl, Mtime, DEFAULT_ACAP_SDK_LOCATION};
@@ -36,7 +36,10 @@ fn scratch_copy(app_dir: &Path) -> anyhow::Result<(tempfile::TempDir, PathBuf)> 
     Ok((scratch, app))
 }
 
-fn check(app_dir: PathBuf, oecore_target_arch: Architecture) -> anyhow::Result<()> {
+fn check(
+    app_dir: PathBuf,
+    oecore_target_arch: OpenEmbeddedTargetArchitecture,
+) -> anyhow::Result<()> {
     let (_candidate_scratch, candidate_app) = scratch_copy(&app_dir)?;
     let (_reference_scratch, reference_app) = scratch_copy(&app_dir)?;
 
@@ -74,7 +77,7 @@ fn check(app_dir: PathBuf, oecore_target_arch: Architecture) -> anyhow::Result<(
 #[derive(clap::Parser)]
 pub struct ReplayCommand {
     #[clap(long, env = "OECORE_TARGET_ARCH")]
-    oecore_target_arch: Architecture,
+    oecore_target_arch: OpenEmbeddedTargetArchitecture,
     /// Directory containing the source code of one application per subdirectory.
     apps: PathBuf,
     #[clap(flatten)]

--- a/crates/acap-build-tester/src/input.rs
+++ b/crates/acap-build-tester/src/input.rs
@@ -2,7 +2,7 @@
 
 use std::path::PathBuf;
 
-use acap_build::{Architecture, BuildOption, Cli};
+use acap_build::{BuildOption, Cli, OpenEmbeddedTargetArchitecture};
 use proptest::{
     arbitrary::any,
     prelude::{BoxedStrategy, Just, Strategy},
@@ -19,7 +19,7 @@ pub struct Input {
     pub invocation: Cli,
 }
 
-pub fn arbitrary_input(oecore_target_arch: Architecture) -> BoxedStrategy<Input> {
+pub fn arbitrary_input(oecore_target_arch: OpenEmbeddedTargetArchitecture) -> BoxedStrategy<Input> {
     (
         any::<Source>(),
         any::<bool>(),

--- a/crates/acap-build/src/lib.rs
+++ b/crates/acap-build/src/lib.rs
@@ -9,21 +9,20 @@ use std::{
 use anyhow::Context;
 use clap::{Parser, ValueEnum};
 use log::debug;
-use rs4a_eap::{AcapBuildImpl, AppBuilder, Mtime, SchemaSource};
+use rs4a_eap::{AcapBuildImpl, AppBuilder, Architecture, Mtime, SchemaSource};
 use tempdir::TempDir;
 
-#[derive(Clone, Copy, Debug, ValueEnum)]
-pub enum Architecture {
+#[derive(Clone, Copy, Debug, clap::ValueEnum)]
+pub enum OpenEmbeddedTargetArchitecture {
     Aarch64,
-    #[value(name = "arm")]
-    Armv7hf,
+    Arm,
 }
 
-impl From<Architecture> for rs4a_eap::Architecture {
-    fn from(value: Architecture) -> Self {
+impl From<OpenEmbeddedTargetArchitecture> for Architecture {
+    fn from(value: OpenEmbeddedTargetArchitecture) -> Self {
         match value {
-            Architecture::Aarch64 => Self::Aarch64,
-            Architecture::Armv7hf => Self::Armv7hf,
+            OpenEmbeddedTargetArchitecture::Aarch64 => Self::Aarch64,
+            OpenEmbeddedTargetArchitecture::Arm => Self::Armv7hf,
         }
     }
 }
@@ -66,7 +65,7 @@ pub struct Cli {
     #[clap(long)]
     pub disable_manifest_validation: bool,
     #[clap(long, env = "OECORE_TARGET_ARCH")]
-    pub oecore_target_arch: Architecture,
+    pub oecore_target_arch: OpenEmbeddedTargetArchitecture,
     #[clap(
         long,
         env = "ACAP_SDK_LOCATION",

--- a/crates/eap/src/files/manifest.rs
+++ b/crates/eap/src/files/manifest.rs
@@ -28,7 +28,7 @@ impl Manifest {
         if schema_version >= semver::Version::new(1, 3, 0) {
             let setup = manifest.try_find_setup_mut()?;
             if let Some(a) = setup.get("architecture") {
-                if a != "all" && a != architecture.nickname() {
+                if a != "all" && a != architecture.as_str() {
                     bail!(
                         "Architecture in manifest ({a}) is not compatible with built target ({:?})",
                         architecture
@@ -41,7 +41,7 @@ impl Manifest {
                 );
                 setup.insert(
                     "architecture".to_string(),
-                    Value::String(architecture.nickname().to_string()),
+                    Value::String(architecture.to_string()),
                 );
             }
         }

--- a/crates/eap/src/files/package_conf.rs
+++ b/crates/eap/src/files/package_conf.rs
@@ -103,9 +103,7 @@ impl PackageConf {
 
     fn set_defaults(&mut self, arch: Architecture) {
         // If not set from the manifest, eap-create.sh would try to infer it.
-        self.0
-            .entry("APPTYPE")
-            .or_insert(arch.nickname().to_string());
+        self.0.entry("APPTYPE").or_insert(arch.to_string());
 
         // If not set from the manifest, eap-create.sh would try to infer it from the exe.
         // But we know that it must be set for the manifest to be valid.

--- a/crates/eap/src/lib.rs
+++ b/crates/eap/src/lib.rs
@@ -3,7 +3,7 @@
 use std::{
     collections::HashSet,
     ffi::OsString,
-    fmt::Display,
+    fmt::{Display, Formatter},
     fs,
     io::Write,
     os::unix::fs::{symlink, PermissionsExt},
@@ -329,7 +329,7 @@ impl<'a> AppBuilder<'a> {
 
         let arch = match manifest.try_find_architecture() {
             Ok(v) => v,
-            Err(json_ext::Error::KeyNotFound(_)) => default_architecture.nickname(),
+            Err(json_ext::Error::KeyNotFound(_)) => default_architecture.as_str(),
             Err(e) => return Err(e.into()),
         };
         let eap_file_name = format!("{package_name}_{major}_{minor}_{patch}_{arch}.eap");
@@ -458,25 +458,24 @@ impl<'a> AppBuilder<'a> {
     }
 }
 
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum Architecture {
     Aarch64,
     Armv7hf,
 }
 
 impl Architecture {
-    pub fn triple(&self) -> &'static str {
-        match self {
-            Architecture::Aarch64 => "aarch64-unknown-linux-gnu",
-            Architecture::Armv7hf => "thumbv7neon-unknown-linux-gnueabihf",
-        }
-    }
-
-    pub fn nickname(&self) -> &'static str {
+    pub fn as_str(&self) -> &'static str {
         match self {
             Self::Aarch64 => "aarch64",
             Self::Armv7hf => "armv7hf",
         }
+    }
+}
+
+impl Display for Architecture {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
     }
 }
 
@@ -486,8 +485,8 @@ impl FromStr for Architecture {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
             "aarch64" => Ok(Self::Aarch64),
-            "arm" => Ok(Self::Armv7hf),
-            _ => Err(anyhow::anyhow!("Unrecognized variant {s}")),
+            "armv7hf" => Ok(Self::Armv7hf),
+            _ => bail!("Expected 'aarch64' or 'armv7hf', but found {s:?}"),
         }
     }
 }
@@ -512,6 +511,19 @@ mod tests {
         }
         for s in ["equivalent", "compatible"] {
             assert_eq!(s.parse::<AcapBuildImpl>().unwrap().to_string(), s);
+        }
+    }
+
+    #[test]
+    fn architecture_round_trips_through_string() {
+        for variant in [Architecture::Aarch64, Architecture::Armv7hf] {
+            assert_eq!(
+                variant.to_string().parse::<Architecture>().unwrap(),
+                variant
+            );
+        }
+        for s in ["aarch64", "armv7hf"] {
+            assert_eq!(s.parse::<Architecture>().unwrap().to_string(), s);
         }
     }
 


### PR DESCRIPTION
Details
=======

`crates/acap-build/src/lib.rs`:
- Rename `Architecture` and its variants to clarify that it is a slightly different concept than `rs4a_eap::Architecture`.

`crates/eap/src/lib.rs`:
- Remove the triple function because it is specific to Cargo and should not be a concern of this library. It doesn't even map 1:1 - there are multiple triples that Cargo could compile for that work with armv7hf.
- Implement `Display` because it is convenient to have and I like making sure that `Display` and `FromStr` round-trip.
- Derive `Eq` because it is convenient for users.