### PR TITLE
fix(abt): Report rejected inputs as such

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2262,6 +2262,7 @@ dependencies = [
  "clap",
  "env_logger",
  "libtest-mimic",
+ "log",
  "proptest",
  "rs4a-eap",
  "serde_json",

--- a/crates/acap-build-tester/Cargo.toml
+++ b/crates/acap-build-tester/Cargo.toml
@@ -9,6 +9,7 @@ anyhow = { workspace = true }
 clap = { workspace = true, features = ["derive", "env"] }
 env_logger = { workspace = true }
 libtest-mimic = { workspace = true }
+log = { workspace = true }
 proptest = { workspace = true }
 serde_json = { workspace = true }
 tempfile = { workspace = true }

--- a/crates/acap-build-tester/src/commands/fuzz.rs
+++ b/crates/acap-build-tester/src/commands/fuzz.rs
@@ -1,3 +1,5 @@
+use std::sync::atomic::{AtomicU64, Ordering};
+
 use acap_build::{Cli, OpenEmbeddedTargetArchitecture};
 use anyhow::{bail, Context};
 use proptest::test_runner::{Config, RngAlgorithm, TestCaseError, TestError, TestRng, TestRunner};
@@ -7,7 +9,18 @@ use crate::{
     invocation::{build_with_candidate, build_with_reference},
 };
 
-fn check(input: &Input) -> anyhow::Result<()> {
+/// The outcome of comparing the candidate against the reference on one input.
+enum Comparison {
+    /// The candidate succeeded and produced the same essence as the reference.
+    Matched,
+    /// The candidate declined the input, so there was nothing to compare against.
+    ///
+    /// Conservative mode is allowed to fail, so this is not a property violation. It is reported
+    /// separately so that a candidate which "passes" by declining every input does not go unnoticed.
+    Declined,
+}
+
+fn check(input: &Input) -> anyhow::Result<Comparison> {
     let candidate_dir = tempfile::tempdir()?;
     input.source.materialize_in(candidate_dir.path())?;
     let candidate = build_with_candidate(Cli {
@@ -16,8 +29,11 @@ fn check(input: &Input) -> anyhow::Result<()> {
     })
     .context("building with the candidate")?;
 
+    // This does not distinguish between inputs rejected by the conservative mode and genuine
+    // crashes.
+    // TODO: Consider distinguishing between failure modes in `acap-build`
     if !candidate.essence().success {
-        return Ok(());
+        return Ok(Comparison::Declined);
     }
 
     let reference_dir = tempfile::tempdir()?;
@@ -31,7 +47,7 @@ fn check(input: &Input) -> anyhow::Result<()> {
     if candidate.essence() != reference.essence() {
         bail!("the candidate succeeded but does not match the reference:\n{candidate:#?}\n{reference:#?}");
     }
-    Ok(())
+    Ok(Comparison::Matched)
 }
 
 fn fuzz(
@@ -47,15 +63,42 @@ fn fuzz(
     let config = Config {
         cases,
         failure_persistence: None,
+        // Accept a rejection rate of 80%
+        // TODO: Consider tuning this value and/or making it configurable
+        max_global_rejects: 4 * cases,
         ..Config::default()
     };
     let rng = TestRng::from_seed(RngAlgorithm::ChaCha, &rng_seed);
 
-    TestRunner::new_with_rng(config, rng)
+    let matched = AtomicU64::new(0);
+    let declined = AtomicU64::new(0);
+
+    let result = TestRunner::new_with_rng(config, rng)
         .run(&arbitrary_input(oecore_target_arch), |input| {
-            check(&input).map_err(|e| TestCaseError::fail(format!("{e:#}")))
+            match check(&input).map_err(|e| TestCaseError::fail(format!("{e:#}")))? {
+                Comparison::Matched => {
+                    matched.fetch_add(1, Ordering::Relaxed);
+                    Ok(())
+                }
+                Comparison::Declined => {
+                    declined.fetch_add(1, Ordering::Relaxed);
+                    Err(TestCaseError::reject("the candidate declined the input"))
+                }
+            }
         })
-        .map_err(Box::new)
+        .map_err(Box::new);
+
+    let matched = matched.load(Ordering::Relaxed);
+    let declined = declined.load(Ordering::Relaxed);
+    let total = matched + declined;
+    if total != 0 {
+        log::info!(
+            "The candidate matched the reference on {matched} and declined {declined} of {total} inputs ({percent:.1}% declined).",
+            percent = 100.0 * declined as f64 / total as f64,
+        );
+    }
+
+    result
 }
 
 #[derive(clap::Parser)]


### PR DESCRIPTION
The goal is to avoid acap-build passing fuzz testing by rejecting all inputs.

Details
=======

`crates/acap-build-tester/src/commands/fuzz.rs`:
- Set `max_global_rejects` based on the number of cases since we do expect a certain rejection rate, we want to stop this from becoming too low and 1024 rejections (the default threshold) is an insanely high rate for one case while unrealistically low for 10k cases. The 80% cutoff is comfortably higher than the 53% observed in a test run, but also far from 100%.
- Report failures in the reference as rejections to ensure that when a 100 cases are requested it actually checks a 100 non-trivial cases. As a side effect, increased rejection rates become indirectly observable by increasing durations.