### PR TITLE
chore: warn on clippy::mod_module_files

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,6 +59,7 @@ allow_attributes = "warn"
 allow_attributes_without_reason = "warn"
 clone_on_ref_ptr = "warn"
 indexing_slicing = "warn"
+mod_module_files = "warn"
 non_ascii_literal = "warn"
 unnecessary_safety_doc = "warn"
 


### PR DESCRIPTION
Mixing styles is only mildly confusing, but I don't see any value in it. This hasn't been a problem on this project, but I'm encoding it anyway because I know I have an opinion and what that opinion is. This project will use self named module files because that is what I'm it already uses and it is the modern convention [^1]:

[^1]: https://rust-lang.github.io/book/ch07-05-separating-modules-into-different-files.html says "So far we’ve covered the most idiomatic file paths the Rust compiler uses, but Rust also supports an older style of file path" where "older style" refers to mod module files.