### PR TITLE
chore: warn on clippy::allow_attributes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,9 +55,10 @@ rs4a-vlt = { path = "crates/vlt" }
 edition = "2021"
 
 [workspace.lints.clippy]
-indexing_slicing = "warn"
+allow_attributes = "warn"
 allow_attributes_without_reason = "warn"
 clone_on_ref_ptr = "warn"
+indexing_slicing = "warn"
 non_ascii_literal = "warn"
 
 [workspace.lints.rust]

--- a/crates/device-inventory/src/commands/list.rs
+++ b/crates/device-inventory/src/commands/list.rs
@@ -112,7 +112,7 @@ impl Table {
     }
 }
 
-#[allow(clippy::too_many_arguments, reason = "TODO: Improve this")]
+#[expect(clippy::too_many_arguments, reason = "TODO: Improve this")]
 async fn probe_device(
     offline: bool,
     fingerprint: String,

--- a/crates/vapix/src/apis/services/action1/action_configurations.rs
+++ b/crates/vapix/src/apis/services/action1/action_configurations.rs
@@ -124,7 +124,7 @@ impl SoapResponse for RemoveActionConfigurationResponse {
         #[derive(Deserialize)]
         #[serde(rename_all = "PascalCase")]
         struct Envelope {
-            #[allow(dead_code, reason = "Required for shape validation")]
+            #[expect(dead_code, reason = "Required for shape validation")]
             body: Body,
         }
         #[derive(Deserialize)]

--- a/crates/vapix/src/apis/services/action1/action_rules.rs
+++ b/crates/vapix/src/apis/services/action1/action_rules.rs
@@ -131,7 +131,7 @@ impl SoapResponse for RemoveActionRuleResponse {
         #[derive(Deserialize)]
         #[serde(rename_all = "PascalCase")]
         struct Envelope {
-            #[allow(dead_code, reason = "Required for shape validation")]
+            #[expect(dead_code, reason = "Required for shape validation")]
             body: Body,
         }
         #[derive(Deserialize)]


### PR DESCRIPTION
This forces us to use `expect` instead of `allow` which has the benefit that if the lint that is being suppressed disappears then we are forced to also remove the suppression leaving us with fewer obsolete (read noisy / misleading) suppressions in the code base.

Details
=======

`Cargo.toml`:
- Also sort the list of lints following my principle that lists should be sorted alphabetically unless there is a reason not to as this makes them easy to scan, etc.