### PR TITLE
chore: warn on clippy::as_conversions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,6 +57,7 @@ edition = "2021"
 [workspace.lints.clippy]
 allow_attributes = "warn"
 allow_attributes_without_reason = "warn"
+as_conversions = "warn"
 clone_on_ref_ptr = "warn"
 indexing_slicing = "warn"
 non_ascii_literal = "warn"

--- a/crates/acap-build-tester/src/commands/fuzz.rs
+++ b/crates/acap-build-tester/src/commands/fuzz.rs
@@ -1,6 +1,6 @@
 use std::{
     path::Path,
-    sync::atomic::{AtomicU64, Ordering},
+    sync::atomic::{AtomicU32, Ordering},
 };
 
 use anyhow::{bail, Context};
@@ -53,8 +53,8 @@ fn fuzz(
     };
     let rng = TestRng::from_seed(RngAlgorithm::ChaCha, &rng_seed);
 
-    let compared = AtomicU64::new(0);
-    let rejected = AtomicU64::new(0);
+    let compared = AtomicU32::new(0);
+    let rejected = AtomicU32::new(0);
 
     let result = TestRunner::new_with_rng(config, rng)
         .run(&arbitrary_input(environment), |input| {
@@ -71,13 +71,13 @@ fn fuzz(
         })
         .map_err(Box::new);
 
-    let compared = compared.load(Ordering::Relaxed);
-    let rejected = rejected.load(Ordering::Relaxed);
+    let compared: f64 = compared.load(Ordering::Relaxed).into();
+    let rejected: f64 = rejected.load(Ordering::Relaxed).into();
     let total = compared + rejected;
-    if total != 0 {
+    if total != 0.0 {
         log::info!(
             "The candidate was compared to the reference on {compared} and rejected {rejected} of {total} inputs ({percent:.1}% rejected).",
-            percent = 100.0 * rejected as f64 / total as f64,
+            percent = 100.0 * rejected / total
         );
     }
 

--- a/crates/eap/src/archive/compatible.rs
+++ b/crates/eap/src/archive/compatible.rs
@@ -23,6 +23,15 @@ const RECORD_SIZE: usize = 20 * BLOCK_SIZE;
 // TODO: Consider adding support for larger files
 const MAX_SIZE: u64 = (1 << 33) - 1;
 
+#[expect(
+    clippy::as_conversions,
+    reason = "lossless on every supported platform, per the const assertion"
+)]
+const fn u64_from_usize(value: usize) -> u64 {
+    const _: () = assert!(usize::BITS <= u64::BITS);
+    value as u64
+}
+
 /// The files and directories excluded by `--exclude-vcs` in GNU tar 1.35.
 // TODO: Consider exposing this concern on the library interface or even pushing it into callers
 const VCS_NAMES: &[&str] = &[
@@ -77,7 +86,7 @@ fn put_octal(field: &mut [u8], value: u64) {
         reason = "`last` is `field.len() - 1`, so the end of the range is in bounds"
     )]
     for slot in field[..last].iter_mut().rev() {
-        *slot = b'0' + (remaining & 7) as u8;
+        *slot = b'0' + u8::try_from(remaining & 7).expect("masked with `& 7`, so at most 7");
         remaining >>= 3;
     }
     #[expect(
@@ -179,7 +188,7 @@ impl Tar {
         let block = header(
             b"././@LongLink",
             0o644,
-            (value.len() + 1) as u64,
+            u64_from_usize(value.len() + 1),
             0,
             typeflag,
             b"",
@@ -256,7 +265,8 @@ impl Tar {
             }
         } else {
             let data = fs::read(&abs)?;
-            if data.len() as u64 > MAX_SIZE {
+            let len = u64_from_usize(data.len());
+            if len > MAX_SIZE {
                 return Err(io::Error::new(
                     io::ErrorKind::InvalidInput,
                     format!(
@@ -265,14 +275,7 @@ impl Tar {
                     ),
                 ));
             }
-            self.append(
-                &tar_name(rel, false),
-                mode,
-                data.len() as u64,
-                b'0',
-                b"",
-                Some(&data),
-            );
+            self.append(&tar_name(rel, false), mode, len, b'0', b"", Some(&data));
         }
         Ok(())
     }

--- a/crates/vapix/src/apis/axis_cgi/basic_device_info_1.rs
+++ b/crates/vapix/src/apis/axis_cgi/basic_device_info_1.rs
@@ -209,6 +209,11 @@ pub enum SocSerialNumber {
 }
 
 impl Display for SocSerialNumber {
+    #[expect(
+        clippy::as_conversions,
+        reason = "each cast deliberately truncates to a 32-bit hex window of a wider integer; \
+        `TryFrom` would be misleading since truncation, not overflow, is the point"
+    )]
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::Plain(v) => write!(f, "{v:016X}"),
@@ -240,7 +245,7 @@ fn parse_dashed_soc_serial_128(s: &str) -> anyhow::Result<u128> {
             );
         }
         let segment = u32::from_str_radix(part, 16)?;
-        bits |= (segment as u128) << (96 - i * 32);
+        bits |= u128::from(segment) << (96 - i * 32);
     }
     Ok(bits)
 }
@@ -260,7 +265,7 @@ fn parse_dashed_soc_serial_64(s: &str) -> anyhow::Result<u64> {
             );
         }
         let segment = u32::from_str_radix(part, 16)?;
-        bits |= (segment as u64) << (32 - i * 32);
+        bits |= u64::from(segment) << (32 - i * 32);
     }
     Ok(bits)
 }

--- a/crates/vapix/tests/cassette_tests.rs
+++ b/crates/vapix/tests/cassette_tests.rs
@@ -108,14 +108,16 @@ type TestFn = for<'a> fn(
 type Substitutions = &'static [(&'static str, &'static str)];
 type TestEntry = (&'static str, TestFn, Substitutions);
 
+const fn test_entry(name: &'static str, test: TestFn, substitutions: Substitutions) -> TestEntry {
+    (name, test, substitutions)
+}
+
 macro_rules! cassette_tests {
     (@entry $name:ident => [$($sub:expr),* $(,)?]) => {
-        (
+        test_entry(
             stringify!($name),
-            (|client, prelude| {
-                Box::pin($name(client, prelude))
-            }) as TestFn,
-            &[$($sub),*] as Substitutions,
+            |client, prelude| Box::pin($name(client, prelude)),
+            &[$($sub),*],
         )
     };
     (@entry $name:ident) => {

--- a/crates/vlt/src/requests.rs
+++ b/crates/vlt/src/requests.rs
@@ -84,8 +84,8 @@ impl TimeOption {
 
     fn end(&self) -> DateTime<Utc> {
         match self.unit {
-            TimeUnit::Days => self.start + chrono::Duration::days(self.count as i64),
-            TimeUnit::Hours => self.start + chrono::Duration::hours(self.count as i64),
+            TimeUnit::Days => self.start + chrono::Duration::days(i64::from(self.count)),
+            TimeUnit::Hours => self.start + chrono::Duration::hours(i64::from(self.count)),
         }
     }
 

--- a/crates/vlt/src/responses.rs
+++ b/crates/vlt/src/responses.rs
@@ -150,6 +150,10 @@ impl TryFrom<u8> for DeviceStatus {
 }
 
 impl From<DeviceStatus> for u8 {
+    #[expect(
+        clippy::as_conversions,
+        reason = "better than the alternative: enumerating variants and risking it goes out of sync"
+    )]
     fn from(status: DeviceStatus) -> Self {
         status as u8
     }
@@ -221,7 +225,7 @@ impl InternalIp {
         // Replace the first digit of `self.base_port` with `protocol_index`
         let scale = 10u16.pow(self.base_port.checked_ilog10().unwrap_or(0));
         let suffix = self.base_port % scale;
-        protocol_index as u16 * scale + suffix
+        u16::from(protocol_index) * scale + suffix
     }
 
     /// Returns the port forwarded to port 80.


### PR DESCRIPTION
This pitfall, like the one detected by `indexing_slicing`, are easy to write and overlook but can really end up biting and in my opinion makes it too easy to circumvent one of Rust's best feature: every failure mode must be explicitly considered.

Details
=======

`crates/acap-build-tester/src/commands/fuzz.rs`:
- Replace `u64` with `u32` which can be converted to `f64` and should be plenty for counting our cases