### PR TITLE
chore(fi): factor out version parser into module

### DIFF
--- a/crates/firmware-inventory/src/commands/get.rs
+++ b/crates/firmware-inventory/src/commands/get.rs
@@ -2,9 +2,9 @@ use std::fs;
 
 use anyhow::{bail, Context};
 use log::info;
-use semver::{Version, VersionReq};
+use semver::VersionReq;
 
-use crate::{authenticated_client, db::Database};
+use crate::{authenticated_client, db::Database, version::version_from_underscore};
 
 const MPQT_BASE_URL: &str = "https://www.axis.com/ftp/pub/axis/software/MPQT/";
 
@@ -14,19 +14,6 @@ pub struct GetCommand {
     pub product: glob::Pattern,
     /// Semver version requirement (e.g. "12", "^12.8", "<13")
     pub version: VersionReq,
-}
-
-fn version_from_underscore(s: &str) -> Option<Version> {
-    let dotted = s.replace('_', ".");
-    coerce_firmware_version(&dotted).ok()
-}
-
-fn coerce_firmware_version(s: &str) -> anyhow::Result<Version> {
-    let mut parts = s.splitn(4, '.');
-    let major = parts.next().unwrap_or_default().parse()?;
-    let minor = parts.next().unwrap_or_default().parse()?;
-    let patch = parts.next().unwrap_or_default().parse()?;
-    Ok(Version::new(major, minor, patch))
 }
 
 impl GetCommand {

--- a/crates/firmware-inventory/src/commands/list.rs
+++ b/crates/firmware-inventory/src/commands/list.rs
@@ -1,9 +1,9 @@
 use std::fmt::Write;
 
 use anyhow::bail;
-use semver::{Version, VersionReq};
+use semver::VersionReq;
 
-use crate::db::Database;
+use crate::{db::Database, version::version_from_underscore};
 
 #[derive(Clone, Debug, clap::Args)]
 pub struct ListCommand {
@@ -11,15 +11,6 @@ pub struct ListCommand {
     pub product: Option<glob::Pattern>,
     /// Semver version requirement to filter versions
     pub version: Option<VersionReq>,
-}
-
-fn version_from_underscore(s: &str) -> Option<Version> {
-    let dotted = s.replace('_', ".");
-    let mut parts = dotted.splitn(4, '.');
-    let major = parts.next()?.parse().ok()?;
-    let minor = parts.next()?.parse().ok()?;
-    let patch = parts.next()?.parse().ok()?;
-    Some(Version::new(major, minor, patch))
 }
 
 impl ListCommand {

--- a/crates/firmware-inventory/src/lib.rs
+++ b/crates/firmware-inventory/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod commands;
 mod db;
 mod scrape;
+mod version;
 
 use std::path::PathBuf;
 

--- a/crates/firmware-inventory/src/version.rs
+++ b/crates/firmware-inventory/src/version.rs
@@ -1,0 +1,38 @@
+use semver::Version;
+
+/// Parse a version the way it appears in archive directory names, e.g. `12_11_68`.
+pub(crate) fn version_from_underscore(s: &str) -> Option<Version> {
+    coerce_firmware_version(&s.replace('_', ".")).ok()
+}
+
+/// Firmware versions are not semver: some have a fourth component, which is dropped.
+pub(crate) fn coerce_firmware_version(s: &str) -> anyhow::Result<Version> {
+    let mut parts = s.splitn(4, '.');
+    let major = parts.next().unwrap_or_default().parse()?;
+    let minor = parts.next().unwrap_or_default().parse()?;
+    let patch = parts.next().unwrap_or_default().parse()?;
+    Ok(Version::new(major, minor, patch))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn version_from_underscore_drops_a_fourth_component() {
+        assert_eq!(
+            version_from_underscore("12_11_68"),
+            Some(Version::new(12, 11, 68))
+        );
+        assert_eq!(
+            version_from_underscore("9_80_3_9"),
+            Some(Version::new(9, 80, 3))
+        );
+    }
+
+    #[test]
+    fn version_from_underscore_rejects_incomplete_versions() {
+        assert_eq!(version_from_underscore("12_11"), None);
+        assert_eq!(version_from_underscore("latest"), None);
+    }
+}


### PR DESCRIPTION
This makes it clear that they are the same thing and prevents drifting.