### PR TITLE
feat: Report a version from publishable binaries

### DIFF
--- a/crates/cli4a/src/main.rs
+++ b/crates/cli4a/src/main.rs
@@ -6,6 +6,7 @@ use rs4a_bin_utils::completions_command::CompletionsCommand;
 use crate::commands::install::InstallCommand;
 
 #[derive(Parser)]
+#[command(version)]
 struct Cli {
     #[command(subcommand)]
     command: Commands,

--- a/crates/device-finder/src/main.rs
+++ b/crates/device-finder/src/main.rs
@@ -6,6 +6,7 @@ use crate::commands::discover_devices::DiscoverDevicesCommand;
 mod commands;
 
 #[derive(Parser)]
+#[command(version)]
 struct Cli {
     #[command(subcommand)]
     command: Option<Commands>,

--- a/crates/device-inventory/src/main.rs
+++ b/crates/device-inventory/src/main.rs
@@ -22,6 +22,7 @@ use crate::{
 };
 
 #[derive(Parser)]
+#[command(version)]
 struct Cli {
     /// Location of the application data.
     #[clap(long, env = "DEVICE_INVENTORY_LOCATION")]

--- a/crates/device-manager/src/lib.rs
+++ b/crates/device-manager/src/lib.rs
@@ -61,6 +61,7 @@ impl Netloc {
 }
 
 #[derive(Parser)]
+#[command(name = "device-manager", version)]
 pub struct Cli {
     #[command(subcommand)]
     pub command: Commands,

--- a/crates/fimage/src/lib.rs
+++ b/crates/fimage/src/lib.rs
@@ -7,6 +7,7 @@ use clap::{Parser, Subcommand};
 pub use crate::commands::{extract::ExtractCommand, inspect::InspectCommand};
 
 #[derive(Parser)]
+#[command(name = "fimage", version)]
 pub struct Cli {
     #[command(subcommand)]
     pub command: Commands,

--- a/crates/firmware-inventory/src/lib.rs
+++ b/crates/firmware-inventory/src/lib.rs
@@ -27,6 +27,7 @@ pub(crate) fn authenticated_client(cookie: SessionCookie) -> anyhow::Result<reqw
 }
 
 #[derive(Parser)]
+#[command(name = "firmware-inventory", version)]
 pub struct Cli {
     /// Location of the application data.
     #[clap(long, env = "FIRMWARE_INVENTORY_LOCATION")]

--- a/snapshots/cli4a-docs
+++ b/snapshots/cli4a-docs
@@ -15,7 +15,8 @@ Commands:
   help         Print this message or the help of the given subcommand(s)
 
 Options:
-  -h, --help  Print help
+  -h, --help     Print help
+  -V, --version  Print version
 + cli4a help completions
 Generate shell completions
 

--- a/snapshots/device-finder-docs
+++ b/snapshots/device-finder-docs
@@ -8,7 +8,8 @@ Commands:
   help              Print this message or the help of the given subcommand(s)
 
 Options:
-  -h, --help  Print help
+  -h, --help     Print help
+  -V, --version  Print version
 + device-finder help completions
 Print a completion file for the given shell.
 

--- a/snapshots/device-inventory-docs
+++ b/snapshots/device-inventory-docs
@@ -20,6 +20,7 @@ Options:
       --inventory <INVENTORY>  Location of the application data [env: DEVICE_INVENTORY_LOCATION=]
       --offline                [env: DEVICE_INVENTORY_OFFLINE=]
   -h, --help                   Print help
+  -V, --version                Print version
 + device-inventory help completions
 Print a completion file for the given shell.
 

--- a/snapshots/device-manager-docs
+++ b/snapshots/device-manager-docs
@@ -16,7 +16,8 @@ Commands:
   help         Print this message or the help of the given subcommand(s)
 
 Options:
-  -h, --help  Print help
+  -h, --help     Print help
+  -V, --version  Print version
 + device-manager help completions
 Generate shell completions
 

--- a/snapshots/fimage-docs
+++ b/snapshots/fimage-docs
@@ -8,7 +8,8 @@ Commands:
   help     Print this message or the help of the given subcommand(s)
 
 Options:
-  -h, --help  Print help
+  -h, --help     Print help
+  -V, --version  Print version
 + fimage help extract
 Extract a firmware image into a directory
 

--- a/snapshots/firmware-inventory-docs
+++ b/snapshots/firmware-inventory-docs
@@ -14,6 +14,7 @@ Options:
       --inventory <INVENTORY>  Location of the application data [env: FIRMWARE_INVENTORY_LOCATION=]
       --offline                [env: FIRMWARE_INVENTORY_OFFLINE=]
   -h, --help                   Print help
+  -V, --version                Print version
 + firmware-inventory help completions
 Print a completion file for the given shell.
 


### PR DESCRIPTION
This will make it easier to support users and deal with bug reports since it makes it narrows the range of commits their binary could have been built from.

Also set `command_name` in binaries that would otherwise report a name that is not aligned with the name of the binary crate.