### PR TITLE
feat(abt): Treat candidate failures as ok

### DIFF
--- a/crates/acap-build-tester/src/commands/fuzz.rs
+++ b/crates/acap-build-tester/src/commands/fuzz.rs
@@ -16,6 +16,10 @@ fn check(input: &Input) -> anyhow::Result<()> {
     })
     .context("building with the candidate")?;
 
+    if !candidate.essence().success {
+        return Ok(());
+    }
+
     let reference_dir = tempfile::tempdir()?;
     input.source.materialize_in(reference_dir.path())?;
     let reference = build_with_reference(Cli {
@@ -25,7 +29,7 @@ fn check(input: &Input) -> anyhow::Result<()> {
     .context("building with the reference")?;
 
     if candidate.essence() != reference.essence() {
-        bail!("the candidate does not match the reference:\n{candidate:#?}\n{reference:#?}");
+        bail!("the candidate succeeded but does not match the reference:\n{candidate:#?}\n{reference:#?}");
     }
     Ok(())
 }

--- a/crates/acap-build-tester/src/main.rs
+++ b/crates/acap-build-tester/src/main.rs
@@ -29,8 +29,8 @@ impl Cli {
 
 #[derive(Subcommand)]
 enum Commands {
-    /// Verify that this workspace's `acap-build` builds generated apps like the reference
-    /// `acap-build` on the `PATH` on generated examples.
+    /// Verify that, on generated examples, whenever this workspace's `acap-build` succeeds it
+    /// produces artifacts bit-identical to the reference `acap-build` on the `PATH`.
     Fuzz(FuzzCommand),
     /// Verify that this workspace's `acap-build` builds the given apps like the reference
     /// `acap-build` on the `PATH` on recorded examples.


### PR DESCRIPTION
The stretch goal is to add a conservative mode to acap-build that guarantees that whenever it succeeds the result will match the reference and this change helps support that claim with differential fuzzing. Another approach considered is to avoid comparing the implementations on inputs that we know risk diverging, either by restricting the input that is generated or by filtering it in the tester. Pros of the chosen approach include:
- Filtering logic lives in exactly one place
- Input modeling can concern itself with generating interesting input and that input can be reused to fuzz implementations in many ways.

Immediate benefits of this change include:
- Faster exploration - when acap-build-tester is built with the dev profile, invoking the reference takes about 95% of the time so we should see a speedup up to about 20x, more if we build with the release profile. In practice the speedup will be less since not all cases will be discarded, especially right now when we model only inputs on which the implementations agree. This is also why the release profile is currently only about 2% faster than the dev profile.