### PR TITLE
refactor(fi)!: Add version new type

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2397,6 +2397,7 @@ dependencies = [
  "rs4a-bin-utils",
  "rs4a-vlt",
  "semver",
+ "serde",
  "serde_json",
  "tokio",
 ]

--- a/crates/cli4a/src/commands/install.rs
+++ b/crates/cli4a/src/commands/install.rs
@@ -8,11 +8,12 @@ use std::{
 use anyhow::Context;
 use log::info;
 use rs4a_fimage::{archive::read_info_json, info::ImageInfo};
+use rs4a_firmware_inventory::Version;
 use rs4a_vapix::apis::{
     basic_device_info_1::GetAllUnrestrictedPropertiesRequest,
     firmware_management_1::{AutoCommit, FactoryDefaultMode},
 };
-use semver::{Version, VersionReq};
+use semver::VersionReq;
 
 #[derive(Clone, Debug, clap::Args)]
 pub struct InstallCommand {
@@ -44,7 +45,7 @@ fn version_from_firmware(path: &Path) -> anyhow::Result<Version> {
         .with_context(|| format!("Failed to read the metadata in {}", path.display()))?
         .parse()
         .with_context(|| format!("Failed to parse the metadata in {}", path.display()))?;
-    Version::parse(&info.release)
+    Version::try_coerced(&info.release)
         .with_context(|| format!("Could not parse a version from release {:?}", info.release))
 }
 
@@ -103,7 +104,7 @@ impl InstallCommand {
         info!("Firmware resolved to {}", firmware_path.display());
 
         let target = version_from_firmware(&firmware_path)?;
-        let factory_default_mode = match target.cmp(&current) {
+        let factory_default_mode = match target.semver().cmp(&current) {
             Ordering::Less => {
                 info!("Target {target} < current {current}: downgrade with factory default");
                 Some(FactoryDefaultMode::Hard)

--- a/crates/firmware-inventory/Cargo.toml
+++ b/crates/firmware-inventory/Cargo.toml
@@ -20,7 +20,8 @@ glob = { workspace = true }
 log = { workspace = true }
 regex = { workspace = true }
 reqwest = { workspace = true, features = ["json", "http2", "rustls-tls"] }
-semver = { workspace = true }
+semver = { workspace = true, features = ["serde"] }
+serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 tokio = { workspace = true, features = ["rt", "rt-multi-thread", "macros"] }
 

--- a/crates/firmware-inventory/src/commands/get.rs
+++ b/crates/firmware-inventory/src/commands/get.rs
@@ -2,13 +2,13 @@ use std::{collections::BTreeSet, fmt::Write, fs};
 
 use anyhow::{bail, Context};
 use log::info;
-use semver::Version;
 
 use crate::{
     authenticated_client,
     db::Database,
     track::{self, Selector},
     version,
+    version::Version,
 };
 
 const MPQT_BASE_URL: &str = "https://www.axis.com/ftp/pub/axis/software/MPQT/";
@@ -71,10 +71,10 @@ impl GetCommand {
             };
 
             let candidates = version::parse_versions(versions);
-            let semvers: Vec<_> = candidates.iter().map(|(_, v)| v.clone()).collect();
+            let parsed: Vec<_> = candidates.iter().map(|(_, v)| v).collect();
 
-            let Some(req) = selector.resolve(&semvers) else {
-                let available = track::available_tracks(&semvers);
+            let Some(req) = selector.resolve(&parsed) else {
+                let available = track::available_tracks(&parsed);
                 let available = if available.is_empty() {
                     "none".to_string()
                 } else {
@@ -86,16 +86,16 @@ impl GetCommand {
                 );
             };
 
-            let (version_str, semver) = candidates
-                .into_iter()
-                .filter(|(_, v)| req.matches(v))
+            let (version_str, version) = candidates
+                .iter()
+                .filter(|(_, v)| v.matches(&req))
                 .max_by(|(_, a), (_, b)| a.cmp(b))
                 .with_context(|| {
                     format!("No version of {product} matched {}", selector.describe())
                 })?;
 
-            info!("Best match: {product} {semver} ({version_str})");
-            resolved.push((product.clone(), version_str.to_string(), semver));
+            info!("Best match: {product} {version} ({version_str})");
+            resolved.push((product.clone(), version_str.to_string(), version.clone()));
         }
 
         // A pattern may be given twice, or two patterns may resolve to the same firmware; fetch it

--- a/crates/firmware-inventory/src/commands/list.rs
+++ b/crates/firmware-inventory/src/commands/list.rs
@@ -30,27 +30,24 @@ impl ListCommand {
         let mut out = String::new();
         for (product, versions) in matching {
             let candidates = version::parse_versions(versions);
-            let semvers: Vec<_> = candidates.iter().map(|(_, v)| v.clone()).collect();
+            let parsed: Vec<_> = candidates.iter().map(|(_, v)| v).collect();
 
             // A product with nothing on the selected track is simply not listed; unlike `get`,
             // this command is a filter and has no single product it could fail on behalf of.
-            let Some(req) = selector.resolve(&semvers) else {
+            let Some(req) = selector.resolve(&parsed) else {
                 continue;
             };
 
-            let mut entries: Vec<_> = candidates
-                .into_iter()
-                .filter(|(_, v)| req.matches(v))
-                .collect();
+            let mut entries: Vec<_> = candidates.iter().filter(|(_, v)| v.matches(&req)).collect();
             entries.sort_by(|(_, a), (_, b)| b.cmp(a));
 
-            for (version_str, semver) in entries {
+            for (version_str, version) in entries {
                 let cached = if db.firmware_path(product, version_str).exists() {
                     " [cached]"
                 } else {
                     ""
                 };
-                writeln!(out, "{product} {semver}{cached}")?;
+                writeln!(out, "{product} {version}{cached}")?;
             }
         }
 

--- a/crates/firmware-inventory/src/lib.rs
+++ b/crates/firmware-inventory/src/lib.rs
@@ -15,6 +15,7 @@ use crate::db::Database;
 pub use crate::{
     commands::{get::GetCommand, list::ListCommand, login::LoginCommand, update::UpdateCommand},
     track::{Selector, Track},
+    version::Version,
 };
 
 pub(crate) fn authenticated_client(cookie: SessionCookie) -> anyhow::Result<reqwest::Client> {

--- a/crates/firmware-inventory/src/track.rs
+++ b/crates/firmware-inventory/src/track.rs
@@ -4,7 +4,9 @@ use std::{
 };
 
 use anyhow::{anyhow, bail};
-use semver::{Comparator, Op, Prerelease, Version, VersionReq};
+use semver::{Comparator, Op, Prerelease, VersionReq};
+
+use crate::version::Version;
 
 /// An AXIS OS long-term support track.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -68,15 +70,15 @@ pub enum Track {
 
 impl Track {
     /// The version requirement matching this track.
-    fn resolve(self, versions: &[Version]) -> Option<VersionReq> {
+    fn resolve(self, versions: &[&Version]) -> Option<VersionReq> {
         match self {
             Self::Active => {
                 let req = req_line(ACTIVE_MAJOR, None);
-                versions.iter().any(|v| req.matches(v)).then_some(req)
+                versions.iter().any(|v| v.matches(&req)).then_some(req)
             }
             Self::Lts(t) => {
                 let req = req_line(t.major, Some(t.minor));
-                versions.iter().any(|v| req.matches(v)).then_some(req)
+                versions.iter().any(|v| v.matches(&req)).then_some(req)
             }
             Self::LatestLts => {
                 debug_assert!(
@@ -89,7 +91,7 @@ impl Track {
                 LTS_TRACKS
                     .iter()
                     .map(|t| req_line(t.major, Some(t.minor)))
-                    .find(|req| versions.iter().any(|v| req.matches(v)))
+                    .find(|req| versions.iter().any(|v| v.matches(req)))
             }
         }
     }
@@ -135,7 +137,7 @@ impl FromStr for Track {
 }
 
 /// Which tracks have firmware for a product, for use in error messages.
-pub(crate) fn available_tracks(versions: &[Version]) -> Vec<String> {
+pub(crate) fn available_tracks(versions: &[&Version]) -> Vec<String> {
     let mut out = Vec::new();
     if Track::Active.resolve(versions).is_some() {
         out.push(format!("active ({ACTIVE_MAJOR}.x)"));
@@ -163,7 +165,7 @@ impl Selector {
     /// The matching version requirement for one product.
     ///
     /// Selecting nothing at all matches every version, which is what `list` without filters wants.
-    pub(crate) fn resolve(&self, versions: &[Version]) -> Option<VersionReq> {
+    pub(crate) fn resolve(&self, versions: &[&Version]) -> Option<VersionReq> {
         match (&self.version, self.track) {
             (Some(req), _) => Some(req.clone()),
             (None, Some(track)) => track.resolve(versions),
@@ -194,8 +196,8 @@ mod tests {
 
     fn best(track: Track, raw: &[&str]) -> Option<Version> {
         let versions = versions(raw);
-        let req = track.resolve(&versions)?;
-        versions.into_iter().filter(|v| req.matches(v)).max()
+        let req = track.resolve(&versions.iter().collect::<Vec<_>>())?;
+        versions.into_iter().filter(|v| v.matches(&req)).max()
     }
 
     #[test]
@@ -272,7 +274,7 @@ mod tests {
     fn available_tracks_names_only_tracks_with_firmware() {
         let versions = versions(&["10_12_239", "11_9_1", "11_11_152"]);
         assert_eq!(
-            available_tracks(&versions),
+            available_tracks(&versions.iter().collect::<Vec<_>>()),
             ["lts2024 (11.11.x)", "lts2022 (10.12.x)"]
         );
     }

--- a/crates/firmware-inventory/src/version.rs
+++ b/crates/firmware-inventory/src/version.rs
@@ -1,20 +1,57 @@
-use semver::Version;
+use std::fmt::{self, Display, Formatter};
+
+use serde::{Deserialize, Serialize};
 
 /// Parse a version the way it appears in archive directory names, e.g. `12_11_68`.
 pub(crate) fn version_from_underscore(s: &str) -> Option<Version> {
-    coerce_firmware_version(&s.replace('_', ".")).ok()
+    Version::try_coerced(&s.replace('_', ".")).ok()
 }
 
-/// Firmware versions are not semver: some have a fourth component, which is dropped.
-pub(crate) fn coerce_firmware_version(s: &str) -> anyhow::Result<Version> {
-    let mut parts = s.splitn(4, '.');
-    let major = parts.next().unwrap_or_default().parse()?;
-    let minor = parts.next().unwrap_or_default().parse()?;
-    let patch = parts.next().unwrap_or_default().parse()?;
-    Ok(Version::new(major, minor, patch))
+/// The version of a firmware release.
+///
+/// Firmware revisions aren't strict semver:
+/// - some have more than three components (a build number tail, dropped here), and
+/// - some have fewer (rejected, since major/minor/patch can't all be inferred).
+///
+/// Because the tail is dropped, two revisions differing only there — `10.0.2.1` and `10.0.2.2` —
+/// are one and the same version here.
+// TODO: Improve the support for non-semver versions with our own Version type and req matching
+#[derive(Clone, Debug, Deserialize, Eq, Ord, PartialEq, PartialOrd, Serialize)]
+pub struct Version(semver::Version);
+
+impl Version {
+    /// Create a [`Version`]
+    pub fn new(major: u64, minor: u64, patch: u64) -> Self {
+        Self(semver::Version::new(major, minor, patch))
+    }
+
+    /// Coerce a dotted revision into a version by keeping only its first three components.
+    pub fn try_coerced(revision: &str) -> anyhow::Result<Self> {
+        let mut parts = revision.splitn(4, '.');
+        let major = parts.next().unwrap_or_default().parse()?;
+        let minor = parts.next().unwrap_or_default().parse()?;
+        let patch = parts.next().unwrap_or_default().parse()?;
+        Ok(Self(semver::Version::new(major, minor, patch)))
+    }
+
+    /// Whether this version satisfies a requirement.
+    pub fn matches(&self, req: &semver::VersionReq) -> bool {
+        req.matches(&self.0)
+    }
+
+    /// The version in the form the `semver` crate compares, for callers outside this crate.
+    pub fn semver(&self) -> &semver::Version {
+        &self.0
+    }
 }
 
-/// Parse each version string, pairing it with its semver form.
+impl Display for Version {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+/// Parse each version string, pairing it with its parsed form.
 ///
 /// NB: drops unparseable version strings.
 pub(crate) fn parse_versions(versions: &[String]) -> Vec<(&str, Version)> {
@@ -22,27 +59,4 @@ pub(crate) fn parse_versions(versions: &[String]) -> Vec<(&str, Version)> {
         .iter()
         .filter_map(|v| Some((v.as_str(), version_from_underscore(v)?)))
         .collect()
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn version_from_underscore_drops_a_fourth_component() {
-        assert_eq!(
-            version_from_underscore("12_11_68"),
-            Some(Version::new(12, 11, 68))
-        );
-        assert_eq!(
-            version_from_underscore("9_80_3_9"),
-            Some(Version::new(9, 80, 3))
-        );
-    }
-
-    #[test]
-    fn version_from_underscore_rejects_incomplete_versions() {
-        assert_eq!(version_from_underscore("12_11"), None);
-        assert_eq!(version_from_underscore("latest"), None);
-    }
 }


### PR DESCRIPTION
This is factored out of another change to keep that small.

Details
=======

`crates/firmware-inventory/src/version.rs`:
- The existing tests are removed because they verified the behavior as it is, not as I want it, which ends up being misleading.