### PR TITLE
chore(abt): Run global proptest filter in process, etc

### DIFF
--- a/crates/acap-build-tester/src/commands/fuzz.rs
+++ b/crates/acap-build-tester/src/commands/fuzz.rs
@@ -11,18 +11,7 @@ use crate::{
     invocation::{build_with, Environment},
 };
 
-/// The outcome of comparing the candidate against the reference on one input.
-enum Comparison {
-    /// The candidate succeeded and produced the same essence as the reference.
-    Matched,
-    /// The candidate declined the input, so there was nothing to compare against.
-    ///
-    /// Conservative mode is allowed to fail, so this is not a property violation. It is reported
-    /// separately so that a candidate which "passes" by declining every input does not go unnoticed.
-    Declined,
-}
-
-fn check(candidate_exe: &Path, input: &Input) -> anyhow::Result<Comparison> {
+fn check(candidate_exe: &Path, input: &Input) -> anyhow::Result<()> {
     let candidate_dir = tempfile::tempdir()?;
     input.source.materialize_in(candidate_dir.path())?;
     let candidate = build_with(
@@ -32,13 +21,6 @@ fn check(candidate_exe: &Path, input: &Input) -> anyhow::Result<Comparison> {
     )
     .context("building with the candidate")?;
 
-    // This does not distinguish between inputs rejected by the conservative mode and genuine
-    // crashes.
-    // TODO: Consider distinguishing between failure modes in `acap-build`
-    if !candidate.essence().success {
-        return Ok(Comparison::Declined);
-    }
-
     let reference_dir = tempfile::tempdir()?;
     input.source.materialize_in(reference_dir.path())?;
     let reference = build_with("acap-build", reference_dir.path(), input.invocation.clone())
@@ -47,7 +29,7 @@ fn check(candidate_exe: &Path, input: &Input) -> anyhow::Result<Comparison> {
     if candidate.essence() != reference.essence() {
         bail!("the candidate succeeded but does not match the reference:\n{candidate:#?}\n{reference:#?}");
     }
-    Ok(Comparison::Matched)
+    Ok(())
 }
 
 fn fuzz(
@@ -71,31 +53,31 @@ fn fuzz(
     };
     let rng = TestRng::from_seed(RngAlgorithm::ChaCha, &rng_seed);
 
-    let matched = AtomicU64::new(0);
-    let declined = AtomicU64::new(0);
+    let compared = AtomicU64::new(0);
+    let rejected = AtomicU64::new(0);
 
     let result = TestRunner::new_with_rng(config, rng)
         .run(&arbitrary_input(environment), |input| {
-            match check(candidate, &input).map_err(|e| TestCaseError::fail(format!("{e:#}")))? {
-                Comparison::Matched => {
-                    matched.fetch_add(1, Ordering::Relaxed);
-                    Ok(())
+            match input.invocation.error_for_conservative() {
+                Ok(()) => {
+                    compared.fetch_add(1, Ordering::Relaxed);
+                    check(candidate, &input).map_err(|e| TestCaseError::fail(format!("{e:#}")))
                 }
-                Comparison::Declined => {
-                    declined.fetch_add(1, Ordering::Relaxed);
-                    Err(TestCaseError::reject("the candidate declined the input"))
+                Err(e) => {
+                    rejected.fetch_add(1, Ordering::Relaxed);
+                    Err(TestCaseError::reject(e.to_string()))
                 }
             }
         })
         .map_err(Box::new);
 
-    let matched = matched.load(Ordering::Relaxed);
-    let declined = declined.load(Ordering::Relaxed);
-    let total = matched + declined;
+    let compared = compared.load(Ordering::Relaxed);
+    let rejected = rejected.load(Ordering::Relaxed);
+    let total = compared + rejected;
     if total != 0 {
         log::info!(
-            "The candidate matched the reference on {matched} and declined {declined} of {total} inputs ({percent:.1}% declined).",
-            percent = 100.0 * declined as f64 / total as f64,
+            "The candidate was compared to the reference on {compared} and rejected {rejected} of {total} inputs ({percent:.1}% rejected).",
+            percent = 100.0 * rejected as f64 / total as f64,
         );
     }
 

--- a/crates/acap-build-tester/src/input.rs
+++ b/crates/acap-build-tester/src/input.rs
@@ -32,33 +32,36 @@ pub fn arbitrary_input(environment: Environment) -> BoxedStrategy<Input> {
         // Nonzero to catch implementations that ignore the variable and use the (zero-ish)
         // default of their tar library; small enough to fit every timestamp encoding.
         prop_oneof![Just(0u64), Just(1234567890)],
+        any::<bool>(),
     )
-        .prop_map(move |(source, disable_manifest_validation, epoch)| Input {
-            invocation: Cli {
-                path: PathBuf::from("."),
-                build: BuildOption::NoBuild,
-                manifest: PathBuf::from(&source.manifest_name),
-                additional_file: source.additional_files.iter().map(PathBuf::from).collect(),
-                disable_manifest_validation,
-                // Taken from the environment rather than generated for now to efficiently generate
-                // interesting inputs given a realistic environment.
-                // TODO: Consider varying this, including leaving it unset.
-                oecore_target_arch,
-                oecore_native_sysroot: oecore_native_sysroot.clone(),
-                sdk_target_sysroot: sdk_target_sysroot.clone(),
-                // Only the default is generated: the reference does not read it, so any other
-                // location would make only the candidate use different schema which is an
-                // unnecessary potential source of divergence.
-                acap_sdk_location: PathBuf::from(DEFAULT_ACAP_SDK_LOCATION),
-                // Always set: `None` falls back to the current time, which the two
-                // implementations would sample at different moments.
-                source_date_epoch: Some(
-                    Mtime::try_from(epoch).expect("generated values fit in the tar headers"),
-                ),
-                acap_build_impl: AcapBuildImpl::Equivalent,
-                conservative: true,
+        .prop_map(
+            move |(source, disable_manifest_validation, epoch, conservative)| Input {
+                invocation: Cli {
+                    path: PathBuf::from("."),
+                    build: BuildOption::NoBuild,
+                    manifest: PathBuf::from(&source.manifest_name),
+                    additional_file: source.additional_files.iter().map(PathBuf::from).collect(),
+                    disable_manifest_validation,
+                    // Taken from the environment rather than generated for now to efficiently generate
+                    // interesting inputs given a realistic environment.
+                    // TODO: Consider varying this, including leaving it unset.
+                    oecore_target_arch,
+                    oecore_native_sysroot: oecore_native_sysroot.clone(),
+                    sdk_target_sysroot: sdk_target_sysroot.clone(),
+                    // Only the default is generated: the reference does not read it, so any other
+                    // location would make only the candidate use different schema which is an
+                    // unnecessary potential source of divergence.
+                    acap_sdk_location: PathBuf::from(DEFAULT_ACAP_SDK_LOCATION),
+                    // Always set: `None` falls back to the current time, which the two
+                    // implementations would sample at different moments.
+                    source_date_epoch: Some(
+                        Mtime::try_from(epoch).expect("generated values fit in the tar headers"),
+                    ),
+                    acap_build_impl: AcapBuildImpl::Equivalent,
+                    conservative,
+                },
+                source,
             },
-            source,
-        })
+        )
         .boxed()
 }

--- a/crates/acap-build/src/conservative.rs
+++ b/crates/acap-build/src/conservative.rs
@@ -17,22 +17,35 @@ macro_rules! reject {
     };
 }
 
-/// Return an error if the correct behavior is ambiguous
-pub fn error_for_rejection(cli: &Cli) -> Result<(), ConservativeRejection> {
-    let Cli {
-        oecore_native_sysroot,
-        oecore_target_arch,
-        sdk_target_sysroot,
-        acap_build_impl,
-        ..
-    } = cli;
+impl Cli {
+    /// Return an error on inputs for which behavior may differ from the reference implementation.
+    pub fn error_for_conservative(&self) -> Result<(), ConservativeRejection> {
+        let Self {
+            path: _,
+            build: _,
+            manifest: _,
+            additional_file: _,
+            disable_manifest_validation: _,
+            oecore_target_arch,
+            oecore_native_sysroot,
+            sdk_target_sysroot,
+            acap_sdk_location: _,
+            source_date_epoch: _,
+            acap_build_impl,
+            conservative,
+        } = self;
 
-    // Ordered cheapest-first
-    error_for_inequivalent_impl(acap_build_impl)?;
-    error_for_unset_native_sysroot(oecore_native_sysroot.as_deref())?;
-    let sdk_target_sysroot = error_for_unset_target_sysroot(sdk_target_sysroot.as_deref())?;
-    error_for_inconsistent_architecture(sdk_target_sysroot, *oecore_target_arch)?;
-    Ok(())
+        if !conservative {
+            return Ok(());
+        }
+
+        // Ordered cheapest-first
+        error_for_inequivalent_impl(acap_build_impl)?;
+        error_for_unset_native_sysroot(oecore_native_sysroot.as_deref())?;
+        let sdk_target_sysroot = error_for_unset_target_sysroot(sdk_target_sysroot.as_deref())?;
+        error_for_inconsistent_architecture(sdk_target_sysroot, *oecore_target_arch)?;
+        Ok(())
+    }
 }
 
 fn error_for_inequivalent_impl(value: &AcapBuildImpl) -> Result<(), ConservativeRejection> {

--- a/crates/acap-build/src/lib.rs
+++ b/crates/acap-build/src/lib.rs
@@ -128,9 +128,7 @@ fn sdk_schema_dir(acap_sdk_location: &Path) -> PathBuf {
 
 impl Cli {
     pub fn exec(self) -> anyhow::Result<String> {
-        if self.conservative {
-            conservative::error_for_rejection(&self)?;
-        }
+        self.error_for_conservative()?;
 
         let Self {
             path,


### PR DESCRIPTION
This commit changes two things:
- Runs the conservative checks in process.
- Accepts inputs that cause the candidate to fail for reasons other than the conservative check.

The first is intended to make the fuzzing run faster (and it does; a 20 case campaign now takes 17 instead of 26 seconds on average). The second is needed for the first and has the nice property that inputs for which we think the behavior should match the reference implementation aren't silently rejected because if the candidate crashed.

Details
=======

`crates/acap-build-tester/src/input.rs`:
- Generate the value for `conservative` to make sure both branches work and that the global filter doesn't let anything through that would be flagged as conservative when running in the sub-process (low risk). Looking forward this may also let us use a single input strategy and have the conservative check route examples to either a differential check or a oracle-less check.