### PR TITLE
fix(c): Read the target version from the image itself

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -525,6 +525,7 @@ dependencies = [
  "log",
  "rs4a-bin-utils",
  "rs4a-device-manager",
+ "rs4a-fimage",
  "rs4a-firmware-inventory",
  "rs4a-vapix",
  "semver",

--- a/crates/cli4a/Cargo.toml
+++ b/crates/cli4a/Cargo.toml
@@ -17,6 +17,7 @@ semver = { workspace = true }
 tokio = { workspace = true, features = ["rt", "rt-multi-thread", "macros"] }
 
 rs4a-device-manager = { workspace = true }
+rs4a-fimage = { workspace = true }
 rs4a-firmware-inventory = { workspace = true }
 rs4a-bin-utils = { workspace = true }
 rs4a-vapix = { workspace = true, features = ["clap"] }

--- a/crates/cli4a/src/commands/install.rs
+++ b/crates/cli4a/src/commands/install.rs
@@ -1,10 +1,13 @@
 use std::{
     cmp::Ordering,
+    fs::File,
+    io::BufReader,
     path::{Path, PathBuf},
 };
 
 use anyhow::Context;
 use log::info;
+use rs4a_fimage::{archive::read_info_json, info::ImageInfo};
 use rs4a_vapix::apis::{
     basic_device_info_1::GetAllUnrestrictedPropertiesRequest,
     firmware_management_1::{AutoCommit, FactoryDefaultMode},
@@ -34,14 +37,15 @@ pub struct InstallCommand {
     profile: rs4a_device_manager::Profile,
 }
 
-fn version_from_firmware_path(path: &Path) -> anyhow::Result<Version> {
-    let version_dir = path
-        .parent()
-        .and_then(|p| p.file_name())
-        .and_then(|s| s.to_str())
-        .context("Could not extract version directory from firmware path")?;
-    let dotted = version_dir.replace('_', ".");
-    Version::parse(&dotted).with_context(|| format!("Could not parse version from '{version_dir}'"))
+/// The version an image installs, according to the image itself.
+fn version_from_firmware(path: &Path) -> anyhow::Result<Version> {
+    let file = File::open(path).with_context(|| format!("Failed to open {}", path.display()))?;
+    let info: ImageInfo = read_info_json(BufReader::new(file))
+        .with_context(|| format!("Failed to read the metadata in {}", path.display()))?
+        .parse()
+        .with_context(|| format!("Failed to parse the metadata in {}", path.display()))?;
+    Version::parse(&info.release)
+        .with_context(|| format!("Could not parse a version from release {:?}", info.release))
 }
 
 impl InstallCommand {
@@ -98,7 +102,7 @@ impl InstallCommand {
         let firmware_path = PathBuf::from(firmware_output.trim_end_matches('\n'));
         info!("Firmware resolved to {}", firmware_path.display());
 
-        let target = version_from_firmware_path(&firmware_path)?;
+        let target = version_from_firmware(&firmware_path)?;
         let factory_default_mode = match target.cmp(&current) {
             Ordering::Less => {
                 info!("Target {target} < current {current}: downgrade with factory default");


### PR DESCRIPTION
`install` compares the version it is about to flash against the one on the device, and it learned the former by parsing the directory name out of the path the image is cached under. That path is a naming convention of ours, so the comparison that decides whether an install is an upgrade or a factory-defaulting downgrade rested on a filename we make up. This long distance coupling is easy to forget and I almost did in another change I'm working on.

This also opens for allowing the image to be provided by the user instead of fetched through `firmware-inventory`; in such cases we cannot rely on naming conventions of the file to infer the version.