### PR TITLE
feat(ab): Add conservative mode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14,6 +14,7 @@ dependencies = [
  "rs4a-eap",
  "tempdir",
  "tempfile",
+ "thiserror",
 ]
 
 [[package]]

--- a/crates/acap-build-tester/src/commands/fuzz.rs
+++ b/crates/acap-build-tester/src/commands/fuzz.rs
@@ -1,12 +1,12 @@
 use std::sync::atomic::{AtomicU64, Ordering};
 
-use acap_build::{Cli, OpenEmbeddedTargetArchitecture};
+use acap_build::Cli;
 use anyhow::{bail, Context};
 use proptest::test_runner::{Config, RngAlgorithm, TestCaseError, TestError, TestRng, TestRunner};
 
 use crate::{
     input::{arbitrary_input, Input},
-    invocation::{build_with_candidate, build_with_reference},
+    invocation::{build_with_candidate, build_with_reference, Environment},
 };
 
 /// The outcome of comparing the candidate against the reference on one input.
@@ -50,11 +50,7 @@ fn check(input: &Input) -> anyhow::Result<Comparison> {
     Ok(Comparison::Matched)
 }
 
-fn fuzz(
-    oecore_target_arch: OpenEmbeddedTargetArchitecture,
-    cases: u32,
-    seed: u64,
-) -> Result<(), Box<TestError<Input>>> {
+fn fuzz(environment: Environment, cases: u32, seed: u64) -> Result<(), Box<TestError<Input>>> {
     let mut rng_seed = [0u8; 32];
     for (dst, src) in rng_seed.iter_mut().zip(seed.to_le_bytes()) {
         *dst = src;
@@ -74,7 +70,7 @@ fn fuzz(
     let declined = AtomicU64::new(0);
 
     let result = TestRunner::new_with_rng(config, rng)
-        .run(&arbitrary_input(oecore_target_arch), |input| {
+        .run(&arbitrary_input(environment), |input| {
             match check(&input).map_err(|e| TestCaseError::fail(format!("{e:#}")))? {
                 Comparison::Matched => {
                     matched.fetch_add(1, Ordering::Relaxed);
@@ -103,26 +99,25 @@ fn fuzz(
 
 #[derive(clap::Parser)]
 pub struct FuzzCommand {
-    /// The architecture to build for.
-    #[clap(long, env = "OECORE_TARGET_ARCH")]
-    oecore_target_arch: OpenEmbeddedTargetArchitecture,
     /// Number of random inputs to try.
     #[clap(long, env = "ACAP_BUILD_FUZZ_CASES", default_value_t = 1)]
     cases: u32,
     /// Seed for the random number generator.
     #[clap(long, env = "ACAP_BUILD_FUZZ_SEED", default_value_t = 0)]
     seed: u64,
+    #[clap(flatten)]
+    environment: Environment,
 }
 
 impl FuzzCommand {
     pub fn exec(self) -> anyhow::Result<()> {
         let Self {
-            oecore_target_arch,
             cases,
             seed,
+            environment,
         } = self;
 
-        match fuzz(oecore_target_arch, cases, seed).map_err(|e| *e) {
+        match fuzz(environment, cases, seed).map_err(|e| *e) {
             Ok(()) => Ok(()),
             Err(TestError::Fail(reason, input)) => {
                 bail!("Property violated by {input:#?}:\n{reason}")

--- a/crates/acap-build-tester/src/commands/replay.rs
+++ b/crates/acap-build-tester/src/commands/replay.rs
@@ -3,12 +3,12 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use acap_build::{BuildOption, Cli, OpenEmbeddedTargetArchitecture, DEFAULT_ACAP_SDK_LOCATION};
+use acap_build::{BuildOption, Cli, DEFAULT_ACAP_SDK_LOCATION};
 use anyhow::{bail, ensure, Context};
 use libtest_mimic::{Arguments, Failed, Trial};
 use rs4a_eap::{AcapBuildImpl, Mtime};
 
-use crate::invocation::{build_with_candidate, build_with_reference};
+use crate::invocation::{build_with_candidate, build_with_reference, Environment};
 
 fn copy_dir(src: &Path, dst: &Path) -> anyhow::Result<()> {
     fs::create_dir_all(dst)?;
@@ -36,10 +36,7 @@ fn scratch_copy(app_dir: &Path) -> anyhow::Result<(tempfile::TempDir, PathBuf)> 
     Ok((scratch, app))
 }
 
-fn check(
-    app_dir: PathBuf,
-    oecore_target_arch: OpenEmbeddedTargetArchitecture,
-) -> anyhow::Result<()> {
+fn check(app_dir: PathBuf, environment: &Environment) -> anyhow::Result<()> {
     let (_candidate_scratch, candidate_app) = scratch_copy(&app_dir)?;
     let (_reference_scratch, reference_app) = scratch_copy(&app_dir)?;
 
@@ -51,10 +48,13 @@ fn check(
         // TODO: Enable storing arguments alongside examples
         additional_file: Vec::new(),
         disable_manifest_validation: true,
-        oecore_target_arch,
+        oecore_target_arch: environment.oecore_target_arch,
+        oecore_native_sysroot: environment.oecore_native_sysroot.clone(),
+        sdk_target_sysroot: environment.sdk_target_sysroot.clone(),
         acap_sdk_location: PathBuf::from(DEFAULT_ACAP_SDK_LOCATION),
         source_date_epoch: Some(Mtime::default()),
         acap_build_impl: AcapBuildImpl::Equivalent,
+        conservative: false,
     };
     let candidate = build_with_candidate(cli.clone()).context("building with the candidate")?;
     let reference = build_with_reference(Cli {
@@ -76,8 +76,8 @@ fn check(
 
 #[derive(clap::Parser)]
 pub struct ReplayCommand {
-    #[clap(long, env = "OECORE_TARGET_ARCH")]
-    oecore_target_arch: OpenEmbeddedTargetArchitecture,
+    #[clap(flatten)]
+    environment: Environment,
     /// Directory containing the source code of one application per subdirectory.
     apps: PathBuf,
     #[clap(flatten)]
@@ -87,7 +87,7 @@ pub struct ReplayCommand {
 impl ReplayCommand {
     pub fn exec(self) -> anyhow::Result<()> {
         let Self {
-            oecore_target_arch,
+            environment,
             apps,
             test_args,
         } = self;
@@ -98,8 +98,9 @@ impl ReplayCommand {
             if entry.file_type()?.is_dir() {
                 let app = entry.path();
                 let name = entry.file_name().to_string_lossy().into_owned();
+                let environment = environment.clone();
                 trials.push(Trial::test(name, move || {
-                    check(app, oecore_target_arch).map_err(|e| Failed::from(format!("{e:#}")))
+                    check(app, &environment).map_err(|e| Failed::from(format!("{e:#}")))
                 }));
             }
         }

--- a/crates/acap-build-tester/src/input.rs
+++ b/crates/acap-build-tester/src/input.rs
@@ -2,7 +2,7 @@
 
 use std::path::PathBuf;
 
-use acap_build::{BuildOption, Cli, OpenEmbeddedTargetArchitecture, DEFAULT_ACAP_SDK_LOCATION};
+use acap_build::{BuildOption, Cli, DEFAULT_ACAP_SDK_LOCATION};
 use proptest::{
     arbitrary::any,
     prelude::{BoxedStrategy, Just, Strategy},
@@ -10,7 +10,7 @@ use proptest::{
 };
 use rs4a_eap::{AcapBuildImpl, Mtime};
 
-use crate::source::Source;
+use crate::{invocation::Environment, source::Source};
 
 /// The complete, known input to an `acap-build` implementation.
 #[derive(Clone, Debug)]
@@ -19,7 +19,13 @@ pub struct Input {
     pub invocation: Cli,
 }
 
-pub fn arbitrary_input(oecore_target_arch: OpenEmbeddedTargetArchitecture) -> BoxedStrategy<Input> {
+pub fn arbitrary_input(environment: Environment) -> BoxedStrategy<Input> {
+    let Environment {
+        oecore_target_arch,
+        oecore_native_sysroot,
+        sdk_target_sysroot,
+    } = environment;
+
     (
         any::<Source>(),
         any::<bool>(),
@@ -41,6 +47,8 @@ pub fn arbitrary_input(oecore_target_arch: OpenEmbeddedTargetArchitecture) -> Bo
                 // interesting inputs given a realistic environment.
                 // TODO: Consider varying this, including leaving it unset.
                 oecore_target_arch,
+                oecore_native_sysroot: oecore_native_sysroot.clone(),
+                sdk_target_sysroot: sdk_target_sysroot.clone(),
                 // Only the default is generated: the reference does not read it, so any other
                 // location would make only the candidate use different schema which is an
                 // unnecessary potential source of divergence.
@@ -51,6 +59,7 @@ pub fn arbitrary_input(oecore_target_arch: OpenEmbeddedTargetArchitecture) -> Bo
                     Mtime::try_from(epoch).expect("generated values fit in the tar headers"),
                 ),
                 acap_build_impl: AcapBuildImpl::Equivalent,
+                conservative: true,
             },
             source,
         })

--- a/crates/acap-build-tester/src/invocation.rs
+++ b/crates/acap-build-tester/src/invocation.rs
@@ -1,9 +1,22 @@
-use std::process::Command;
+use std::{path::PathBuf, process::Command};
 
-use acap_build::Cli;
+use acap_build::{Cli, OpenEmbeddedTargetArchitecture};
 use clap::ValueEnum;
 
 use crate::output::Output;
+
+#[derive(Clone, clap::Parser)]
+pub struct Environment {
+    /// Passed through to implementations
+    #[clap(long, env = "OECORE_TARGET_ARCH")]
+    pub(crate) oecore_target_arch: OpenEmbeddedTargetArchitecture,
+    /// Passed through to implementations
+    #[clap(long, env = "OECORE_NATIVE_SYSROOT")]
+    pub(crate) oecore_native_sysroot: Option<PathBuf>,
+    /// Passed through to implementations
+    #[clap(long, env = "SDKTARGETSYSROOT")]
+    pub(crate) sdk_target_sysroot: Option<PathBuf>,
+}
 
 /// Run the workspace `acap-build` in-process.
 ///
@@ -25,9 +38,13 @@ pub fn build_with_reference(cli: Cli) -> anyhow::Result<Output> {
         additional_file,
         disable_manifest_validation,
         oecore_target_arch,
-        acap_sdk_location: _,
+        oecore_native_sysroot,
+        sdk_target_sysroot,
         source_date_epoch,
+        // Not part of the reference interface
+        acap_sdk_location: _,
         acap_build_impl: _,
+        conservative: _,
     } = cli;
 
     let mut command = Command::new("acap-build");
@@ -40,6 +57,17 @@ pub fn build_with_reference(cli: Cli) -> anyhow::Result<Output> {
             .expect("no architecture variant is skipped")
             .get_name(),
     );
+
+    match oecore_native_sysroot {
+        Some(v) => command.env("OECORE_NATIVE_SYSROOT", v),
+        None => command.env_remove("OECORE_NATIVE_SYSROOT"),
+    };
+
+    match sdk_target_sysroot {
+        Some(v) => command.env("SDKTARGETSYSROOT", v),
+        None => command.env_remove("SDKTARGETSYSROOT"),
+    };
+
     match source_date_epoch {
         Some(epoch) => command.env("SOURCE_DATE_EPOCH", u64::from(epoch).to_string()),
         None => command.env_remove("SOURCE_DATE_EPOCH"),

--- a/crates/acap-build/Cargo.toml
+++ b/crates/acap-build/Cargo.toml
@@ -14,6 +14,7 @@ env_logger = { workspace = true }
 log = { workspace = true }
 tempfile = { workspace = true }
 tempdir = { workspace = true }
+thiserror = { workspace = true }
 
 rs4a-eap = { workspace = true, features = ["clap"] }
 

--- a/crates/acap-build/src/conservative.rs
+++ b/crates/acap-build/src/conservative.rs
@@ -1,0 +1,95 @@
+//! Conservative-mode checks: refuse inputs for which the correct behavior is ambiguous
+
+use std::{ffi::OsStr, path::Path};
+
+use rs4a_eap::Architecture;
+
+use crate::{Cli, OpenEmbeddedTargetArchitecture};
+
+/// A rejection by conservative mode, carrying a human-readable explanation.
+#[derive(Debug, thiserror::Error)]
+#[error("conservative mode: {0}")]
+pub struct ConservativeRejection(String);
+
+macro_rules! reject {
+    ($($arg:tt)*) => {
+        return Err(ConservativeRejection(format!($($arg)*)))
+    };
+}
+
+/// Return an error if the correct behavior is ambiguous
+pub fn error_for_rejection(cli: &Cli) -> Result<(), ConservativeRejection> {
+    let Cli {
+        oecore_native_sysroot,
+        oecore_target_arch,
+        sdk_target_sysroot,
+        ..
+    } = cli;
+
+    // Ordered cheapest-first
+    error_for_unset_native_sysroot(oecore_native_sysroot.as_deref())?;
+    let sdk_target_sysroot = error_for_unset_target_sysroot(sdk_target_sysroot.as_deref())?;
+    error_for_inconsistent_architecture(sdk_target_sysroot, *oecore_target_arch)?;
+    Ok(())
+}
+
+/// The reference implementation depends on `OECORE_NATIVE_SYSROOT` being set correctly to
+/// succeed and/or produce correct output.
+/// Either way, no reliable reference output exists and the desired output is therefore ambiguous.
+fn error_for_unset_native_sysroot(value: Option<&Path>) -> Result<(), ConservativeRejection> {
+    if non_empty(value).is_none() {
+        reject!("OECORE_NATIVE_SYSROOT is not set");
+    }
+    Ok(())
+}
+
+/// The reference implementation infers the package architecture from `SDKTARGETSYSROOT` and aborts
+/// when it is unset.
+/// Since no reference output exists for such invocations, the desired output is ambiguous.
+fn error_for_unset_target_sysroot(value: Option<&Path>) -> Result<&Path, ConservativeRejection> {
+    let Some(value) = non_empty(value) else {
+        reject!("SDKTARGETSYSROOT is not set");
+    };
+    Ok(value)
+}
+
+/// The reference implementation sets a default package architecture in manifest.json and
+/// package.conf, but it infers them from different environment variables.
+/// In the reference environment these are configured consistently,
+/// but when they are not the expected output is ambiguous.
+fn error_for_inconsistent_architecture(
+    target_sysroot: &Path,
+    target_arch: OpenEmbeddedTargetArchitecture,
+) -> Result<(), ConservativeRejection> {
+    let expected = Architecture::from(target_arch);
+    let derived = architecture_from_sysroot(target_sysroot)?;
+    if derived != expected {
+        reject!("SDKTARGETSYSROOT and OECORE_TARGET_ARCH imply different architectures");
+    }
+    Ok(())
+}
+
+/// Infer the [`Architecture`] from `SDKTARGETSYSROOT`
+fn architecture_from_sysroot(
+    sdk_target_sysroot: &Path,
+) -> Result<Architecture, ConservativeRejection> {
+    let Some(leaf) = sdk_target_sysroot.file_name().and_then(OsStr::to_str) else {
+        reject!(
+            "SDKTARGETSYSROOT={sdk_target_sysroot:?} has no final path component or is not UTF-8"
+        );
+    };
+    let machine = leaf
+        .split_once("-poky-linux")
+        .map_or(leaf, |(before, _)| before);
+    Ok(match machine {
+        "cortexa9hf-neon" | "armv7hf" => Architecture::Armv7hf,
+        "cortexa53-crypto" | "aarch64" => Architecture::Aarch64,
+        other => reject!(
+            "SDKTARGETSYSROOT names architecture {other:?}, which the reference does not recognise"
+        ),
+    })
+}
+
+fn non_empty(value: Option<&Path>) -> Option<&Path> {
+    value.filter(|v| !v.as_os_str().is_empty())
+}

--- a/crates/acap-build/src/lib.rs
+++ b/crates/acap-build/src/lib.rs
@@ -12,6 +12,10 @@ use log::debug;
 use rs4a_eap::{AcapBuildImpl, AppBuilder, Architecture, Mtime, SchemaSource};
 use tempdir::TempDir;
 
+mod conservative;
+
+pub use conservative::ConservativeRejection;
+
 /// The location where the ACAP SDK is installed by default.
 pub const DEFAULT_ACAP_SDK_LOCATION: &str = "/opt/axis/";
 
@@ -69,6 +73,12 @@ pub struct Cli {
     pub disable_manifest_validation: bool,
     #[clap(long, env = "OECORE_TARGET_ARCH")]
     pub oecore_target_arch: OpenEmbeddedTargetArchitecture,
+    /// Used by `--conservative`.
+    #[clap(long, env = "OECORE_NATIVE_SYSROOT")]
+    pub oecore_native_sysroot: Option<PathBuf>,
+    /// Used by `--conservative`.
+    #[clap(long, env = "SDKTARGETSYSROOT")]
+    pub sdk_target_sysroot: Option<PathBuf>,
     #[clap(
         long,
         env = "ACAP_SDK_LOCATION",
@@ -83,6 +93,9 @@ pub struct Cli {
     /// Implementation used to package the EAP.
     #[clap(long = "impl", env = "ACAP_BUILD_IMPL", default_value_t = AcapBuildImpl::Equivalent)]
     pub acap_build_impl: AcapBuildImpl,
+    /// Reject inputs for which the correct behavior is ambiguous.
+    #[clap(long)]
+    pub conservative: bool,
 }
 
 fn parse_mtime(s: &str) -> anyhow::Result<Mtime> {
@@ -104,6 +117,10 @@ fn sdk_schema_dir(acap_sdk_location: &Path) -> PathBuf {
 
 impl Cli {
     pub fn exec(self) -> anyhow::Result<String> {
+        if self.conservative {
+            conservative::error_for_rejection(&self)?;
+        }
+
         let Self {
             path,
             build,
@@ -111,9 +128,12 @@ impl Cli {
             additional_file,
             disable_manifest_validation,
             oecore_target_arch,
+            oecore_native_sysroot: _,
+            sdk_target_sysroot: _,
             acap_sdk_location,
             source_date_epoch,
             acap_build_impl,
+            conservative: _,
         } = self;
 
         let schema = if disable_manifest_validation {

--- a/snapshots/acap-build-docs
+++ b/snapshots/acap-build-docs
@@ -15,11 +15,17 @@ Options:
           Disable validation of manifest file against manifest schema
       --oecore-target-arch <OECORE_TARGET_ARCH>
           [env: OECORE_TARGET_ARCH=] [possible values: aarch64, arm]
+      --oecore-native-sysroot <OECORE_NATIVE_SYSROOT>
+          Used by `--conservative` [env: OECORE_NATIVE_SYSROOT=]
+      --sdk-target-sysroot <SDK_TARGET_SYSROOT>
+          Used by `--conservative` [env: SDKTARGETSYSROOT=]
       --acap-sdk-location <ACAP_SDK_LOCATION>
           [env: ACAP_SDK_LOCATION=] [default: /opt/axis/]
       --source-date-epoch <SOURCE_DATE_EPOCH>
           Time to stamp on every archive member, in seconds after the Unix epoch [env: SOURCE_DATE_EPOCH=]
       --impl <ACAP_BUILD_IMPL>
           Implementation used to package the EAP [env: ACAP_BUILD_IMPL=] [default: equivalent] [possible values: equivalent, compatible]
+      --conservative
+          Reject inputs for which the correct behavior is ambiguous
   -h, --help
           Print help (see more with '--help')


### PR DESCRIPTION
This makes it possible to say that whenever the program succeeds, the produced artifacts are correct in the sense that they are bit-identical to what the reference implementation would produce. Another approach considered is implementing the same behavior as the reference implementation bug for bug, but some bugs are difficult to reproduce in rust, such as pathological friendly name values causing code execution, and it would be nice to be able to offer an experience with fewer sharp edges. A central observation to this decision is that an erroneously rejected input is detected early and therefore much less costly than an incorrect artifact.

Details
=======

`crates/acap-build/src/conservative.rs`:
- The macro has no documentation because its private to the module and reading the implementation is not much more difficult than reading a docstring while being more reliable.

`crates/acap-build-tester/src/commands/replay.rs`:
- Leave new environment variables unset because they are only needed for conservative mode, which is disabled
- Conservative mode is disabled because in replay we care about reproducibility and other oracle-free evidence of correctness, not about matching the reference implementation exactly. Most of these properties should hold also for the compatible implementation, even though tests for that are not yet implemented.

`crates/acap-build-tester/src/input.rs`:
- Conservative mode is enabled because we want to quickly reject inputs where we know the candidate and reference implementations are likely to disagree.

`crates/acap-build-tester/src/invocation.rs`:
- Passed through environment variables are factored out into a struct because passing them around as individual arguments is getting verbose and would only get worse. The new struct is added to here to keep the inter-module dependency graph sane - all dependants already import from this module.