### PR TITLE
feat(fi): get and list accept multiple products and --track

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ Commands:
   login        Login to access firmware downloads
   update       Update the local firmware index for products matching a glob
   list         List indexed firmware versions, showing which are cached locally
-  get          Get firmware matching product and version requirement
+  get          Get firmware for each product, matching a version requirement or a track
   completions  Print a completion file for the given shell
   help         Print this message or the help of the given subcommand(s)
 

--- a/crates/cli4a/src/commands/install.rs
+++ b/crates/cli4a/src/commands/install.rs
@@ -87,8 +87,11 @@ impl InstallCommand {
             inventory,
             offline,
             command: rs4a_firmware_inventory::Commands::Get(rs4a_firmware_inventory::GetCommand {
-                product,
-                version,
+                products: vec![product],
+                selector: rs4a_firmware_inventory::Selector {
+                    version: Some(version),
+                    track: None,
+                },
             }),
         };
         let firmware_output = get_cli.exec().await?;

--- a/crates/firmware-inventory/src/commands/get.rs
+++ b/crates/firmware-inventory/src/commands/get.rs
@@ -1,96 +1,137 @@
-use std::fs;
+use std::{collections::BTreeSet, fmt::Write, fs};
 
 use anyhow::{bail, Context};
 use log::info;
-use semver::VersionReq;
+use semver::Version;
 
-use crate::{authenticated_client, db::Database, version::version_from_underscore};
+use crate::{
+    authenticated_client,
+    db::Database,
+    track::{self, Selector},
+    version,
+};
 
 const MPQT_BASE_URL: &str = "https://www.axis.com/ftp/pub/axis/software/MPQT/";
 
 #[derive(Clone, Debug, clap::Args)]
+#[command(group(clap::ArgGroup::new("get_selector").required(true).args(["version", "track"])))]
 pub struct GetCommand {
-    /// Glob pattern to match a product name (must match exactly one)
-    pub product: glob::Pattern,
-    /// Semver version requirement (e.g. "12", "^12.8", "<13")
-    pub version: VersionReq,
+    /// Glob patterns to match product names (each must match exactly one)
+    #[clap(required = true)]
+    pub products: Vec<glob::Pattern>,
+    #[command(flatten)]
+    pub selector: Selector,
+}
+
+async fn download(
+    client: &reqwest::Client,
+    db: &Database,
+    product: &str,
+    version: &str,
+) -> anyhow::Result<()> {
+    let url = format!("{MPQT_BASE_URL}{product}/{version}/{product}_{version}.bin");
+    info!("Downloading {url}");
+
+    let response = client
+        .get(&url)
+        .send()
+        .await?
+        .error_for_status()
+        .context("Failed to download firmware")?;
+    let bytes = response.bytes().await?;
+
+    let path = db.firmware_path(product, version);
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).context("Failed to create firmware directory")?;
+    }
+    fs::write(&path, &bytes).context("Failed to write firmware file")
 }
 
 impl GetCommand {
     pub(crate) async fn exec(self, db: &Database, offline: bool) -> anyhow::Result<String> {
-        let Self {
-            product,
-            version: req,
-        } = self;
+        let Self { products, selector } = self;
 
         let index = db.read_index()?;
-        let matching: Vec<_> = index.keys().filter(|p| product.matches(p)).collect();
 
-        let product = match matching.as_slice() {
-            [] => bail!("No indexed products matched {product:?}. Run update-index first.",),
-            [p] => *p,
-            pss => bail!(
-                "Product glob {product} matched {} products: {pss:?}. Use a more specific pattern.",
-                pss.len()
-            ),
-        };
-
-        #[expect(
-            clippy::indexing_slicing,
-            reason = "product is one of the keys in the index"
-        )]
-        let versions = &index[product];
-
-        let best = versions
-            .iter()
-            .filter_map(|v| {
-                let semver = version_from_underscore(v)?;
-                if req.matches(&semver) {
-                    Some((v.clone(), semver))
-                } else {
-                    None
+        // Resolve every pattern before fetching anything, so that a pattern that cannot be
+        // satisfied is reported before any bytes are spent on the ones before it.
+        let mut resolved: Vec<(String, String, Version)> = Vec::new();
+        for pattern in &products {
+            let matching: Vec<_> = index.iter().filter(|(p, _)| pattern.matches(p)).collect();
+            let (product, versions) = match matching.as_slice() {
+                [] => bail!("No indexed products matched {pattern:?}. Run update first."),
+                [pair] => *pair,
+                pairs => {
+                    let names: Vec<_> = pairs.iter().map(|(p, _)| p.as_str()).collect();
+                    bail!(
+                        "Product glob {pattern} matched {} products: {names:?}. Use a more specific pattern.",
+                        names.len()
+                    )
                 }
-            })
-            .max_by(|(_, a), (_, b)| a.cmp(b));
+            };
 
-        let (version_str, semver) = best.context("No versions matched the requirement")?;
+            let candidates = version::parse_versions(versions);
+            let semvers: Vec<_> = candidates.iter().map(|(_, v)| v.clone()).collect();
 
-        info!("Best match: {product} {semver} ({version_str})");
+            let Some(req) = selector.resolve(&semvers) else {
+                let available = track::available_tracks(&semvers);
+                let available = if available.is_empty() {
+                    "none".to_string()
+                } else {
+                    available.join(", ")
+                };
+                bail!(
+                    "{product} has no firmware on {}. Tracks with firmware for {product}: {available}",
+                    selector.describe()
+                );
+            };
 
-        let path = db.firmware_path(product, &version_str);
+            let (version_str, semver) = candidates
+                .into_iter()
+                .filter(|(_, v)| req.matches(v))
+                .max_by(|(_, a), (_, b)| a.cmp(b))
+                .with_context(|| {
+                    format!("No version of {product} matched {}", selector.describe())
+                })?;
 
-        if path.exists() {
-            return Ok(format!("{}\n", path.display()));
+            info!("Best match: {product} {semver} ({version_str})");
+            resolved.push((product.clone(), version_str.to_string(), semver));
         }
 
-        if offline {
-            bail!(
-                "Firmware not cached and offline mode is enabled: {}",
-                path.display()
-            );
+        // A pattern may be given twice, or two patterns may resolve to the same firmware; fetch it
+        // once and report it once per pattern.
+        let missing: BTreeSet<(&str, &str)> = resolved
+            .iter()
+            .filter(|(p, v, _)| !db.firmware_path(p, v).exists())
+            .map(|(p, v, _)| (p.as_str(), v.as_str()))
+            .collect();
+
+        if !missing.is_empty() {
+            if offline {
+                let paths: Vec<_> = missing
+                    .iter()
+                    .map(|(p, v)| db.firmware_path(p, v).display().to_string())
+                    .collect();
+                bail!(
+                    "Firmware not cached and offline mode is enabled: {}",
+                    paths.join(", ")
+                );
+            }
+
+            let cookie = db
+                .read_cookie()?
+                .context("No login session, please run the login command")?;
+            let client = authenticated_client(cookie)?;
+
+            for (product, version_str) in missing {
+                download(&client, db, product, version_str).await?;
+            }
         }
 
-        let cookie = db
-            .read_cookie()?
-            .context("No login session, please run the login command")?;
-        let client = authenticated_client(cookie)?;
-
-        let url = format!("{MPQT_BASE_URL}{product}/{version_str}/{product}_{version_str}.bin");
-        info!("Downloading {url}");
-
-        let response = client
-            .get(&url)
-            .send()
-            .await?
-            .error_for_status()
-            .context("Failed to download firmware")?;
-        let bytes = response.bytes().await?;
-
-        if let Some(parent) = path.parent() {
-            fs::create_dir_all(parent).context("Failed to create firmware directory")?;
+        let mut out = String::new();
+        for (product, version_str, _) in &resolved {
+            writeln!(out, "{}", db.firmware_path(product, version_str).display())?;
         }
-        fs::write(&path, &bytes).context("Failed to write firmware file")?;
-
-        Ok(format!("{}\n", path.display()))
+        Ok(out)
     }
 }

--- a/crates/firmware-inventory/src/commands/list.rs
+++ b/crates/firmware-inventory/src/commands/list.rs
@@ -1,29 +1,26 @@
 use std::fmt::Write;
 
 use anyhow::bail;
-use semver::VersionReq;
 
-use crate::{db::Database, version::version_from_underscore};
+use crate::{db::Database, track::Selector, version};
 
 #[derive(Clone, Debug, clap::Args)]
+#[command(group(clap::ArgGroup::new("list_selector").args(["version", "track"])))]
 pub struct ListCommand {
-    /// Glob pattern to match product names (default: all)
-    pub product: Option<glob::Pattern>,
-    /// Semver version requirement to filter versions
-    pub version: Option<VersionReq>,
+    /// Glob patterns to match product names (default: all)
+    pub products: Vec<glob::Pattern>,
+    #[command(flatten)]
+    pub selector: Selector,
 }
 
 impl ListCommand {
     pub(crate) fn exec(self, db: &Database) -> anyhow::Result<String> {
-        let Self {
-            product,
-            version: req,
-        } = self;
+        let Self { products, selector } = self;
 
         let index = db.read_index()?;
         let matching: Vec<_> = index
-            .keys()
-            .filter(|p| product.as_ref().is_none_or(|pat| pat.matches(p)))
+            .iter()
+            .filter(|(p, _)| products.is_empty() || products.iter().any(|pat| pat.matches(p)))
             .collect();
 
         if matching.is_empty() {
@@ -31,23 +28,19 @@ impl ListCommand {
         }
 
         let mut out = String::new();
-        for product in &matching {
-            #[expect(
-                clippy::indexing_slicing,
-                reason = "product is one of the keys in the index"
-            )]
-            let versions = &index[product.as_str()];
-            let mut entries: Vec<_> = versions
-                .iter()
-                .filter_map(|v| {
-                    let semver = version_from_underscore(v)?;
-                    if let Some(req) = &req {
-                        if !req.matches(&semver) {
-                            return None;
-                        }
-                    }
-                    Some((v.as_str(), semver))
-                })
+        for (product, versions) in matching {
+            let candidates = version::parse_versions(versions);
+            let semvers: Vec<_> = candidates.iter().map(|(_, v)| v.clone()).collect();
+
+            // A product with nothing on the selected track is simply not listed; unlike `get`,
+            // this command is a filter and has no single product it could fail on behalf of.
+            let Some(req) = selector.resolve(&semvers) else {
+                continue;
+            };
+
+            let mut entries: Vec<_> = candidates
+                .into_iter()
+                .filter(|(_, v)| req.matches(v))
                 .collect();
             entries.sort_by(|(_, a), (_, b)| b.cmp(a));
 

--- a/crates/firmware-inventory/src/lib.rs
+++ b/crates/firmware-inventory/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod commands;
 mod db;
 mod scrape;
+mod track;
 mod version;
 
 use std::path::PathBuf;
@@ -10,10 +11,11 @@ use clap::{Parser, Subcommand};
 use rs4a_authentication::SessionCookie;
 use rs4a_bin_utils::completions_command::CompletionsCommand;
 
-pub use crate::commands::{
-    get::GetCommand, list::ListCommand, login::LoginCommand, update::UpdateCommand,
-};
 use crate::db::Database;
+pub use crate::{
+    commands::{get::GetCommand, list::ListCommand, login::LoginCommand, update::UpdateCommand},
+    track::{Selector, Track},
+};
 
 pub(crate) fn authenticated_client(cookie: SessionCookie) -> anyhow::Result<reqwest::Client> {
     let mut headers = reqwest::header::HeaderMap::new();
@@ -64,7 +66,7 @@ pub enum Commands {
     Update(UpdateCommand),
     /// List indexed firmware versions, showing which are cached locally
     List(ListCommand),
-    /// Get firmware matching product and version requirement
+    /// Get firmware for each product, matching a version requirement or a track
     Get(GetCommand),
     /// Print a completion file for the given shell.
     ///

--- a/crates/firmware-inventory/src/track.rs
+++ b/crates/firmware-inventory/src/track.rs
@@ -1,0 +1,279 @@
+use std::{
+    fmt::{self, Display, Formatter},
+    str::FromStr,
+};
+
+use anyhow::{anyhow, bail};
+use semver::{Comparator, Op, Prerelease, Version, VersionReq};
+
+/// An AXIS OS long-term support track.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct LtsTrack {
+    pub year: u16,
+    pub major: u64,
+    pub minor: u64,
+}
+
+// TODO: Consider inferring these from external source to avoid toil on author and user side
+
+/// The major version of the active track.
+const ACTIVE_MAJOR: u64 = 12;
+
+/// Known LTS tracks, newest first.
+const LTS_TRACKS: &[LtsTrack] = &[
+    LtsTrack {
+        year: 2026,
+        major: 12,
+        minor: 11,
+    },
+    LtsTrack {
+        year: 2024,
+        major: 11,
+        minor: 11,
+    },
+    LtsTrack {
+        year: 2022,
+        major: 10,
+        minor: 12,
+    },
+    LtsTrack {
+        year: 2020,
+        major: 9,
+        minor: 80,
+    },
+];
+
+fn req_line(major: u64, minor: Option<u64>) -> VersionReq {
+    VersionReq {
+        comparators: vec![Comparator {
+            op: Op::Exact,
+            major,
+            minor,
+            patch: None,
+            pre: Prerelease::EMPTY,
+        }],
+    }
+}
+
+/// A release track, as an alternative to naming a version requirement.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum Track {
+    /// The track Axis is currently releasing new features on.
+    Active,
+    /// The newest LTS track that has firmware for the product.
+    LatestLts,
+    /// One specific LTS track.
+    Lts(&'static LtsTrack),
+}
+
+impl Track {
+    /// The version requirement matching this track.
+    fn resolve(self, versions: &[Version]) -> Option<VersionReq> {
+        match self {
+            Self::Active => {
+                let req = req_line(ACTIVE_MAJOR, None);
+                versions.iter().any(|v| req.matches(v)).then_some(req)
+            }
+            Self::Lts(t) => {
+                let req = req_line(t.major, Some(t.minor));
+                versions.iter().any(|v| req.matches(v)).then_some(req)
+            }
+            Self::LatestLts => {
+                debug_assert!(
+                    LTS_TRACKS.windows(2).all(|w| match w {
+                        [a, b] => a.year > b.year,
+                        _ => true,
+                    }),
+                    "LTS_TRACKS must be sorted newest-first"
+                );
+                LTS_TRACKS
+                    .iter()
+                    .map(|t| req_line(t.major, Some(t.minor)))
+                    .find(|req| versions.iter().any(|v| req.matches(v)))
+            }
+        }
+    }
+}
+
+impl Display for Track {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Active => write!(f, "active"),
+            Self::LatestLts => write!(f, "lts"),
+            Self::Lts(t) => write!(f, "lts{}", t.year),
+        }
+    }
+}
+
+impl FromStr for Track {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let s = s.trim().to_ascii_lowercase();
+        if s == "active" {
+            return Ok(Self::Active);
+        }
+        let Some(rest) = s.strip_prefix("lts") else {
+            bail!("expected \"active\", \"lts\", or an LTS year such as \"lts2024\", got {s:?}");
+        };
+        let rest = rest.trim_matches(|c: char| c == '-' || c == '_' || c.is_whitespace());
+        if rest.is_empty() {
+            return Ok(Self::LatestLts);
+        }
+        LTS_TRACKS
+            .iter()
+            .find(|t| t.year.to_string() == rest)
+            .map(Self::Lts)
+            .ok_or_else(|| {
+                let known: Vec<_> = LTS_TRACKS.iter().map(|t| t.year.to_string()).collect();
+                anyhow!(
+                    "unknown LTS year {rest:?}, known years are {}",
+                    known.join(", ")
+                )
+            })
+    }
+}
+
+/// Which tracks have firmware for a product, for use in error messages.
+pub(crate) fn available_tracks(versions: &[Version]) -> Vec<String> {
+    let mut out = Vec::new();
+    if Track::Active.resolve(versions).is_some() {
+        out.push(format!("active ({ACTIVE_MAJOR}.x)"));
+    }
+    for t in LTS_TRACKS {
+        if Track::Lts(t).resolve(versions).is_some() {
+            out.push(format!("lts{} ({}.{}.x)", t.year, t.major, t.minor));
+        }
+    }
+    out
+}
+
+/// How to pick a version, by requirement or by track.
+#[derive(Clone, Debug, clap::Args)]
+pub struct Selector {
+    /// Semver version requirement (e.g. "12", "^12.8", "<13")
+    #[clap(long)]
+    pub version: Option<VersionReq>,
+    /// Release track: "active", "lts", or an LTS year (e.g. "lts2024")
+    #[clap(long)]
+    pub track: Option<Track>,
+}
+
+impl Selector {
+    /// The matching version requirement for one product.
+    ///
+    /// Selecting nothing at all matches every version, which is what `list` without filters wants.
+    pub(crate) fn resolve(&self, versions: &[Version]) -> Option<VersionReq> {
+        match (&self.version, self.track) {
+            (Some(req), _) => Some(req.clone()),
+            (None, Some(track)) => track.resolve(versions),
+            (None, None) => Some(VersionReq::STAR),
+        }
+    }
+
+    /// How the selection was expressed, for use in error messages.
+    pub(crate) fn describe(&self) -> String {
+        match (&self.version, self.track) {
+            (Some(req), _) => format!("version requirement {req}"),
+            (None, Some(track)) => format!("track {track}"),
+            (None, None) => "no filter".to_string(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::version::version_from_underscore;
+
+    fn versions(raw: &[&str]) -> Vec<Version> {
+        raw.iter()
+            .map(|v| version_from_underscore(v).unwrap())
+            .collect()
+    }
+
+    fn best(track: Track, raw: &[&str]) -> Option<Version> {
+        let versions = versions(raw);
+        let req = track.resolve(&versions)?;
+        versions.into_iter().filter(|v| req.matches(v)).max()
+    }
+
+    #[test]
+    fn track_parses_every_accepted_spelling() {
+        assert_eq!("active".parse::<Track>().unwrap(), Track::Active);
+        assert_eq!("ACTIVE".parse::<Track>().unwrap(), Track::Active);
+        assert_eq!("lts".parse::<Track>().unwrap(), Track::LatestLts);
+        for s in ["lts2024", "LTS 2024", "lts-2024", "lts_2024"] {
+            let Ok(Track::Lts(t)) = s.parse::<Track>() else {
+                panic!("{s} did not parse as a specific LTS track");
+            };
+            assert_eq!((t.major, t.minor), (11, 11));
+        }
+    }
+
+    #[test]
+    fn track_rejects_years_it_has_no_mapping_for() {
+        assert!("lts2019".parse::<Track>().is_err());
+        assert!("stable".parse::<Track>().is_err());
+    }
+
+    #[test]
+    fn active_picks_the_newest_release_on_the_active_major() {
+        assert_eq!(
+            best(Track::Active, &["11_11_152", "12_5_35", "12_11_68"]),
+            Some(Version::new(12, 11, 68))
+        );
+    }
+
+    #[test]
+    fn active_ignores_a_major_the_table_does_not_yet_call_active() {
+        // Until ACTIVE_MAJOR is bumped, firmware from a newer major is not the active track.
+        assert_eq!(
+            best(Track::Active, &["12_11_68", "13_0_1"]),
+            Some(Version::new(12, 11, 68))
+        );
+    }
+
+    #[test]
+    fn active_fails_rather_than_falling_back_for_a_product_that_never_got_it() {
+        assert_eq!(best(Track::Active, &["10_12_239", "11_11_152"]), None);
+    }
+
+    #[test]
+    fn lts_is_a_minor_line_not_a_major() {
+        // 11.9 is on the same major as the 2024 LTS track but is not on the track itself.
+        assert_eq!(
+            best(Track::LatestLts, &["11_9_1", "11_11_152", "12_5_35"]),
+            Some(Version::new(11, 11, 152))
+        );
+    }
+
+    #[test]
+    fn latest_lts_prefers_the_newest_track_the_product_has() {
+        assert_eq!(
+            best(Track::LatestLts, &["11_11_152", "12_11_68"]),
+            Some(Version::new(12, 11, 68))
+        );
+        assert_eq!(
+            best(Track::LatestLts, &["10_12_239", "11_11_152"]),
+            Some(Version::new(11, 11, 152))
+        );
+    }
+
+    #[test]
+    fn latest_lts_falls_back_for_a_product_too_old_for_the_newest_track() {
+        assert_eq!(
+            best(Track::LatestLts, &["9_80_3", "10_12_239"]),
+            Some(Version::new(10, 12, 239))
+        );
+    }
+
+    #[test]
+    fn available_tracks_names_only_tracks_with_firmware() {
+        let versions = versions(&["10_12_239", "11_9_1", "11_11_152"]);
+        assert_eq!(
+            available_tracks(&versions),
+            ["lts2024 (11.11.x)", "lts2022 (10.12.x)"]
+        );
+    }
+}

--- a/crates/firmware-inventory/src/version.rs
+++ b/crates/firmware-inventory/src/version.rs
@@ -14,6 +14,16 @@ pub(crate) fn coerce_firmware_version(s: &str) -> anyhow::Result<Version> {
     Ok(Version::new(major, minor, patch))
 }
 
+/// Parse each version string, pairing it with its semver form.
+///
+/// NB: drops unparseable version strings.
+pub(crate) fn parse_versions(versions: &[String]) -> Vec<(&str, Version)> {
+    versions
+        .iter()
+        .filter_map(|v| Some((v.as_str(), version_from_underscore(v)?)))
+        .collect()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/snapshots/firmware-inventory-docs
+++ b/snapshots/firmware-inventory-docs
@@ -6,7 +6,7 @@ Commands:
   login        Login to access firmware downloads
   update       Update the local firmware index for products matching a glob
   list         List indexed firmware versions, showing which are cached locally
-  get          Get firmware matching product and version requirement
+  get          Get firmware for each product, matching a version requirement or a track
   completions  Print a completion file for the given shell
   help         Print this message or the help of the given subcommand(s)
 
@@ -29,27 +29,29 @@ Options:
   -h, --help
           Print help (see a summary with '-h')
 + firmware-inventory help get
-Get firmware matching product and version requirement
+Get firmware for each product, matching a version requirement or a track
 
-Usage: firmware-inventory get <PRODUCT> <VERSION>
+Usage: firmware-inventory get <--version <VERSION>|--track <TRACK>> <PRODUCTS>...
 
 Arguments:
-  <PRODUCT>  Glob pattern to match a product name (must match exactly one)
-  <VERSION>  Semver version requirement (e.g. "12", "^12.8", "<13")
+  <PRODUCTS>...  Glob patterns to match product names (each must match exactly one)
 
 Options:
-  -h, --help  Print help
+      --version <VERSION>  Semver version requirement (e.g. "12", "^12.8", "<13")
+      --track <TRACK>      Release track: "active", "lts", or an LTS year (e.g. "lts2024")
+  -h, --help               Print help
 + firmware-inventory help list
 List indexed firmware versions, showing which are cached locally
 
-Usage: firmware-inventory list [PRODUCT] [VERSION]
+Usage: firmware-inventory list [OPTIONS] [PRODUCTS]...
 
 Arguments:
-  [PRODUCT]  Glob pattern to match product names (default: all)
-  [VERSION]  Semver version requirement to filter versions
+  [PRODUCTS]...  Glob patterns to match product names (default: all)
 
 Options:
-  -h, --help  Print help
+      --version <VERSION>  Semver version requirement (e.g. "12", "^12.8", "<13")
+      --track <TRACK>      Release track: "active", "lts", or an LTS year (e.g. "lts2024")
+  -h, --help               Print help
 + firmware-inventory help login
 Login to access firmware downloads
 


### PR DESCRIPTION
This is a provisional feature to support other developers' workflows.

Details
=======

`crates/firmware-inventory/src/track.rs`:
- Axis markets an LTS track by year but numbers it as a `major.minor` line, and the year cannot be derived from the version [^1], so the mapping is recorded here.
- An LTS entry is a historical fact and never changes once added. A new one is needed every other year, but is knowable before it is: Axis names the LTS track of a major while that major is still the active one, as it did for 12.11 in 2026. Older tracks Axis has not named by year -- 8.40 and 6.50 -- are reachable with `--version` instead.

[^1]: <https://help.axis.com/en-us/axis-os>, fetched 2026-07-30. The 2020 track's year is not stated there, where 9.80 appears under product-specific support; it is taken from `acap-rs`, `docs/compatibility.md`.