### PR TITLE
feat(ab,eap)!: Change schema resolution root to schemas dir

### DIFF
--- a/crates/acap-build-tester/src/commands/replay.rs
+++ b/crates/acap-build-tester/src/commands/replay.rs
@@ -3,10 +3,10 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use acap_build::{BuildOption, Cli, OpenEmbeddedTargetArchitecture};
+use acap_build::{BuildOption, Cli, OpenEmbeddedTargetArchitecture, DEFAULT_ACAP_SDK_LOCATION};
 use anyhow::{bail, ensure, Context};
 use libtest_mimic::{Arguments, Failed, Trial};
-use rs4a_eap::{AcapBuildImpl, Mtime, DEFAULT_ACAP_SDK_LOCATION};
+use rs4a_eap::{AcapBuildImpl, Mtime};
 
 use crate::invocation::{build_with_candidate, build_with_reference};
 

--- a/crates/acap-build-tester/src/input.rs
+++ b/crates/acap-build-tester/src/input.rs
@@ -2,13 +2,13 @@
 
 use std::path::PathBuf;
 
-use acap_build::{BuildOption, Cli, OpenEmbeddedTargetArchitecture};
+use acap_build::{BuildOption, Cli, OpenEmbeddedTargetArchitecture, DEFAULT_ACAP_SDK_LOCATION};
 use proptest::{
     arbitrary::any,
     prelude::{BoxedStrategy, Just, Strategy},
     prop_oneof,
 };
-use rs4a_eap::{AcapBuildImpl, Mtime, DEFAULT_ACAP_SDK_LOCATION};
+use rs4a_eap::{AcapBuildImpl, Mtime};
 
 use crate::source::Source;
 

--- a/crates/acap-build/src/lib.rs
+++ b/crates/acap-build/src/lib.rs
@@ -1,7 +1,7 @@
 use std::{
     fmt::{Display, Formatter},
     fs,
-    path::PathBuf,
+    path::{Path, PathBuf},
     process::Command,
     time::{SystemTime, UNIX_EPOCH},
 };
@@ -11,6 +11,9 @@ use clap::{Parser, ValueEnum};
 use log::debug;
 use rs4a_eap::{AcapBuildImpl, AppBuilder, Architecture, Mtime, SchemaSource};
 use tempdir::TempDir;
+
+/// The location where the ACAP SDK is installed by default.
+pub const DEFAULT_ACAP_SDK_LOCATION: &str = "/opt/axis/";
 
 #[derive(Clone, Copy, Debug, clap::ValueEnum)]
 pub enum OpenEmbeddedTargetArchitecture {
@@ -69,7 +72,7 @@ pub struct Cli {
     #[clap(
         long,
         env = "ACAP_SDK_LOCATION",
-        default_value = rs4a_eap::DEFAULT_ACAP_SDK_LOCATION
+        default_value = DEFAULT_ACAP_SDK_LOCATION
     )]
     pub acap_sdk_location: PathBuf,
     /// Time to stamp on every archive member, in seconds after the Unix epoch.
@@ -84,6 +87,19 @@ pub struct Cli {
 
 fn parse_mtime(s: &str) -> anyhow::Result<Mtime> {
     s.trim().parse::<u64>()?.try_into()
+}
+
+/// The directory under an installed ACAP SDK that holds the manifest schemas.
+///
+/// The schemas are nested deeply within the reference SDK layout; deriving the path here keeps that
+/// knowledge in the binary rather than in the `eap` library, whose `SchemaSource::Resolve` takes the
+/// schemas dir directly.
+fn sdk_schema_dir(acap_sdk_location: &Path) -> PathBuf {
+    acap_sdk_location
+        .join("acapsdk")
+        .join("axis-acap-manifest-tools")
+        .join("schema")
+        .join("schemas")
 }
 
 impl Cli {
@@ -103,7 +119,7 @@ impl Cli {
         let schema = if disable_manifest_validation {
             SchemaSource::None
         } else {
-            SchemaSource::Resolve(acap_sdk_location)
+            SchemaSource::Resolve(sdk_schema_dir(&acap_sdk_location))
         };
 
         // Reading the clock here, and the environment via clap, keeps the library deterministic

--- a/crates/eap/src/lib.rs
+++ b/crates/eap/src/lib.rs
@@ -31,11 +31,6 @@ pub use schema::SchemaSource;
 
 use crate::archive::{CompatibleArchiveBuilder, EquivalentArchiveBuilder};
 
-/// The location where the ACAP SDK is installed by default.
-///
-/// Used as the default location for resolving manifest schemas; see [`SchemaSource::Resolve`].
-pub const DEFAULT_ACAP_SDK_LOCATION: &str = "/opt/axis/";
-
 /// A modification time, in seconds after the Unix epoch, that the tar headers in the EAP can
 /// represent.
 ///

--- a/crates/eap/src/schema.rs
+++ b/crates/eap/src/schema.rs
@@ -16,6 +16,8 @@ pub enum SchemaSource {
     /// Validate against the schema at this path, ignoring the manifest's `schemaVersion`.
     File(PathBuf),
     /// Resolve a schema by the manifest's `schemaVersion` from an installed SDK.
+    ///
+    /// The path should be that of the `schemas` dir.
     Resolve(PathBuf),
     /// Do not validate the manifest.
     #[default]
@@ -33,7 +35,7 @@ pub fn validate(manifest: &Value, source: &SchemaSource) -> anyhow::Result<()> {
             debug!("Validating manifest against schema {path:?}");
             read_schema(path)?
         }
-        SchemaSource::Resolve(acap_sdk_location) => resolve(acap_sdk_location, manifest)?,
+        SchemaSource::Resolve(schemas_dir) => resolve(schemas_dir, manifest)?,
     };
 
     let validator = jsonschema::options()
@@ -64,8 +66,8 @@ fn read_schema(path: &Path) -> anyhow::Result<Value> {
 }
 
 /// Resolve a schema by the manifest's `schemaVersion` from the installed SDK.
-fn resolve(acap_sdk_location: &Path, manifest: &Value) -> anyhow::Result<Value> {
-    resolve_in_dir(manifest, &sdk_schema_dir(acap_sdk_location))
+fn resolve(schemas_dir: &Path, manifest: &Value) -> anyhow::Result<Value> {
+    resolve_in_dir(manifest, schemas_dir)
 }
 
 fn resolve_in_dir(manifest: &Value, sdk_dir: &Path) -> anyhow::Result<Value> {
@@ -85,14 +87,6 @@ fn resolve_in_dir(manifest: &Value, sdk_dir: &Path) -> anyhow::Result<Value> {
              provides it, or skip validation with `SchemaSource::None`."
         ),
     }
-}
-
-fn sdk_schema_dir(acap_sdk_location: &Path) -> PathBuf {
-    acap_sdk_location
-        .join("acapsdk")
-        .join("axis-acap-manifest-tools")
-        .join("schema")
-        .join("schemas")
 }
 
 /// Find the schema file matching `version` under `dir`, if any.


### PR DESCRIPTION
This frees users from having to install the schemas in the same deeply nested structure as in the reference build environment.

Details
=======

`crates/acap-build/src/lib.rs`:
- The interface keeps `ACAP_SDK_LOCATION` because it is more convenient to specify and convenience matter more for a CLI that is invoked regularly than for a library which is integrated with rarely. Furthermore I have fewer reservations about coupling `acap-build` to the reference build environment and I'm even considering replicating some bugs of the reference implementation to make the drop-in property easier to test for.

`crates/eap/src/lib.rs`:
- `DEFAULT_ACAP_SDK_LOCATION` is removed to reduce the coupling between the library and the reference build environment; the library should work in that environment but I don't think it should describe it and users may have their own idea of what "default" means (I started on this change because I thought it would be neat to infer the location from something like `SDKTARGETSYSROOT` in `acap-build` but ended up realizing that would bring no benefits in the reference environment and force all users to set that path as an indirect way of locating the schemas).