### PR TITLE
chore: warn on clippy::unnecessary_safety_doc

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,6 +60,7 @@ allow_attributes_without_reason = "warn"
 clone_on_ref_ptr = "warn"
 indexing_slicing = "warn"
 non_ascii_literal = "warn"
+unnecessary_safety_doc = "warn"
 
 [workspace.lints.rust]
 unsafe_code = "forbid"


### PR DESCRIPTION
In this code base, for as long as unsafe code is forbidden, these should never exist. Regardless, an unnecessary safety doc is likely an improper use of the word "safe", which in this context should be interpreted as related to the "unsafe" keyword. Other kinds of safety comments should use other terms to make it clear what contract is being fulfilled.

I have seen this lint trigger false positives when the word safety is used in doc comments, but the workaround has been pretty simple and caused any meaningful deterioration in the code.