### PR TITLE
chore: Document macOS quarantine

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,11 @@ cargo install --locked --git https://github.com/apljungquist/rs4a.git rs4a-firmw
 ```
 
 Prebuilt binaries are also published on the [Releases page](https://github.com/apljungquist/rs4a/releases) as they become available.
+On macOS, binaries downloaded this way are unsigned, so Gatekeeper will refuse to run them until you clear the quarantine flag:
+
+```shell
+xattr -d com.apple.quarantine /path/to/binary
+```
 
 If you want to install them another way, open an issue and I may be able to help.
 


### PR DESCRIPTION
I hit this myself and I don't run arbitrary binaries often enough that I know what to do and I almost did not try to fix it because I assumed anything unsigned cannot run with the default system settings.