### PR TITLE
chore: warn on clippy::clone_on_ref_ptr

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,6 +57,7 @@ edition = "2021"
 [workspace.lints.clippy]
 indexing_slicing = "warn"
 allow_attributes_without_reason = "warn"
+clone_on_ref_ptr = "warn"
 non_ascii_literal = "warn"
 
 [workspace.lints.rust]


### PR DESCRIPTION
I think it makes to both be clear about what is being cloned. It also to highlights that it's not deep data is being cloned, only a _handle_ [^1]. Hopefully the language eventually gains better support for expressing this, but for now this seems to be the best way.

[^1]: Term inspired by https://smallcultfollowing.com/babysteps/blog/2025/10/07/the-handle-trait/